### PR TITLE
Exposed BANE and aegean options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@
   - Convert flux columns to Jy
 - Improved docs
 - Added chunking to the NaN/UVW/zero flagging during selfcal
+- Added `update_bane_options` and `update_aegean_options` to `flint.source_finding.aegean`
+  - Initially to support using more cores
+  - Patched in the `get_options_from_strategy` function in the continuum flow
 
 # 0.2.13
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,6 +15,7 @@ data.md
 config.md
 flagging.md
 masking.md
+source_finding.md
 contributions.md
 ```
 

--- a/docs/source_finding.md
+++ b/docs/source_finding.md
@@ -1,0 +1,44 @@
+# Source Finding
+
+Current in `flint` [the `aegeantools` package](https://github.com/PaulHancock/Aegean) is the only source finder supported. Even so, it is only used through a container as a CLI callable and not directly accessed via its private API.
+
+There are two reasons where `aegeantools` is currently used:
+
+1 - background and noise maps
+2 - slim source finding
+
+## Background and noise estimation
+
+There are weak links to the `BANE` program packaged in `aegeantools`. The computation of the `bkg` and `rms` maps through a rolling sigma-clipping boxcar function produces reliable and easily accessible direction-dependent diagnostics. In early versions of `flint` these were used as the basis of our clean mask creation routines. The `rms` map is also used when creating a summary field figure.
+
+We note that in the latest version of `aegeantools` that there is [an ongoing bug that can lead to a deadlock issue](https://github.com/PaulHancock/Aegean/issues/198). For these reason we only expose the `cores` argument and have logic to ensure that the `stripes` `BANE` parameters it always one less than this.
+
+```{literalinclude}  ../flint/source_finding/aegean.py
+:pyobject: BANEOptions
+```
+
+## Source finding
+
+`Flint` offers the `aegean` source finding tool to be executed after `BANE` has been invoked. These two tools will always run sequentially. A limited set of `aegean` options have been exposed.
+
+Importantly the intention here is to obtain a set of diagnostic results with minimal computation. The `AegeanOptions` exposed correspond to equivalent `aegean` CLI arguments. Do not that the default value of `noconv` is `True` -- this mode does not handle the correlation of adjacent pixels.
+
+
+```{literalinclude}  ../flint/source_finding/aegean.py
+:pyobject: AegeanOptions
+```
+
+```{admonition} Caution
+:class: caution
+
+The `flint_aegean` CLI will append options from both `BANEOptions` and `AegeanOptions`, and craft instances of these objects automatically. The default type of `nocon` and `autoload` will be translated to `store_false` options in `argparse.ArgumentParser`. If you want to use the quick version of `aegean` do not pass `--noconv` to the `flint_aegean find` CLI call.
+```
+
+## Accessing via the CLI
+
+The primary entry point for the source finding with `aegean` in  `flint` is via `flint_aegean`:
+
+```{argparse}
+:ref: flint.source_finding.aegean.get_parser
+:prog: flint_aegean
+```

--- a/flint/flagging.py
+++ b/flint/flagging.py
@@ -142,7 +142,7 @@ def nan_zero_extreme_flag_ms(
     flag_extreme_dxy: bool = True,
     dxy_thresh: float = 4.0,
     nan_data_on_flag: bool = False,
-    chunk_size: int = 250000,
+    chunk_size: int = 100000,
 ) -> MS:
     """Will flag a MS based on NaNs or zeros in the nominated data column of a measurement set.
     These NaNs might be introduced into a column via the application of a applysolutions task.
@@ -159,7 +159,7 @@ def nan_zero_extreme_flag_ms(
         flag_extreme_dxy (bool, optional): Whether Stokes-V will be inspected and flagged. Defaults to True.
         dxy_thresh (float, optional): Threshold used in the Stokes-V case. Defaults to 4.0.
         nan_data_on_flag (bool, optional): If True, data whose FLAG is set to True will become NaNs. Defaults to False.
-        chunk_size (int, optional): Number of rows to process at a time. Defaults to 250000.
+        chunk_size (int, optional): Number of rows to process at a time. Defaults to 100000.
 
     Returns:
         MS: The container of the processed MS

--- a/flint/flagging.py
+++ b/flint/flagging.py
@@ -209,7 +209,7 @@ def nan_zero_extreme_flag_ms(
                 data[flags] = np.nan
                 logger.info(f"Setting {np.sum(flags)} DATA items to NaN.")
                 tab.putcol(data_column, data, startrow=start_row, nrow=chunk_size)
-
+            tab.flush()
             idx += 1
 
         tab.close()

--- a/flint/prefect/common/imaging.py
+++ b/flint/prefect/common/imaging.py
@@ -187,12 +187,12 @@ def task_extract_solution_path(calibrate_cmd: CalibrateCommand) -> Path:
     return calibrate_cmd.solution_path
 
 
-# BANE sometimes gets cauht in some stalled staTE
-@task(retries=3)
+@task
 def task_run_bane_and_aegean(
     image: WSCleanResult | LinmosResult,
     aegean_container: Path,
-    timelimit_seconds: int | float = 60 * 45,
+    update_bane_options: dict[str, Any] | None = None,
+    update_aegean_options: dict[str, Any] | None = None,
 ) -> AegeanOutputs:
     """Run BANE and Aegean against a FITS image.
 
@@ -205,7 +205,8 @@ def task_run_bane_and_aegean(
     Args:
         image (Union[WSCleanResult, LinmosResult]): The image that will be searched
         aegean_container (Path): Path to a singularity container containing BANE and aegean
-        timelimit_seconds (Union[int,float], optional): The maximum amount of time, in seconds, before an exception is raised. Defaults to 45*60.
+        update_bane_options (dict[str, Any] | None, optional): Over-ride any default options of BANEOptions. If None defaults are used. Defaults to None.
+        update_aegean_options (dict[str, Any] | None, optional): Over-ride any default options of AegeanOptions. If None defaults are used. Defaults to None.
 
     Raises:
         ValueError: Raised when ``image`` is not a supported type
@@ -235,7 +236,10 @@ def task_run_bane_and_aegean(
         raise ValueError(f"Unexpected type, have received {type(image)} for {image=}. ")
 
     aegean_outputs = run_bane_and_aegean(
-        image=image_path, aegean_container=aegean_container
+        image=image_path,
+        aegean_container=aegean_container,
+        update_bane_options=update_bane_options,
+        update_aegean_options=update_aegean_options,
     )
 
     return aegean_outputs

--- a/flint/selfcal/casa.py
+++ b/flint/selfcal/casa.py
@@ -259,7 +259,7 @@ def gaincal_applycal_ms(
         GainCallError: Raised when raise_error_on_fail is True and gaincal does not converge.
 
     Returns:
-        MS: THe self-calibrated measurement set.
+        MS: The self-calibrated measurement set.
     """
     logger.info(f"Measurement set to be self-calibrated: ms={ms}")
 

--- a/flint/source_finding/aegean.py
+++ b/flint/source_finding/aegean.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from argparse import ArgumentParser
 from pathlib import Path
-from typing import NamedTuple
+from typing import Any, NamedTuple
 
 from astropy.io import fits
 
@@ -121,6 +121,8 @@ def run_bane_and_aegean(
     aegean_container: Path,
     bane_options: BANEOptions | None = None,
     aegean_options: AegeanOptions | None = None,
+    update_bane_options: dict[str, Any] | None = None,
+    update_aegean_options: dict[str, Any] | None = None,
 ) -> AegeanOutputs:
     """Run BANE, the background and noise estimator, and aegean, the source finder,
     against an input image. This function attempts to hook into the AegeanTools
@@ -131,12 +133,19 @@ def run_bane_and_aegean(
         aegean_container (Path): Path to a singularity container that was the AegeanTools packages installed.
         bane_options (Optional[BANEOptions], optional): The options that are provided to BANE. If None defaults of BANEOptions are used. Defaults to None.
         aegean_options (Optional[AegeanOptions], optional): The options that are provided to Aegean. if None defaults of AegeanOptions are used. Defaults to None.
+        update_bane_options (dict[str, Any] | None, optional): Over-ride any default options of BANEOptions. If None defaults are used. Defaults to None.
+        update_aegean_options (dict[str, Any] | None, optional): Over-ride any default options of AegeanOptions. If None defaults are used. Defaults to None.
 
     Returns:
         AegeanOutputs: The newly created BANE products
     """
     bane_options = bane_options if bane_options else BANEOptions()
+    if update_bane_options:
+        bane_options = bane_options.with_options(**update_bane_options)
+
     aegean_options = aegean_options if aegean_options else AegeanOptions()
+    if update_aegean_options:
+        aegean_options = aegean_options.with_options(**update_aegean_options)
 
     image = image.absolute()
     base_output = str(image.parent / image.stem)

--- a/flint/source_finding/aegean.py
+++ b/flint/source_finding/aegean.py
@@ -11,19 +11,22 @@ from astropy.io import fits
 from flint.exceptions import AttemptRerunException
 from flint.logging import logger
 from flint.naming import create_aegean_names
+from flint.options import BaseOptions, add_options_to_parser, create_options_from_parser
 from flint.sclient import run_singularity_command
 
 
-class BANEOptions(NamedTuple):
+class BANEOptions(BaseOptions):
     """Container for basic BANE related options. Only a subclass of BANE options are supported."""
 
     grid_size: tuple[int, int] | None = (16, 16)
     """The step interval of each box, in pixels"""
     box_size: tuple[int, int] | None = (196, 196)
     """The size of the box in pixels"""
+    cores: int = 12
+    """Number of cores to use. The number of stripes will be less than this number."""
 
 
-class AegeanOptions(NamedTuple):
+class AegeanOptions(BaseOptions):
     """Container for basic aegean options. Only a subclass of aegean options are supported.
 
     Of note is the lack of a tables option (corresponding to --tables). This is dependent on knowing the base output name
@@ -54,10 +57,12 @@ class AegeanOutputs(NamedTuple):
     """The input image that was used to source find against"""
 
 
-def _get_bane_command(image: Path, cores: int, bane_options: BANEOptions) -> str:
+def _get_bane_command(image: Path, bane_options: BANEOptions) -> str:
     """Create the BANE command to run"""
     # The stripes is purposely set lower than the cores due to an outstanding bane bug that can cause a deadlock.
-    bane_command_str = f"BANE {image!s} --cores {cores} --stripes {cores - 1} "
+    cores = max(1, bane_options.cores)
+    stripes = max(1, cores - 1)
+    bane_command_str = f"BANE {image!s} --cores {cores} --stripes {stripes} "
     if bane_options.grid_size:
         bane_command_str += (
             f"--grid {bane_options.grid_size[0]} {bane_options.grid_size[1]} "
@@ -114,7 +119,6 @@ def _get_aegean_command(
 def run_bane_and_aegean(
     image: Path,
     aegean_container: Path,
-    cores: int = 8,
     bane_options: BANEOptions | None = None,
     aegean_options: AegeanOptions | None = None,
 ) -> AegeanOutputs:
@@ -125,7 +129,6 @@ def run_bane_and_aegean(
     Args:
         image (Path): The input image that BANE will calculate a background and RMS map for
         aegean_container (Path): Path to a singularity container that was the AegeanTools packages installed.
-        cores (int, optional): The number of cores to allow BANE to use. Internally BANE will create a number of sub-processes. Defaults to 8.
         bane_options (Optional[BANEOptions], optional): The options that are provided to BANE. If None defaults of BANEOptions are used. Defaults to None.
         aegean_options (Optional[AegeanOptions], optional): The options that are provided to Aegean. if None defaults of AegeanOptions are used. Defaults to None.
 
@@ -142,9 +145,7 @@ def run_bane_and_aegean(
     aegean_names = create_aegean_names(base_output=base_output)
     logger.debug(f"{aegean_names=}")
 
-    bane_command_str = _get_bane_command(
-        image=image, cores=cores, bane_options=bane_options
-    )
+    bane_command_str = _get_bane_command(image=image, bane_options=bane_options)
 
     bind_dir = [image.absolute().parent]
     run_singularity_command(
@@ -199,9 +200,8 @@ def get_parser() -> ArgumentParser:
     bane_parser.add_argument(
         "container", type=Path, help="Path to container with AegeanTools"
     )
-    bane_parser.add_argument(
-        "--cores", type=int, default=8, help="Number of cores to instruct aegean to use"
-    )
+    bane_parser = add_options_to_parser(parser=bane_parser, options_class=BANEOptions)
+    bane_parser = add_options_to_parser(parser=bane_parser, options_class=AegeanOptions)
 
     return parser
 
@@ -212,8 +212,17 @@ def cli() -> None:
     args = parser.parse_args()
 
     if args.mode == "find":
+        bane_options = create_options_from_parser(
+            parser_namespace=args, options_class=BANEOptions
+        )
+        aegean_options = create_options_from_parser(
+            parser_namespace=args, options_class=AegeanOptions
+        )
         run_bane_and_aegean(
-            image=args.image, aegean_container=args.container, cores=args.cores
+            image=args.image,
+            aegean_container=args.container,
+            bane_options=bane_options,
+            aegean_options=aegean_options,
         )
 
 

--- a/flint/source_finding/aegean.py
+++ b/flint/source_finding/aegean.py
@@ -224,6 +224,9 @@ def cli() -> None:
             bane_options=bane_options,
             aegean_options=aegean_options,
         )
+    else:
+        logger.info(f"Mode '{args.mode}' is not known.")
+        parser.print_help()
 
 
 if __name__ == "__main__":

--- a/tests/test_aegean.py
+++ b/tests/test_aegean.py
@@ -16,7 +16,13 @@ from flint.source_finding.aegean import (
     _bane_output_callback,
     _get_aegean_command,
     _get_bane_command,
+    get_parser,
 )
+
+
+def test_get_parser():
+    """Make sure that there are no conflicting options when creating the parser object"""
+    _ = get_parser()
 
 
 def test_bane_deadlock_callback():
@@ -42,12 +48,12 @@ def test_bane_options():
     assert isinstance(bane_opts, BANEOptions)
 
     bane_str = _get_bane_command(
-        image=Path("this/is/a/test.fits"), cores=8, bane_options=bane_opts
+        image=Path("this/is/a/test.fits"), bane_options=bane_opts
     )
 
     assert isinstance(bane_str, str)
 
-    expected = "BANE this/is/a/test.fits --cores 8 --stripes 7 --grid 20 10 --box 2 1"
+    expected = f"BANE this/is/a/test.fits --cores {bane_opts.cores} --stripes {bane_opts.cores - 1} --grid 20 10 --box 2 1"
     assert expected == bane_str
 
 
@@ -57,19 +63,19 @@ def test_bane_options_with_defaults():
     assert isinstance(bane_opts, BANEOptions)
 
     bane_str = _get_bane_command(
-        image=Path("this/is/a/test.fits"), cores=8, bane_options=bane_opts
+        image=Path("this/is/a/test.fits"), bane_options=bane_opts
     )
 
     assert isinstance(bane_str, str)
 
-    expected = "BANE this/is/a/test.fits --cores 8 --stripes 7"
+    expected = f"BANE this/is/a/test.fits --cores {bane_opts.cores} --stripes {bane_opts.cores - 1}"
     assert expected == bane_str
 
     bane_opts = BANEOptions(box_size=(3, 5), grid_size=None)
     bane_str = _get_bane_command(
-        image=Path("this/is/a/test.fits"), cores=8, bane_options=bane_opts
+        image=Path("this/is/a/test.fits"), bane_options=bane_opts
     )
-    expected = "BANE this/is/a/test.fits --cores 8 --stripes 7 --box 3 5"
+    expected = f"BANE this/is/a/test.fits --cores {bane_opts.cores} --stripes {bane_opts.cores - 1} --box 3 5"
     assert expected == bane_str
 
 


### PR DESCRIPTION
For some time the number of cores and stripes to use in BANE were hardcoded to 8 and 7. These were set a long time ago without much thought. 

Tweaking these numbers would be ideal, especially if larger compute resources are requested per dask worker. 

This change brings in the ability to set the cores through `BANEOptions`. Potentially this could further be expanded to allow it to be auto-detected (may be the default behavior in BANE) but I am a little uncomfortable with this:
1 - there is a bug in current BANE where deadlocking can occur should CPUs == stripes
2 - not sure how the python get cpu functions behave in all environments

I am therefore for the moment in favor of an explicit is better approach. In the continuum pipeline I have also added plumbing to draw from the strategy file. 

Some extensions have been made to `flint_aegean`. 

Added some basic source finder docs