### PR TITLE
Rename mbc to mac

### DIFF
--- a/docs/quickstart/selfcal.md
+++ b/docs/quickstart/selfcal.md
@@ -86,9 +86,9 @@ defaults:
     flood_fill: true
     flood_fill_positive_seed_clip: 6
     flood_fill_positive_flood_clip: 1.25
-    flood_fill_use_mbc_adaptive_max_depth: 4
-    flood_fill_use_mbc_adaptive_skew_delta: 0.025
-    flood_fill_use_mbc_adaptive_step_factor: 4
+    flood_fill_use_mac_adaptive_max_depth: 4
+    flood_fill_use_mac_adaptive_skew_delta: 0.025
+    flood_fill_use_mac_adaptive_step_factor: 4
     grow_low_snr_island: false
     grow_low_snr_island_clip: 1.75
     grow_low_snr_island_size: 12046
@@ -134,10 +134,10 @@ selfcal:
       uvrange: '>400m'
       nspw: 2
     masking:
-      flood_fill_use_mbc: true
+      flood_fill_use_mac: true
       flood_fill_positive_seed_clip: 1.5
       flood_fill_positive_flood_clip: 1.2
-      flood_fill_use_mbc_box_size: 400
+      flood_fill_use_mac_box_size: 400
   2:
     wsclean:
       auto_mask: 2
@@ -151,10 +151,10 @@ selfcal:
       uvrange: '>400m'
       nspw: 4
     masking:
-      flood_fill_use_mbc: true
+      flood_fill_use_mac: true
       flood_fill_positive_seed_clip: 1.2
       flood_fill_positive_flood_clip: 1.1
-      flood_fill_use_mbc_box_size: 300
+      flood_fill_use_mac_box_size: 300
   3:
     wsclean:
       auto_mask: 2.0
@@ -168,10 +168,10 @@ selfcal:
       uvrange: '>400m'
       nspw: 2
     masking:
-      flood_fill_use_mbc: true
+      flood_fill_use_mac: true
       flood_fill_positive_seed_clip: 1.2
       flood_fill_positive_flood_clip: 0.8
-      flood_fill_use_mbc_box_size: 60
+      flood_fill_use_mac_box_size: 60
   4:
     wsclean:
       auto_mask: 2.0
@@ -184,10 +184,10 @@ selfcal:
       uvrange: '>400m'
       nspw: 2
     masking:
-      flood_fill_use_mbc: true
+      flood_fill_use_mac: true
       flood_fill_positive_seed_clip: 1.2
       flood_fill_positive_flood_clip: 0.7
-      flood_fill_use_mbc_box_size: 60
+      flood_fill_use_mac_box_size: 60
 stokesv:
   wsclean:
     pol: v

--- a/flint/masking.py
+++ b/flint/masking.py
@@ -45,15 +45,15 @@ class MaskingOptions(BaseOptions):
     """The clipping level to seed islands that will be grown to lower signal metric"""
     flood_fill_positive_flood_clip: float = 1.5
     """Clipping level used to grow seeded islands down to"""
-    flood_fill_use_mbc: bool = False
+    flood_fill_use_mac: bool = False
     """If True, the clipping levels are used as the `increase_factor` when using a minimum absolute clip"""
-    flood_fill_use_mbc_box_size: int = 75
-    """The size of the mbc box size should mbc be used"""
-    flood_fill_use_mbc_adaptive_step_factor: float = 2.0
+    flood_fill_use_mac_box_size: int = 75
+    """The size of the mac box size should mac be used"""
+    flood_fill_use_mac_adaptive_step_factor: float = 2.0
     """Stepping size used to increase box by should adaptive detect poor boxcar statistics"""
-    flood_fill_use_mbc_adaptive_skew_delta: float = 0.2
+    flood_fill_use_mac_adaptive_skew_delta: float = 0.2
     """A box is consider too small for a pixel if the fractional proportion of positive pixels is larger than the deviation away of (0.5 + frac). This threshold is therefore 0 to 0.5"""
-    flood_fill_use_mbc_adaptive_max_depth: int | None = None
+    flood_fill_use_mac_adaptive_max_depth: int | None = None
     """Determines the number of adaptive boxcar scales to use when constructing seed mask. If None no adaptive boxcar sizes"""
     grow_low_snr_island: bool = False
     """Whether to attempt to grow a mask to capture islands of low SNR (e.g. diffuse emission)"""
@@ -546,22 +546,22 @@ def reverse_negative_flood_fill(
     logger.info("Will be reversing flood filling")
     logger.info(f"{masking_options=} ")
 
-    if masking_options.flood_fill_use_mbc:
+    if masking_options.flood_fill_use_mac:
         positive_mask = minimum_absolute_clip(
             image=base_image,
             increase_factor=masking_options.flood_fill_positive_seed_clip,
-            box_size=masking_options.flood_fill_use_mbc_box_size,
-            adaptive_max_depth=masking_options.flood_fill_use_mbc_adaptive_max_depth,
-            adaptive_box_step=masking_options.flood_fill_use_mbc_adaptive_step_factor,
-            adaptive_skew_delta=masking_options.flood_fill_use_mbc_adaptive_skew_delta,
+            box_size=masking_options.flood_fill_use_mac_box_size,
+            adaptive_max_depth=masking_options.flood_fill_use_mac_adaptive_max_depth,
+            adaptive_box_step=masking_options.flood_fill_use_mac_adaptive_step_factor,
+            adaptive_skew_delta=masking_options.flood_fill_use_mac_adaptive_skew_delta,
         )
         flood_floor_mask = minimum_absolute_clip(
             image=base_image,
             increase_factor=masking_options.flood_fill_positive_flood_clip,
-            box_size=masking_options.flood_fill_use_mbc_box_size,
-            adaptive_max_depth=masking_options.flood_fill_use_mbc_adaptive_max_depth,
-            adaptive_box_step=masking_options.flood_fill_use_mbc_adaptive_step_factor,
-            adaptive_skew_delta=masking_options.flood_fill_use_mbc_adaptive_skew_delta,
+            box_size=masking_options.flood_fill_use_mac_box_size,
+            adaptive_max_depth=masking_options.flood_fill_use_mac_adaptive_max_depth,
+            adaptive_box_step=masking_options.flood_fill_use_mac_adaptive_step_factor,
+            adaptive_skew_delta=masking_options.flood_fill_use_mac_adaptive_skew_delta,
         )
     else:
         # Sanity check the upper clip level, you rotten seadog
@@ -630,7 +630,7 @@ def _create_signal_from_rmsbkg(
 
 def _need_to_make_signal(masking_options: MaskingOptions) -> bool:
     """Isolated functions to consider whether a signal image is needed"""
-    return not masking_options.flood_fill_use_mbc
+    return not masking_options.flood_fill_use_mac
 
 
 def create_snr_mask_from_fits(
@@ -671,7 +671,7 @@ def create_snr_mask_from_fits(
         fits_image=fits_image_path, include_signal_path=create_signal_fits
     )
 
-    # TODOL Make the bkg and rms images optional. Don't need to load if mbc is usede
+    # TODOL Make the bkg and rms images optional. Don't need to load if mac is usede
     with fits.open(fits_image_path) as fits_image:
         fits_header = fits_image[0].header  # type: ignore
         signal_data = fits_image[0].data  # type: ignore
@@ -703,7 +703,7 @@ def create_snr_mask_from_fits(
     # contain a cube of images.
     if masking_options.flood_fill:
         # TODO: The image and signal masks both don't need to be inputs. Image is only used
-        # if mbc = True
+        # if mac = True
         mask_data = reverse_negative_flood_fill(
             base_image=np.squeeze(signal_data),
             masking_options=masking_options,

--- a/tests/test_masking.py
+++ b/tests/test_masking.py
@@ -61,28 +61,28 @@ def test_private_minimum_absolute_clip():
 
     image = np.ones(SHAPE) * -1.0
     image[10, 10] = -2
-    private_mbc_mask = _minimum_absolute_clip(image=image, box_size=10)
-    mbc_mask = minimum_absolute_clip(image=image, box_size=10)
-    assert np.all(~mbc_mask)
-    assert np.all(private_mbc_mask == mbc_mask)
+    private_mac_mask = _minimum_absolute_clip(image=image, box_size=10)
+    mac_mask = minimum_absolute_clip(image=image, box_size=10)
+    assert np.all(~mac_mask)
+    assert np.all(private_mac_mask == mac_mask)
 
     image[12, 12] = 5
-    private_mbc_mask = _minimum_absolute_clip(image=image)
-    mbc_mask = minimum_absolute_clip(image=image)
-    assert np.sum(mbc_mask) == 1
-    assert np.all(private_mbc_mask == mbc_mask)
+    private_mac_mask = _minimum_absolute_clip(image=image)
+    mac_mask = minimum_absolute_clip(image=image)
+    assert np.sum(mac_mask) == 1
+    assert np.all(private_mac_mask == mac_mask)
 
     image[12, 12] = 0
-    private_mbc_mask = _minimum_absolute_clip(image=image)
-    mbc_mask = minimum_absolute_clip(image=image)
-    assert np.all(~mbc_mask)
-    assert np.all(private_mbc_mask == mbc_mask)
+    private_mac_mask = _minimum_absolute_clip(image=image)
+    mac_mask = minimum_absolute_clip(image=image)
+    assert np.all(~mac_mask)
+    assert np.all(private_mac_mask == mac_mask)
 
     image[12, 12] = 5
-    private_mbc_mask = _minimum_absolute_clip(image=image, increase_factor=3)
-    mbc_mask = minimum_absolute_clip(image=image, increase_factor=3)
-    assert np.all(~mbc_mask)
-    assert np.all(private_mbc_mask == mbc_mask)
+    private_mac_mask = _minimum_absolute_clip(image=image, increase_factor=3)
+    mac_mask = minimum_absolute_clip(image=image, increase_factor=3)
+    assert np.all(~mac_mask)
+    assert np.all(private_mac_mask == mac_mask)
 
 
 def test_create_signal_from_rmsbkg():
@@ -123,7 +123,7 @@ def test_need_to_make_signal():
     masking_options = MaskingOptions()
     assert _need_to_make_signal(masking_options=masking_options)
 
-    masking_options = MaskingOptions(flood_fill_use_mbc=True)
+    masking_options = MaskingOptions(flood_fill_use_mac=True)
     assert not _need_to_make_signal(masking_options=masking_options)
 
 
@@ -132,14 +132,14 @@ def test_arg_parser_cli_and_masking_options():
     options which are properly converted to a MaskingOptions object"""
     parser = get_parser()
     args = parser.parse_args(
-        args="mask img --rms-fits rms --bkg-fits bkg --flood-fill --flood-fill-positive-seed-clip 10 --flood-fill-positive-flood-clip 1. --flood-fill-use-mbc --flood-fill-use-mbc-box-size 100".split()
+        args="mask img --rms-fits rms --bkg-fits bkg --flood-fill --flood-fill-positive-seed-clip 10 --flood-fill-positive-flood-clip 1. --flood-fill-use-mac --flood-fill-use-mac-box-size 100".split()
     )
     masking_options = create_options_from_parser(
         parser_namespace=args, options_class=MaskingOptions
     )
     assert isinstance(masking_options, MaskingOptions)
     assert masking_options.flood_fill
-    assert masking_options.flood_fill_use_mbc
+    assert masking_options.flood_fill_use_mac
     assert masking_options.flood_fill_positive_seed_clip == 10.0
     assert masking_options.flood_fill_positive_flood_clip == 1.0
 


### PR DESCRIPTION
The masking procedure has been renamed `mbc` (minimum box clip) to the much cooler `mac` (minimum absolute clip). 

I thought this was done some time ago, but I am guessing it was in a branch that was never merged. 

In any case. This may be a slightly annoying change as strings in the strategy files need to be updated. But I am OK with this. Sorry to others who are not. This is not a change to the strategy file itself, just to fields in the `MaskingOptions` class. 