### PR TITLE
Proposed more flexible handling of environment variables if the user wants to mix those with paths

### DIFF
--- a/flint/imager/wsclean.py
+++ b/flint/imager/wsclean.py
@@ -749,7 +749,9 @@ def _resolve_wsclean_key_value_to_cli_str(key: str, value: Any) -> ResolvedCLIRe
 
     logger.debug(f"{key=} {value=} {type(value)=}")
 
-    value = get_environment_variable(variable=value)
+    value = (
+        get_environment_variable(variable=value) if isinstance(value, str) else value
+    )
 
     cmd = None
     unknown = None

--- a/flint/imager/wsclean.py
+++ b/flint/imager/wsclean.py
@@ -179,8 +179,6 @@ class WSCleanOptions(BaseOptions):
     """If True do not log the wsclean output"""
     no_mf_weighting: bool = False
     """Opposite of -ms-weighting; can be used to turn off MF weighting in -join-channels mode"""
-    flint_make_cube_inplace: bool = True
-    """Rotate the cube for the linmos axis ordering in place, or do it via a temporary file that then gets deleted. Good thing to turn off when getting weird OSErrors on file writing"""
 
 
 class WSCleanResult(BaseOptions):
@@ -213,7 +211,6 @@ def combine_images_to_cube(
     prefix: str,
     mode: str,
     remove_original_images: bool = False,
-    inplace: bool = True,
 ) -> Path:
     """Combine wsclean subband channel images into a cube. Each collection attribute
     of the input `image_set` will be inspected. The MFS images will be ignored.
@@ -223,8 +220,7 @@ def combine_images_to_cube(
     Args:
         image_set (ImageSet): Collection of wsclean image productds
         remove_original_images (bool, optional): If True, images that went into the cube are removed. Defaults to False.
-        inplace (bool, optional): If True, modify the file in-place. If False, write to a temporary file and
-        then replace the original. Default True
+
     Returns:
         ImageSet: Updated iamgeset describing the new outputs
     """
@@ -234,7 +230,7 @@ def combine_images_to_cube(
 
     logger.info(f"Combining {len(images)} images. {images=}")
     freqs = combine_fits(file_list=images, out_cube=output_cube_name)
-    rotate_cube(output_cube_name, inplace=inplace)
+    rotate_cube(output_cube_name)
 
     # Write out the hdu to preserve the beam table constructed in fitscube
     logger.info(f"Writing {output_cube_name=}")
@@ -753,11 +749,7 @@ def _resolve_wsclean_key_value_to_cli_str(key: str, value: Any) -> ResolvedCLIRe
 
     logger.debug(f"{key=} {value=} {type(value)=}")
 
-    value = (
-        get_environment_variable(variable=value)
-        if isinstance(value, str) and value[0] == "$"
-        else value
-    )
+    value = get_environment_variable(variable=value)
 
     cmd = None
     unknown = None
@@ -882,67 +874,34 @@ def create_wsclean_cmd(
     )
 
 
-def rotate_cube(output_cube_path: str | Path, inplace: bool = True) -> Path:
-    """
-    Rotate the FITS cube axes to a shape of (chan, pol, dec, ra)
-    which is what yandasoft linmos tasks expect.
+def rotate_cube(output_cube_name) -> None:
+    logger.info(f"Rotating {output_cube_name=}")
+    # This changes the output cube to a shape of (chan, pol, dec, ra)
+    # which is what yandasoft linmos tasks like
+    with fits.open(output_cube_name, mode="update", memmap=True) as hdulist:
+        hdu = hdulist[0]
+        new_header = hdu.header
+        data_cube = hdu.data
 
-    Parameters
-    ----------
-    output_cube_path : str | Path
-        Path to the FITS cube to rotate.
-    inplace : bool, optional
-        If True, modify the file in-place. If False, write to a temporary file and
-        then replace the original. Default True
+        tmp_header = new_header.copy()
+        # Need to swap NAXIS 3 and 4 to make LINMOS happy - booo
+        for a, b in ((3, 4), (4, 3)):
+            new_header[f"CTYPE{a}"] = tmp_header[f"CTYPE{b}"]
+            new_header[f"CRPIX{a}"] = tmp_header[f"CRPIX{b}"]
+            new_header[f"CRVAL{a}"] = tmp_header[f"CRVAL{b}"]
+            new_header[f"CDELT{a}"] = tmp_header[f"CDELT{b}"]
+            new_header[f"CUNIT{a}"] = tmp_header[f"CUNIT{b}"]
 
-    Returns
-    -------
-    Path
-        Path to the rotated FITS cube.
-    """
-    output_path = Path(output_cube_path)
-    logger.info(f"Rotating FITS axes of {output_path.name}")
-
-    # Read original data and header
-    with fits.open(output_path, mode="readonly", memmap=True) as hdul:
-        header = hdul[0].header.copy()
-        data_cube = hdul[0].data.copy()
-
-    # Swap axes in header
-    tmp_header = header.copy()
-    for a, b in ((3, 4), (4, 3)):
-        header[f"CTYPE{a}"] = tmp_header[f"CTYPE{b}"]
-        header[f"CRPIX{a}"] = tmp_header[f"CRPIX{b}"]
-        header[f"CRVAL{a}"] = tmp_header[f"CRVAL{b}"]
-        header[f"CDELT{a}"] = tmp_header[f"CDELT{b}"]
-        header[f"CUNIT{a}"] = tmp_header[f"CUNIT{b}"]
-
-    # Move data axis: (pol, chan, dec, ra) → (chan, pol, dec, ra)
-    rotated_data = np.moveaxis(data_cube, 1, 0)
-
-    if inplace:
-        logger.info(f"Rotating {output_path.name} in place")
-        with fits.open(output_path, mode="update", memmap=True) as hdul:
-            hdul[0].data = rotated_data
-            hdul[0].header = header
-            hdul.flush()
-        return output_path
-
-    # Not in-place: write to temp then replace
-    tmp_path = output_path.with_name(f"{output_path.stem}_rotated{output_path.suffix}")
-    logger.info(f"Writing rotated cube to temporary file {tmp_path.name}")
-    fits.PrimaryHDU(data=rotated_data, header=header).writeto(tmp_path, overwrite=True)
-
-    output_path.unlink()
-    tmp_path.rename(output_path)
-    logger.info(f"Replaced original {output_path.name} with rotated cube")
-    return output_path
+        # Cube is currently STOKES, FREQ, RA, DEC - needs to be FREQ, STOKES, RA, DEC
+        data_cube = np.moveaxis(data_cube, 1, 0)
+        hdu.data = data_cube
+        hdu.header = new_header
+        hdulist.flush()
 
 
 def combine_image_set_to_cube(
     image_set: ImageSet,
     remove_original_images: bool = False,
-    inplace: bool = True,
 ) -> ImageSet:
     """Combine wsclean subband channel images into a cube. Each collection attribute
     of the input `image_set` will be inspected. The MFS images will be ignored.
@@ -952,8 +911,6 @@ def combine_image_set_to_cube(
     Args:
         image_set (ImageSet): Collection of wsclean image productds
         remove_original_images (bool, optional): If True, images that went into the cube are removed. Defaults to False.
-        inplace (bool, optional): If True, modify the file in-place. If False, write to a temporary file and
-        then replace the original. Default True
 
     Returns:
         ImageSet: Updated iamgeset describing the new outputs
@@ -988,7 +945,7 @@ def combine_image_set_to_cube(
         logger.info(f"Combining {len(subband_images)} images. {subband_images=}")
         freqs = combine_fits(file_list=subband_images, out_cube=output_cube_name)
 
-        rotate_cube(output_cube_name, inplace=inplace)
+        rotate_cube(output_cube_name)
 
         # Write out the hdu to preserve the beam table constructed in fitscube
         logger.info(f"Writing {output_cube_name=}")
@@ -1165,9 +1122,7 @@ def run_wsclean_imager(
 
     if make_cube_from_subbands:
         image_set = combine_image_set_to_cube(
-            image_set=image_set,
-            remove_original_images=True,
-            inplace=wsclean_result.options.flint_make_cube_inplace,
+            image_set=image_set, remove_original_images=True
         )
 
     image_set = rename_wsclean_prefix_in_image_set(input_image_set=image_set)

--- a/flint/imager/wsclean.py
+++ b/flint/imager/wsclean.py
@@ -48,8 +48,8 @@ from flint.options import (
 )
 from flint.sclient import run_singularity_command
 from flint.utils import (
-    get_environment_variable,
     hold_then_move_into,
+    parse_environment_variables,
     remove_files_folders,
 )
 
@@ -710,7 +710,7 @@ def create_wsclean_name_argument(wsclean_options: WSCleanOptions, ms: MS) -> Pat
     temp_dir = wsclean_options_dict.get("temp_dir", None)
     if temp_dir:
         # attempt to resolve possible environment variables flexibly
-        name_dir = get_environment_variable(variable=temp_dir)
+        name_dir = parse_environment_variables(variable=temp_dir)
 
     assert name_dir is not None, f"{name_dir=} is None, which is bad"
 
@@ -754,7 +754,7 @@ def _resolve_wsclean_key_value_to_cli_str(key: str, value: Any) -> ResolvedCLIRe
     logger.debug(f"{key=} {value=} {type(value)=}")
 
     value = (
-        get_environment_variable(variable=value) if isinstance(value, str) else value
+        parse_environment_variables(variable=value) if isinstance(value, str) else value
     )
 
     cmd = None

--- a/flint/utils.py
+++ b/flint/utils.py
@@ -201,7 +201,7 @@ def temporarily_move_into(
         shutil.rmtree(temporary_directory)
 
 
-def get_environment_variable(
+def parse_environment_variables(
     variable: str | None, default: str | None = None
 ) -> str | None:
     """Expand a $VARIABLE environment variable to obtain its value from
@@ -283,8 +283,8 @@ def get_slurm_info() -> SlurmInfo:
     """
 
     hostname = gethostname()
-    job_id = get_environment_variable("$SLURM_JOB_ID")
-    task_id = get_environment_variable("$SLURM_ARRAY_TASK_ID")
+    job_id = parse_environment_variables("$SLURM_JOB_ID")
+    task_id = parse_environment_variables("$SLURM_ARRAY_TASK_ID")
     time = str(datetime.datetime.now())
 
     return SlurmInfo(hostname=hostname, job_id=job_id, task_id=task_id, time=time)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dynamic = ["version"]
 dependencies = [
     "astropy>=6.1.3", # fixing until units change in 6.1.4 addressed in radio-beam
     "numpy>=2.0.0",
-    "pydantic",
+    "pydantic<2.11", # prefect v2 seems unhappy with pydantic 2.11
     "scipy",
     "spython>=0.3.1",
     "matplotlib",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -258,7 +258,7 @@ def set_env():
 
 def test_get_environment_variable(set_env):
     """Make sure that the variable is processed nicely when getting environment variable"""
-    val = get_environment_variable("TEST1")
+    val = get_environment_variable("$TEST1")
     assert val == "Pirates"
     val2 = get_environment_variable("$TEST2")
     assert val2 == "Treasure"
@@ -266,16 +266,21 @@ def test_get_environment_variable(set_env):
     assert (
         val3 == "THISNOEXISTS"
     )  # in case the user gives a path that is not a variable return the same thing
-    val4 = get_environment_variable("TEST1/TEST2")
+    val4 = get_environment_variable("$TEST1/$TEST2")
     assert val4 == "Pirates/Treasure"
-    val5 = get_environment_variable("TEST1/TEST2/TEST3")
+    val5 = get_environment_variable("$TEST1/$TEST2/TEST3")
     assert (
         val5 == "Pirates/Treasure/TEST3"
     )  # in case the user gives a path that includes variables and directories
 
+    val6 = get_environment_variable("$TEST1/$TEST2/$TEST3")
+    assert val6 is None  # If one goes down all do
+    val7 = get_environment_variable("$TEST1/$TEST3/$TEST2")
+    assert val7 is None  # Same as above but reordered
+
     # Same as above but with a trailing slash
-    val4 = get_environment_variable("TEST1/TEST2/")
-    assert val4 == "Pirates/Treasure/"
+    val8 = get_environment_variable("$TEST1/$TEST2/")
+    assert val8 == "Pirates/Treasure/"
 
 
 @pytest.fixture

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -282,6 +282,8 @@ def test_get_environment_variable(set_env):
     val8 = get_environment_variable("$TEST1/$TEST2/")
     assert val8 == "Pirates/Treasure/"
 
+    assert get_environment_variable(variable=None) is None
+
 
 @pytest.fixture
 def ms_example(tmpdir):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -273,6 +273,10 @@ def test_get_environment_variable(set_env):
         val5 == "Pirates/Treasure/TEST3"
     )  # in case the user gives a path that includes variables and directories
 
+    # Same as above but with a trailing slash
+    val4 = get_environment_variable("TEST1/TEST2/")
+    assert val4 == "Pirates/Treasure/"
+
 
 @pytest.fixture
 def ms_example(tmpdir):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -263,7 +263,15 @@ def test_get_environment_variable(set_env):
     val2 = get_environment_variable("$TEST2")
     assert val2 == "Treasure"
     val3 = get_environment_variable("THISNOEXISTS")
-    assert val3 is None
+    assert (
+        val3 == "THISNOEXISTS"
+    )  # in case the user gives a path that is not a variable return the same thing
+    val4 = get_environment_variable("TEST1/TEST2")
+    assert val4 == "Pirates/Treasure"
+    val5 = get_environment_variable("TEST1/TEST2/TEST3")
+    assert (
+        val5 == "Pirates/Treasure/TEST3"
+    )  # in case the user gives a path that includes variables and directories
 
 
 @pytest.fixture

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -27,12 +27,12 @@ from flint.utils import (
     generate_strict_stub_wcs_header,
     generate_stub_wcs_header,
     get_beam_shape,
-    get_environment_variable,
     get_packaged_resource_path,
     get_pixels_per_beam,
     get_slurm_info,
     hold_then_move_into,
     log_job_environment,
+    parse_environment_variables,
     temporarily_move_into,
     timelimit_on_context,
 )
@@ -256,33 +256,33 @@ def set_env():
     os.environ["TEST2"] = "Treasure"
 
 
-def test_get_environment_variable(set_env):
+def test_parse_environment_variables(set_env):
     """Make sure that the variable is processed nicely when getting environment variable"""
-    val = get_environment_variable("$TEST1")
+    val = parse_environment_variables("$TEST1")
     assert val == "Pirates"
-    val2 = get_environment_variable("$TEST2")
+    val2 = parse_environment_variables("$TEST2")
     assert val2 == "Treasure"
-    val3 = get_environment_variable("THISNOEXISTS")
+    val3 = parse_environment_variables("THISNOEXISTS")
     assert (
         val3 == "THISNOEXISTS"
     )  # in case the user gives a path that is not a variable return the same thing
-    val4 = get_environment_variable("$TEST1/$TEST2")
+    val4 = parse_environment_variables("$TEST1/$TEST2")
     assert val4 == "Pirates/Treasure"
-    val5 = get_environment_variable("$TEST1/$TEST2/TEST3")
+    val5 = parse_environment_variables("$TEST1/$TEST2/TEST3")
     assert (
         val5 == "Pirates/Treasure/TEST3"
     )  # in case the user gives a path that includes variables and directories
 
-    val6 = get_environment_variable("$TEST1/$TEST2/$TEST3")
+    val6 = parse_environment_variables("$TEST1/$TEST2/$TEST3")
     assert val6 is None  # If one goes down all do
-    val7 = get_environment_variable("$TEST1/$TEST3/$TEST2")
+    val7 = parse_environment_variables("$TEST1/$TEST3/$TEST2")
     assert val7 is None  # Same as above but reordered
 
     # Same as above but with a trailing slash
-    val8 = get_environment_variable("$TEST1/$TEST2/")
+    val8 = parse_environment_variables("$TEST1/$TEST2/")
     assert val8 == "Pirates/Treasure/"
 
-    assert get_environment_variable(variable=None) is None
+    assert parse_environment_variables(variable=None) is None
 
 
 @pytest.fixture


### PR DESCRIPTION
Addresses #295, now `get_environment_variable()` attempts to resolve each part of a path as a possible environment variable, instead of only assuming that the full path is an environment variable.

Example behaviour (updated test):

```
@pytest.fixture(scope="session", autouse=True)
def set_env():
    """Set up variables for a specific test"""
    os.environ["TEST1"] = "Pirates"
    os.environ["TEST2"] = "Treasure"


def test_get_environment_variable(set_env):
    """Make sure that the variable is processed nicely when getting environment variable"""
    val = get_environment_variable("TEST1")
    assert val == "Pirates"
    val2 = get_environment_variable("$TEST2")
    assert val2 == "Treasure"
    val3 = get_environment_variable("THISNOEXISTS")
    assert (
        val3 == "THISNOEXISTS"
    )  # in case the user gives a path that isnt a variable return the same thing
    val4 = get_environment_variable("TEST1/TEST2")
    assert val4 == "Pirates/Treasure"
    val5 = get_environment_variable("TEST1/TEST2/TEST3")
    assert (
        val5 == "Pirates/Treasure/TEST3"
    )  # in case the user gives a path that includes variables and directories
```