### PR TITLE
Fix pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 
 [project]
-name = "flint"
+name = "askap-flint"
 authors = [
     {name="Tim Galvin", email="tim.galvin@csiro.au"}
 ]


### PR DESCRIPTION
Need pyproject.toml to match PyPI. Have no fear, me hearties, the package name is still `flint` and we still `import flint`. But now we `pip install askap-flint`