### PR TITLE
removed --skip-bandpass-check option in the self-calibration and continuum flow

### DIFF
--- a/flint/prefect/flows/continuum_pipeline.py
+++ b/flint/prefect/flows/continuum_pipeline.py
@@ -524,13 +524,7 @@ def setup_run_process_science_field(
     split_path: Path,
     field_options: FieldOptions,
     bandpass_path: Path | None = None,
-    skip_bandpass_check: bool = False,
 ) -> None:
-    if not skip_bandpass_check and bandpass_path:
-        assert bandpass_path.exists() and bandpass_path.is_dir(), (
-            f"{bandpass_path=} needs to exist and be a directory! "
-        )
-
     science_sbid = get_sbid_from_path(path=science_path)
 
     if field_options.sbid_copy_path:
@@ -584,12 +578,6 @@ def get_parser() -> ArgumentParser:
         default="petrichor",
         help="Path to a cluster configuration file, or a known cluster name. ",
     )
-    parser.add_argument(
-        "--skip-bandpass-check",
-        default=False,
-        action="store_true",
-        help="Skip checking whether the path containing bandpass solutions exists (e.g. if solutions have already been applied)",
-    )
 
     parser = add_options_to_parser(parser=parser, options_class=FieldOptions)
 
@@ -617,7 +605,6 @@ def cli() -> None:
         bandpass_path=args.calibrated_bandpass_path,
         split_path=args.split_path,
         field_options=field_options,
-        skip_bandpass_check=args.skip_bandpass_check,
     )
 
 


### PR DESCRIPTION
The `--skip-bandpass-check` is an older option in the flint flow that should not be used any more. It has led to confusion about it's role when attempting to process CASDA measurement sets, and was originally added as a way of short-circuiting the wait time for a prefect flow to start running only to fail. 

It was written (I believe) when the pipeline expected to always apply solutions. 