### PR TITLE
Zeors to NaN in linmos output

### DIFF
--- a/flint/coadd/linmos.py
+++ b/flint/coadd/linmos.py
@@ -202,6 +202,11 @@ def trim_fits_image(
         data = fits_image[0].data  # type: ignore
         logger.info(f"Original data shape: {data.shape}")
 
+        # 0.0 is not a real number, blank them out so the border
+        # can be computed and trimmed correctly.
+        logger.info("Blanking pixels with values of 0.0.")
+        data[data == 0.0] = np.nan
+
         image_shape = data.shape[-2:]
         logger.info(f"The image dimensions are: {image_shape}")
 

--- a/flint/coadd/linmos.py
+++ b/flint/coadd/linmos.py
@@ -188,7 +188,8 @@ def trim_fits_image(
     image_path: Path, bounding_box: BoundingBox | None = None
 ) -> TrimImageResult:
     """Trim the FITS image produces by linmos to remove as many empty pixels around
-    the border of the image as possible. This is an inplace operation.
+    the border of the image as possible. This is an inplace operation. Pixels
+    that have a value of 0.0 are first filled with nan values before trimming.
 
     Args:
         image_path (Path): The FITS image that will have its border trimmed

--- a/tests/test_linmos_coadd.py
+++ b/tests/test_linmos_coadd.py
@@ -79,10 +79,11 @@ def test_get_image_weight_plane():
     assert _get_image_weight_plane(image_data=data) == 0.0
 
 
-def create_fits_image(out_path, image_size=(1000, 1000)):
+def create_fits_image(out_path, image_size=(1000, 1000), set_to_nan: bool = True):
     data = np.zeros(image_size)
     data[10:600, 20:500] = 1
-    data[data == 0] = np.nan
+    if set_to_nan:
+        data[data == 0] = np.nan
 
     header = fits.header.Header({"CRPIX1": 10, "CRPIX2": 20})
 
@@ -230,6 +231,27 @@ def test_linmos_holo_options(tmpdir):
                 Path("doesnotexist.fits"),
             ],
         )
+
+
+def test_trim_fits_while_blanking(tmp_path):
+    """Ensure that fits files can be trimmed appropriately based on row/columns with valid pixels.
+    This will require pixels with values of 0.0 to be naned"""
+    tmp_dir = tmp_path / "imagenan"
+    tmp_dir.mkdir()
+
+    out_fits = tmp_dir / "example.fits"
+
+    create_fits_image(out_fits, set_to_nan=False)
+    og_hdr = fits.getheader(out_fits)
+    assert og_hdr["CRPIX1"] == 10
+    assert og_hdr["CRPIX2"] == 20
+
+    trim_fits_image(out_fits)
+    trim_hdr = fits.getheader(out_fits)
+    trim_data = fits.getdata(out_fits)
+    assert trim_hdr["CRPIX1"] == -10
+    assert trim_hdr["CRPIX2"] == 10
+    assert trim_data.shape == (589, 479)
 
 
 def test_trim_fits(tmp_path):

--- a/tests/test_linmos_coadd.py
+++ b/tests/test_linmos_coadd.py
@@ -252,6 +252,7 @@ def test_trim_fits_while_blanking(tmp_path):
     assert trim_hdr["CRPIX1"] == -10
     assert trim_hdr["CRPIX2"] == 10
     assert trim_data.shape == (589, 479)
+    assert np.sum(trim_data == 0.0) == 0
 
 
 def test_trim_fits(tmp_path):


### PR DESCRIPTION
It has been noted that depending on conditions with the `cutoff` and `finalcutoff` parameters in linmos that there are pixels that are written to the output fits images filled with 0's. These are, presumably, the default values o the internal array. 

This PR introduces a 0.0 to nan step which is used when trimming the linmos images and weights. 