### PR TITLE
Fixes to the badges embedded in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![pre-commit.ci status](https://results.pre-commit.ci/badge/github/tjgalvin/flint/main.svg)](https://results.pre-commit.ci/latest/github/tjgalvin/flint/main)
-[![codecov](https://codecov.io/github/tjgalvin/flint/graph/badge.svg?token=7ZEKJ78TBZ)](https://codecov.io/github/tjgalvin/flint)
+[![pre-commit.ci status](https://results.pre-commit.ci/badge/github/flint-crew/flint/main.svg)](https://results.pre-commit.ci/latest/github/flint-crew/flint/main)
+[![codecov](https://codecov.io/gh/flint-crew/flint/graph/badge.svg?token=7ZEKJ78TBZ)](https://codecov.io/gh/flint-crew/flint)
 
 # flint
 


### PR DESCRIPTION
When we moved the repository from my personal account to `flint-crew` the badges broke. This adds back the tracking functionality. 