### PR TITLE
Fixes issue #263 (linmos parser option name) 

### DIFF
--- a/flint/coadd/linmos.py
+++ b/flint/coadd/linmos.py
@@ -746,7 +746,7 @@ def cli() -> None:
         )
         if args.yandasoft_container is None:
             linmos_names = create_linmos_names(
-                name_prefix=args.image_output_name,
+                name_prefix=args.base_output_name,
                 parset_output_path=args.parset_output_path,
             )
             generate_linmos_parameter_set(


### PR DESCRIPTION
This _should_ fix #263 , though I don't have a test environment set up yet to make sure. We can open this as a draft until it can be confirmed it is just the arg variable name that is the issue. 