### PR TITLE
Fixes docker devcontainer.json for failing tests

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,20 +10,22 @@
 		"options": [
 			"--platform=linux/x86_64"
 		]
-	}
-
+	},
 	// Features to add to the dev container. More info: https://containers.dev/features.
-	// "features": {},
-
+	"features": {
+		"ghcr.io/rocker-org/devcontainer-features/apt-packages:1": {
+			"packages": "curl,nano,rsync"
+		}
+	},
+	"mounts": [
+		"source=${localEnv:HOME}${localEnv:USERPROFILE},target=/host-home-folder,type=bind,consistency=cached"
+	]
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
-
 	// Uncomment the next line to run commands after the container is created.
 	// "postCreateCommand": "cat /etc/os-release",
-
 	// Configure tool-specific properties.
 	// "customizations": {},
-
 	// Uncomment to connect as an existing user other than the container default. More info: https://aka.ms/dev-containers-non-root.
 	// "remoteUser": "devcontainer"
 }

--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get install -y wget && \
 
 # Create conda environment
 WORKDIR /root
-RUN conda install -c conda-forge python=3.12 boost casacore compilers
+RUN conda install -c conda-forge python=3.12 libsqlite=3.46.1 boost casacore compilers
 # Make RUN commands use the new environment:
 SHELL ["conda", "run", "-n", "base", "/bin/bash", "-c"]
 RUN conda clean --all --yes

--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update && apt-get install -y wget && \
 
 # Create conda environment
 WORKDIR /root
+# settomg libsqlite for https://github.com/PrefectHQ/prefect/issues/17186
 RUN conda install -c conda-forge python=3.12 libsqlite=3.46.1 boost casacore compilers
 # Make RUN commands use the new environment:
 SHELL ["conda", "run", "-n", "base", "/bin/bash", "-c"]

--- a/containers/Dockerfile-dev
+++ b/containers/Dockerfile-dev
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get install -y wget && \
 
 # Create conda environment
 WORKDIR /root
-RUN conda install -c conda-forge python=3.12 boost casacore compilers
+RUN conda install -c conda-forge python=3.12 libsqlite=3.46.1 boost casacore compilers
 # Make RUN commands use the new environment:
 SHELL ["conda", "run", "-n", "base", "/bin/bash", "-c"]
 RUN conda clean --all --yes

--- a/containers/Dockerfile-dev
+++ b/containers/Dockerfile-dev
@@ -14,6 +14,7 @@ RUN apt-get update && apt-get install -y wget && \
 
 # Create conda environment
 WORKDIR /root
+# settomg libsqlite for https://github.com/PrefectHQ/prefect/issues/17186
 RUN conda install -c conda-forge python=3.12 libsqlite=3.46.1 boost casacore compilers
 # Make RUN commands use the new environment:
 SHELL ["conda", "run", "-n", "base", "/bin/bash", "-c"]

--- a/tests/test_prefect_helpers.py
+++ b/tests/test_prefect_helpers.py
@@ -3,8 +3,16 @@
 from __future__ import annotations
 
 from prefect import flow
+from prefect.logging import disable_run_logger
+from prefect.testing.utilities import prefect_test_harness
 
 from flint.prefect.helpers import enable_loguru_support
+
+
+@flow
+def example_flow():
+    enable_loguru_support()
+    return "JackSparrow"
 
 
 def test_enable_loguru_support():
@@ -15,8 +23,6 @@ def test_enable_loguru_support():
     error, though whether it still works is a completely different
     question!"""
 
-    @flow
-    def example_flow():
-        enable_loguru_support()
-
-    example_flow()
+    with prefect_test_harness():
+        with disable_run_logger():
+            assert example_flow() == "JackSparrow"


### PR DESCRIPTION
There were a couple of pytest unit tests that began to fail when running in a `devcontainer.json` established container. This is useful when developing in a docker container, such as one built when using the `Dev Containers` extension available in `vscode`. 

In short there were two tests failing:
- `rsync` was not in the container. It is used in one location to ensure an accurate copy of a file or folder (silly scratch on setonix)
- Fixing some sqlite version change that was causing prefect flows to fail