### PR TITLE
Removing the result block on field summary creation

### DIFF
--- a/flint/prefect/flows/continuum_pipeline.py
+++ b/flint/prefect/flows/continuum_pipeline.py
@@ -251,7 +251,7 @@ def process_science_fields(
         mss=preprocess_science_mss,
         cal_sbid_path=bandpass_path,
         holography_path=field_options.holofile,
-    ).result()  # type: ignore
+    )  # type: ignore
     logger.info(f"{field_summary=}")
 
     if field_options.wsclean_container is None:


### PR DESCRIPTION
There was a `.result` blocking call placed on the function that constructs the initial `FieldSummary`. It was initial a suspected source of some MS read errors in aoflagger. It turns out that it was in fact not the source. 

So small files this is a nother task. For larger EMU ones it can cause a ~25 minute task run as the meta-data are extracted. The specific slow down is the construction of a `MSSummary` object for each MS, which is done serially. 

The result object is not really needed and is being removed. In the future a better approach will be to redesign the `FieldSummary` creation so that we can supply a set of precomputed `MSSummary` objects. 