### PR TITLE
Use xdist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,8 @@ jobs:
       - name: Test package
         run: >-
           python -m pytest -ra --cov --cov-report=xml --cov-report=term
-          --durations=20
+          --durations=20 -n auto -p no:warnings
+      # -p no:warnings is needed to avoid warnings errors caused by VOTable
 
       - name: Upload coverage report
         uses: codecov/codecov-action@v5.4.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,6 @@ metadata.allow-direct-references = true
 
 [project.optional-dependencies]
 dev = [
-    "black",
     "mypy",
     "isort",
     "pre-commit",
@@ -73,6 +72,7 @@ dev = [
     "sphinx-argparse",
     "furo",
     "pytest-rerunfailures",
+    "pytest-xdist",
 ]
 casa =[
     "python-casacore>=3.6.0",


### PR DESCRIPTION
After testing in #300 `xdist` was failing. Looks like it was some `astropy.VOTable` warnings that we can probably ignore for faster CI completion