### PR TITLE
Add FitsCubeOptions to known classes / subtract_cube_pipeline

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -50,6 +50,7 @@ A 'mode' refers to a set of options for a given tool. As of version 0.2, the fol
 - `bane` : This corresponds to `flint.source_finding.aegean.BANEOptions`
 - `aegean` : This corresponds to `flint.source_finding.aegean.AegeanOptions`
 - `potatopeel`: This corresponds to `flint.peel.potato.PotatoPeelOptions`
+- `fitscube`: This correspond to `flint.options.FitsCubeOptions`
 
 To see all the available options you can run `flint_{mode} -h` on the command-line.
 All attributes available in the corresponding `Options` class listed above may be
@@ -91,6 +92,7 @@ through this template method are:
 - `ArchiveOptions` (shorthand `archive`)
 - `BANEOptions` (shorthand `bane`)
 - `AegeanOptions` (shorthand `aegean`)
+- `FitsCubeOptions` (shorthand `fitscube`)
 
 All attributes supported by these options may be set in this template format.
 Not that these options would have to be retrieved within a particular flow and

--- a/flint/configuration.py
+++ b/flint/configuration.py
@@ -17,7 +17,7 @@ from flint.imager.wsclean import WSCleanOptions
 from flint.logging import logger
 from flint.masking import MaskingOptions
 from flint.naming import add_timestamp_to_path
-from flint.options import ArchiveOptions
+from flint.options import ArchiveOptions, FitsCubeOptions
 from flint.peel.potato import PotatoPeelOptions
 from flint.selfcal.casa import GainCalOptions
 from flint.source_finding.aegean import AegeanOptions, BANEOptions
@@ -42,6 +42,7 @@ MODE_OPTIONS_MAPPING = {
     "bane": BANEOptions,
     "aegean": AegeanOptions,
     "potatopeel": PotatoPeelOptions,
+    "fitscube": FitsCubeOptions,
 }
 POLARISATION_MAPPING = {
     "total": "i",

--- a/flint/data/tests/test_config_2.yaml
+++ b/flint/data/tests/test_config_2.yaml
@@ -73,6 +73,8 @@ defaults:
       - .*png
       - .*csv
       - testing_for_sparrow.csv
+  fitscube:
+    max_workers: 123
 
 selfcal:
   0:

--- a/flint/options.py
+++ b/flint/options.py
@@ -541,3 +541,15 @@ class ArchiveOptions(BaseOptions):
     """Regular-expressions to use to collect files that should be tarballed"""
     copy_file_re_patterns: tuple[str, ...] = DEFAULT_COPY_RE_PATTERNS
     """Regular-expressions used to identify files to copy into a final location (not tarred)"""
+
+
+class FitsCubeOptions(BaseOptions):
+    """Container of opptions used to combine images into a single cube using the `fitscube` package.
+    This is particularly useful to manage the larger concatenations."""
+
+    bounding_box: bool = False
+    """Whether to attempt to trim images when combining"""
+    max_workers: int = 4
+    """The number of concurrent workers (readers/writers) that are permitted at a time"""
+    invalidate_zeros: bool = True
+    """Set pixels whose values are exactly 0.0 to not-a-number (nan)"""


### PR DESCRIPTION
There were some recent changes to the fitscube package that started to expose more options that foresee-ably could be useful to align to environment / worker settings. 

This PR adds a simple option class to represent these options and exposes it within the subtract cube workflow. 