### PR TITLE
Add chunking to nan / zero flagger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
   - Using `vizier` normalised position units
   - Convert flux columns to Jy
 - Improved docs
+- Added chunking to the NaN/UVW/zero flagging during selfcal
 
 # 0.2.13
 

--- a/docs/flagging.md
+++ b/docs/flagging.md
@@ -1,0 +1,33 @@
+# Flagging Visibilities
+
+`Flint` currently flags visibilities through two main mechanisms:
+
+1 - Using an `ASKAP.lua` script (see `flint.data.aoflagger`) provided to a containerised version of `aoflagger`
+2 - Flagging of known bad systematics
+
+## Flagging with `aoflagger`
+
+Automated RFI flagging is carried out with `aoflagger`. We have packaged with `flint` a customised `lua` script that attempts to craft an appropriate flagging strategy. This `lua` script flags based on smoothness along the frequency axis. Flagging occurs per-baseline on each of the recorded instrumental polarisation products.
+
+The default `ASKAP.lua` strategy adds to the existing set of flags. Any flags that are set as `True` of the input measurement set are retained after processing. Data values that are either not-a-number (NaN) or are zero'd are also flagged.
+
+## Manual flagging
+
+Some stages in `flint` also do an additional round of flagging as a 'just in case'. Data will be forcefully flagged if:
+
+1 - data are recorded as being `0` or `NaN`
+2 - the `uvw` is recorded as `(0, 0, 0)`
+3 - significant Stokes-V emission
+
+Optionally, any data whose corresponding flag is set to `True` can be `NaN`.
+
+This functionality is implemented in `flint.flagging.nan_zero_extreme_flag_ms` function0n.
+
+## Accessing via the CLI
+
+The flagging utilities via the CLI in `flint` can be done via `flint_flagging`:
+
+```{argparse}
+:ref: flint.flagging.get_parser
+:prog: flint_flagging
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,6 +13,7 @@ quickstart.md
 about.md
 data.md
 config.md
+flagging.md
 masking.md
 contributions.md
 ```

--- a/flint/flagging.py
+++ b/flint/flagging.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from argparse import ArgumentParser
 from pathlib import Path
 from typing import Collection, NamedTuple
@@ -176,10 +177,14 @@ def nan_zero_extreme_flag_ms(
 
     with table(str(ms.path), readonly=False, ack=False) as tab:
         no_rows = len(tab)
-        logger.info(f"Number of rows: {no_rows}")
+        no_chunks = math.ceil(no_rows / chunk_size)
+        logger.info(f"Number of rows: {no_rows} across {no_chunks}")
         idx = 0
         while idx * chunk_size < no_rows:
             start_row = idx * chunk_size
+            logger.info(
+                f"Flagging {idx + 1} of {no_chunks} - {start_row=} with {chunk_size=}"
+            )
 
             data = tab.getcol(data_column, startrow=start_row, nrow=chunk_size)
             flags = tab.getcol("FLAG", startrow=start_row, nrow=chunk_size)

--- a/flint/flagging.py
+++ b/flint/flagging.py
@@ -206,7 +206,7 @@ def nan_zero_extreme_flag_ms(
             # column wwe would otherwise check to see if this option is enabled
             # when putting the column. May as well keep it here.
             if nan_data_on_flag:
-                data[flags is True] = np.nan
+                data[flags] = np.nan
                 logger.info(f"Setting {np.sum(flags)} DATA items to NaN.")
                 tab.putcol(data_column, data, startrow=start_row, nrow=chunk_size)
 

--- a/flint/flagging.py
+++ b/flint/flagging.py
@@ -8,6 +8,7 @@ from typing import Collection, NamedTuple
 
 import numpy as np
 from casacore.tables import table
+from numpy.typing import NDArray
 
 from flint.exceptions import MSError
 from flint.logging import logger
@@ -76,12 +77,71 @@ def flag_ms_zero_uvws(ms: MS, chunk_size: int = 10000) -> MS:
     return ms
 
 
+def _nan_zero_extreme_flag(
+    data: NDArray[np.complex128],
+    flags: NDArray[np.bool],
+    uvws: NDArray[np.float64],
+    flag_extreme_dxy: bool = True,
+    dxy_thresh: float = 4.0,
+) -> tuple[NDArray[np.complex128], NDArray[np.bool], NDArray[np.float64]]:
+    """Used to evaluate the flags that should be applied to the MS based on
+    data values (if there are 0's or nans), uvw values (which can be 0's) and
+    extreme stokes-v values.
+
+    This is the internal checker for the larger `nan_zero_extreme_flags_in_ms`
+    function.
+
+    Args:
+        data (NDArray[np.complex128]): Data that is being consider drawn from a `DATA` like column
+        flags (NDArray[np.bool]): The flags that correspond to the `DATA` column drawn from the `FLAG` column
+        uvws (NDArray[np.float64]): The (U,V,W) coordinates of the data
+        flag_extreme_dxy (bool, optional): Whether flagging on extreme stokes-v should be consider. Defaults to True.
+        dxy_thresh (float, optional): The threshold of the stokes-v flagging. Defaults to 4.0.
+
+    Returns:
+        tuple[NDArray[np.complex128], NDArray[np.bool], NDArray[np.float64]]: Copies of the input `data`, `flags` and `uvws`. The `flags` are updated based on the results of the flagging.
+    """
+
+    no_flags_before = np.sum(flags)
+
+    nan_mask = np.where(~np.isfinite(data))
+    zero_mask = np.where(data == 0 + 0j)
+    uvw_mask = np.any(uvws == 0, axis=1)
+    logger.info(
+        f"Will flag {np.sum(nan_mask)} NaNs, zero'd data {np.sum(zero_mask)}, zero'd UVW {np.sum(uvw_mask)}. "
+    )
+
+    flags[nan_mask] = True
+    flags[zero_mask] = True
+    flags[uvw_mask] = True
+
+    if flag_extreme_dxy:
+        logger.info(f"Flagging based on extreme Stokes-V, threshold {dxy_thresh=}")
+        dxy = np.abs(data[:, :, 1] - data[:, :, 2])
+        dxy_mask = np.where(dxy > dxy_thresh)
+        logger.info(f"Will flag {np.sum(dxy_mask)} extreme Stokes-V.")
+
+        # TODO: This can be compressed to a one-liner
+        flags[:, :, 0][dxy_mask] = True
+        flags[:, :, 1][dxy_mask] = True
+        flags[:, :, 2][dxy_mask] = True
+        flags[:, :, 3][dxy_mask] = True
+
+    no_flags_after = np.sum(flags)
+    logger.info(
+        f"Flags before: {no_flags_before}, Flags after: {no_flags_after}, Difference {no_flags_after - no_flags_before}"
+    )
+
+    return (data, flags, uvws)
+
+
 def nan_zero_extreme_flag_ms(
     ms: Path | MS,
     data_column: str | None = None,
     flag_extreme_dxy: bool = True,
     dxy_thresh: float = 4.0,
     nan_data_on_flag: bool = False,
+    chunk_size: int = 250000,
 ) -> MS:
     """Will flag a MS based on NaNs or zeros in the nominated data column of a measurement set.
     These NaNs might be introduced into a column via the application of a applysolutions task.
@@ -96,8 +156,9 @@ def nan_zero_extreme_flag_ms(
         ms (Union[Path,MS]): The measurement set that will be processed and have visibilities flagged.
         data_column (Optional[str], optional): The column to inspect. This will override the value in the nominated column of the MS. Defaults to None.
         flag_extreme_dxy (bool, optional): Whether Stokes-V will be inspected and flagged. Defaults to True.
-        dxy_thresh (float, optional): Threshold used in the Stokes-V case. Defaults to 4..
+        dxy_thresh (float, optional): Threshold used in the Stokes-V case. Defaults to 4.0.
         nan_data_on_flag (bool, optional): If True, data whose FLAG is set to True will become NaNs. Defaults to False.
+        chunk_size (int, optional): Number of rows to process at a time. Defaults to 250000.
 
     Returns:
         MS: The container of the processed MS
@@ -114,46 +175,37 @@ def nan_zero_extreme_flag_ms(
     logger.info(f"Flagging NaNs and zeros in {data_column}.")
 
     with table(str(ms.path), readonly=False, ack=False) as tab:
-        data = tab.getcol(data_column)
-        flags = tab.getcol("FLAG")
+        no_rows = len(tab)
+        logger.info(f"Number of rows: {no_rows}")
+        idx = 0
+        while idx * chunk_size < no_rows:
+            start_row = idx * chunk_size
 
-        nan_mask = np.where(~np.isfinite(data))
-        zero_mask = np.where(data == 0 + 0j)
-        uvw_mask = np.any(tab.getcol("UVW") == 0, axis=1)
-        logger.info(
-            f"Will flag {np.sum(nan_mask)} NaNs, zero'd data {np.sum(zero_mask)}, zero'd UVW {np.sum(uvw_mask)}. "
-        )
+            data = tab.getcol(data_column, startrow=start_row, nrow=chunk_size)
+            flags = tab.getcol("FLAG", startrow=start_row, nrow=chunk_size)
+            uvws = tab.getcol("UVW", startrow=start_row, nrow=chunk_size)
 
-        no_flags_before = np.sum(flags)
-        # TODO: Consider batching this to allow larger MS being used
-        flags[nan_mask] = True
-        flags[zero_mask] = True
-        flags[uvw_mask] = True
+            data, flags, uvws = _nan_zero_extreme_flag(
+                data=data,
+                flags=flags,
+                uvws=uvws,
+                flag_extreme_dxy=flag_extreme_dxy,
+                dxy_thresh=dxy_thresh,
+            )
 
-        if flag_extreme_dxy:
-            logger.info(f"Flagging based on extreme Stokes-V, threshold {dxy_thresh=}")
-            dxy = np.abs(data[:, :, 1] - data[:, :, 2])
-            dxy_mask = np.where(dxy > dxy_thresh)
-            logger.info(f"Will flag {np.sum(dxy_mask)} extreme Stokes-V.")
+            logger.info("Adding updated flags column")
+            tab.putcol("FLAG", flags, startrow=start_row, nrow=chunk_size)
 
-            # TODO: This can be compressed to a one-liner
-            flags[:, :, 0][dxy_mask] = True
-            flags[:, :, 1][dxy_mask] = True
-            flags[:, :, 2][dxy_mask] = True
-            flags[:, :, 3][dxy_mask] = True
+            # Keep this outside the above function to avoid
+            # passing the table reference. To avoid thrashing the data
+            # column wwe would otherwise check to see if this option is enabled
+            # when putting the column. May as well keep it here.
+            if nan_data_on_flag:
+                data[flags is True] = np.nan
+                logger.info(f"Setting {np.sum(flags)} DATA items to NaN.")
+                tab.putcol(data_column, data, startrow=start_row, nrow=chunk_size)
 
-        no_flags_after = np.sum(flags)
-        logger.info(
-            f"Flags before: {no_flags_before}, Flags after: {no_flags_after}, Difference {no_flags_after - no_flags_before}"
-        )
-
-        logger.info("Adding updated flags column")
-        tab.putcol("FLAG", flags)
-
-        if nan_data_on_flag:
-            data[flags is True] = np.nan
-            logger.info(f"Setting {np.sum(flags)} DATA items to NaN.")
-            tab.putcol(data_column, data)
+            idx += 1
 
         tab.close()
 

--- a/flint/selfcal/casa.py
+++ b/flint/selfcal/casa.py
@@ -250,7 +250,7 @@ def gaincal_applycal_ms(
         gain_cal_options (Optional[GainCalOptions], optional): Options provided to gaincal. Defaults to None.
         update_gain_cal_options (Optional[Dict[str, Any]], optional): Update the gain_cal_options with these. Defaults to None.
         archive_input_ms (bool, optional): If True, the input measurement set will be compressed into a single file. Defaults to False.
-        raise_error_on_fail (bool, optional): If gaincal does not converge raise en error. if False and gain cal fails return the input ms. Defaults to True.
+        raise_error_on_fail (bool, optional): If gaincal does not converge raise en error. If False and gain cal fails return the input ms. Defaults to True.
         skip_selfcal (bool, optional): Should this self-cal be skipped. If `True`, the a new MS is created but not calibrated the appropriate new name and returned.
         rename_ms (bool, optional): It `True` simply rename a MS and adjust columns appropriately (potentially deleting them) instead of copying the complete MS. If `True` `archive_input_ms` is ignored. Defaults to False.
         archive_cal_table (bool, optional): Archive the output calibration table in a tarball. Defaults to False.

--- a/flint/selfcal/casa.py
+++ b/flint/selfcal/casa.py
@@ -327,7 +327,7 @@ def gaincal_applycal_ms(
     # not overwriting the entire column
     for idx, (spw_str, cal_table) in enumerate(spw_and_cal_tables):
         logger.info(
-            f"{idx + 1} of {len(spw_and_cal_tables)}, applying solutions for {spw_str}"
+            f"Apply solutions {idx + 1} of {len(spw_and_cal_tables)}, {spw_str}"
         )
         applycal(
             container=casa_container,

--- a/tests/test_flagging.py
+++ b/tests/test_flagging.py
@@ -108,3 +108,29 @@ def test_nan_zero_extreme_flag_ms_with_chunks(ms_example):
 
         assert np.sum(uvw_mask) > 0
         assert np.all(flags[uvw_mask] == True)  # noQA: E712
+
+
+def test_nan_zero_extreme_flag_ms_with_chunks_and_datanan(ms_example):
+    """Makes sure that flagging the NaNs, UVWs of zero and
+    extreme outliers works. Was added after introducing the
+    chunking.
+
+    Same as above test but with chunk size and naning data when flags are true"""
+    with table(str(ms_example), readonly=False, ack=False) as tab:
+        uvws = tab.getcol("UVW")
+        uvws[:20, :] = 0
+
+        tab.putcol("UVW", uvws)
+
+    nan_zero_extreme_flag_ms(ms=ms_example, chunk_size=1, nan_data_on_flag=True)
+
+    with table(str(ms_example), ack=False) as tab:
+        uvws = tab.getcol("UVW")
+
+        flags = tab.getcol("FLAG")
+        data = tab.getcol("DATA")
+        uvw_mask = np.all(uvws == 0, axis=1)
+
+        assert np.sum(np.isnan(data)) == np.sum(flags)
+        assert np.sum(uvw_mask) > 0
+        assert np.all(flags[uvw_mask] == True)  # noQA: E712

--- a/tests/test_flagging.py
+++ b/tests/test_flagging.py
@@ -119,7 +119,7 @@ def test_nan_zero_extreme_flag_ms_with_chunks_and_datanan(ms_example):
     with table(str(ms_example), readonly=False, ack=False) as tab:
         uvws = tab.getcol("UVW")
         uvws[:20, :] = 0
-
+        original_data = tab.getcol("DATA")
         tab.putcol("UVW", uvws)
 
     nan_zero_extreme_flag_ms(ms=ms_example, chunk_size=1, nan_data_on_flag=True)
@@ -132,5 +132,6 @@ def test_nan_zero_extreme_flag_ms_with_chunks_and_datanan(ms_example):
         uvw_mask = np.all(uvws == 0, axis=1)
 
         assert np.sum(np.isnan(data)) == np.sum(flags)
+        assert np.sum(np.isnan(data)) > np.sum(np.isnan(original_data))
         assert np.sum(uvw_mask) > 0
         assert np.all(flags[uvw_mask] == True)  # noQA: E712


### PR DESCRIPTION
ASKAP data will flag data online by setting data to 0's and uvws to 0's. Somethings the flags captures these appropriately. Sometimes not. 

Previous behavior would read in the DATA, FLAG and UVW columns all into memory in complete form while flagging. 

Some strange behavior has been noted when running on setonix with large MSs. The suspicion is that these large reads are causing issues. I am unsure whether it is OOM (unlikely, but never know), or just hitting the I/O, or something in between. It looks like the dask nanny process is killing the worker and reallocating it to another worker. Since the self-cal process is not pure there are some errors raised. 

This PR attempts to provide some relief by doing the initial flagging in a batched / chunked process. 