### PR TITLE
Add casa container to known containers / fix typo in potato container file name

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,19 +25,19 @@ repos:
       - id: requirements-txt-fixer
       - id: trailing-whitespace
 
-  - repo: https://github.com/pre-commit/pygrep-hooks
-    rev: "v1.10.0"
-    hooks:
-      - id: rst-backticks
-      - id: rst-directive-colons
-      - id: rst-inline-touching-normal
+  # - repo: https://github.com/pre-commit/pygrep-hooks
+  #   rev: "v1.10.0"
+  #   hooks:
+  #     - id: rst-backticks
+  #     - id: rst-directive-colons
+  #     - id: rst-inline-touching-normal
 
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: "v4.0.0-alpha.8"
-    hooks:
-      - id: prettier
-        types_or: [yaml, markdown, html, css, scss, javascript, json]
-        args: [--prose-wrap=always]
+  # - repo: https://github.com/pre-commit/mirrors-prettier
+  #   rev: "v4.0.0-alpha.8"
+  #   hooks:
+  #     - id: prettier
+  #       types_or: [yaml, markdown, html, css, scss, javascript, json]
+  #       args: [--prose-wrap=always]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: "v0.9.4"

--- a/flint/containers.py
+++ b/flint/containers.py
@@ -56,7 +56,7 @@ aegean_contaer = FlintContainer(
 )
 potato_container = FlintContainer(
     name="potato",
-    file_name="flint-container_potato.sif",
+    file_name="flint-containers_potato.sif",
     uri="docker://alecthomson/flint-containers:potato",
     description="Peel out that terrible annoying source",
 )

--- a/flint/containers.py
+++ b/flint/containers.py
@@ -60,7 +60,12 @@ potato_container = FlintContainer(
     uri="docker://alecthomson/flint-containers:potato",
     description="Peel out that terrible annoying source",
 )
-
+casa_container = FlintContainer(
+    name="casa",
+    file_name="flint-containers_casa.sif",
+    uri="docker://alecthomson/flint-containers:casa",
+    description="A monolithic install of the CASA application",
+)
 LIST_OF_KNOWN_CONTAINERS = (
     calibrate_container,
     wsclean_container,
@@ -68,10 +73,27 @@ LIST_OF_KNOWN_CONTAINERS = (
     aoflagger_contaer,
     aegean_contaer,
     potato_container,
+    casa_container,
 )
 KNOWN_CONTAINER_LOOKUP: dict[str, FlintContainer] = {
     v.name: v for v in LIST_OF_KNOWN_CONTAINERS
 }
+
+
+def _sanity_check_containers(
+    container_list: list[FlintContainer] | tuple[FlintContainer, ...],
+) -> None:
+    """Do some quick validation checks on the set of loaded containers. Make sure there are no
+    duplicated names or file names"""
+    assert len(container_list) == len(
+        set([container.name for container in container_list])
+    ), "Duplicated name detected in reference containers"
+    assert len(container_list) == len(
+        set([container.file_name for container in container_list])
+    ), "Duplicated file name detected in reference containers"
+
+
+_sanity_check_containers(container_list=LIST_OF_KNOWN_CONTAINERS)
 
 
 def log_known_containers() -> None:

--- a/tests/test_containers.py
+++ b/tests/test_containers.py
@@ -4,13 +4,29 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from flint.containers import (
     KNOWN_CONTAINER_LOOKUP,
     LIST_OF_KNOWN_CONTAINERS,
     FlintContainer,
+    _sanity_check_containers,
     log_known_containers,
     verify_known_containers,
 )
+
+
+def test_sanity_check_containers():
+    """Make sure that the reference containers are valid with a simple set of checks.
+    Make sure not doubling up on the reference name of file name"""
+    _sanity_check_containers(container_list=LIST_OF_KNOWN_CONTAINERS)
+    from copy import deepcopy
+
+    dummy = list(deepcopy(LIST_OF_KNOWN_CONTAINERS))
+    dummy.append(dummy[0])
+
+    with pytest.raises(AssertionError):
+        _sanity_check_containers(container_list=dummy)
 
 
 def test_verify_known_containers(tmpdir):


### PR DESCRIPTION
It was noted that there is not a known flint reference container for casa. This has been added to the dockerhub repo (@AlecThomson ) and its description has been recorded. 

There was also an annoying file name typo for the potato container. This has been repaired. 