### PR TITLE
Fixes to enable gaskap continuum processing

### DIFF
--- a/flint/imager/wsclean.py
+++ b/flint/imager/wsclean.py
@@ -922,6 +922,10 @@ def rotate_cube(output_cube_path: str | Path, inplace: bool = True) -> Path:
     output_path = Path(output_cube_path)
     logger.info(f"Rotating FITS axes of {output_path.name}")
 
+    if not Path(output_cube_path).exists():
+        logger.warning(f"{output_cube_path=} does not appear to exist. Returning.")
+        return Path(output_cube_path)
+
     # Read original data and header
     with fits.open(output_path, mode="readonly", memmap=True) as hdul:
         header = hdul[0].header.copy()

--- a/flint/naming.py
+++ b/flint/naming.py
@@ -92,6 +92,7 @@ def create_largest_common_field_name(
 
     from difflib import SequenceMatcher
 
+    # Construct a list of unique field names seen across all inputs
     consider_fields = list(
         set(
             [
@@ -105,14 +106,24 @@ def create_largest_common_field_name(
         f"Expected a longer list of potential fields, got {consider_fields=}"
     )
 
+    # The starting case can be any name in the set. The longest substring will be
+    # at best this name if the length is all field names are the same.
     longest_common_string: str = consider_fields[0]
 
+    # Iterate over the remaining names to consider for substring matches
+    # with the current longest substring seen
     for i, field_name in enumerate(consider_fields[1:]):
         logger.debug(f"{i=} {field_name=} {longest_common_string=}")
+
+        # This was a nice find in the stdlib.
         substring_match = SequenceMatcher(
             isjunk=None, a=longest_common_string, b=field_name
         ).find_longest_match()
 
+        # If the below is ever entered irrespective of the number of
+        # unique fields to consider then there is no substring possible,
+        # This silly pirate has just realised that a single common letter
+        # could be returned if it is present across all fields.
         if substring_match.size == 0:
             logger.warning("No matching substring found.")
             return field_default
@@ -120,8 +131,10 @@ def create_largest_common_field_name(
         longest_common_string = longest_common_string[
             substring_match.a : substring_match.a + substring_match.size
         ]
+
+    # Remove any silly characters at the end of the substring, like '_'
     if strip_characters is not None:
-        longest_common_string = longest_common_string.strip(" _")
+        longest_common_string = longest_common_string.strip(strip_characters)
 
     return longest_common_string
 

--- a/flint/naming.py
+++ b/flint/naming.py
@@ -64,6 +64,68 @@ LONG_FIELD_TO_SHORTHAND = {
 """Name mapping between the longform of ProcessedFieldComponents and shorthands used"""
 
 
+def create_largest_common_field_name(
+    field_list: list[str | ProcessedNameComponents],
+    field_default: str = "sparrow",
+    strip_characters: str | None = " _",
+) -> str:
+    """Given a collection of field names in either a string of encapsulated in
+    a ``ProcessedNameComponents`` form, find the longest common substring. If
+
+    >>> fields = [
+    >>>    "G334_1666_A_1",
+    >>>    "G334_1666_B_1",
+    >>>    "G334_1666_C_1"
+    >>> ]
+
+    then the output should be ``G334_1666`` if ``strip_characters`` is used.
+
+
+    Args:
+        field_list (list[str  |  ProcessedNameComponents]): Collection of field names to search through
+        field_default (str, optional): The value to return if no common substring was found. Defaults to "sparrow".
+        strip_characters (str | None, optional): If not None that the ``str.strip()`` method will be issued on the returned result with these characters. Defaults to " _".
+
+    Returns:
+        str: _description_
+    """
+
+    from difflib import SequenceMatcher
+
+    consider_fields = list(
+        set(
+            [
+                f.field if isinstance(f, ProcessedNameComponents) else f
+                for f in field_list
+            ]
+        )
+    )
+
+    assert len(consider_fields) >= 2, (
+        f"Expected a longer list of potential fields, got {consider_fields=}"
+    )
+
+    longest_common_string: str = consider_fields[0]
+
+    for i, field_name in enumerate(consider_fields[1:]):
+        logger.debug(f"{i=} {field_name=} {longest_common_string=}")
+        substring_match = SequenceMatcher(
+            isjunk=None, a=longest_common_string, b=field_name
+        ).find_longest_match()
+
+        if substring_match.size == 0:
+            logger.warning("No matching substring found.")
+            return field_default
+
+        longest_common_string = longest_common_string[
+            substring_match.a : substring_match.a + substring_match.size
+        ]
+    if strip_characters is not None:
+        longest_common_string = longest_common_string.strip(" _")
+
+    return longest_common_string
+
+
 def create_name_from_common_fields(
     in_paths: tuple[Path, ...], additional_suffixes: str | None = None
 ) -> Path:
@@ -109,6 +171,21 @@ def create_name_from_common_fields(
         if len(set([pcd[key] for pcd in processed_components_dict])) == 1
         and processed_components_dict[0][key] is not None
     }
+
+    # Handle the case where a mandatory field is not present. For field names
+    # we pirates can handle something like this. Not going to for sbids.
+    if "field" not in constant_fields:
+        field_substring = create_largest_common_field_name(
+            field_list=[
+                processed_name_component.field
+                for processed_name_component in processed_components
+                if processed_name_component is not None
+            ]
+        )
+        constant_fields["field"] = field_substring
+        logger.info(
+            f"Have extracted {field_substring=} as there was not a constant field present"
+        )
 
     name_path = create_path_from_processed_name_components(
         processed_name_components=ProcessedNameComponents(**constant_fields),

--- a/flint/options.py
+++ b/flint/options.py
@@ -364,6 +364,8 @@ class SubtractFieldOptions(BaseOptions):
     """The maximum number of scans/channels to consider"""
     fitscube_remove_original_images: bool = False
     """Remove the images that go into forming the fitscube"""
+    max_imaging_workers: int | None = None
+    """Reset the maximum of dask workers (assuming apative scaling) to this number during the imaging stage. """
 
 
 class FieldOptions(BaseOptions):

--- a/flint/options.py
+++ b/flint/options.py
@@ -364,8 +364,6 @@ class SubtractFieldOptions(BaseOptions):
     """The maximum number of scans/channels to consider"""
     fitscube_remove_original_images: bool = False
     """Remove the images that go into forming the fitscube"""
-    max_imaging_workers: int | None = None
-    """Reset the maximum of dask workers (assuming apative scaling) to this number during the imaging stage. """
 
 
 class FieldOptions(BaseOptions):

--- a/flint/selfcal/casa.py
+++ b/flint/selfcal/casa.py
@@ -48,6 +48,8 @@ class GainCalOptions(BaseOptions):
     will be used to craft an appropriate ``select_spw=`` interval range. If larger
     than one, ``gaincal`` will be carried out against each interval and results will
     be appended to a common solutions file. """
+    solnorm: bool = False
+    """Renormalise the distribution of the amplite gains so the mean is unity."""
 
 
 def copy_and_clean_ms_casagain(
@@ -308,6 +310,7 @@ def gaincal_applycal_ms(
             calmode=gain_cal_options.calmode,
             selectdata=gain_cal_options.selectdata,
             uvrange=gain_cal_options.uvrange,
+            solnorm=gain_cal_options.solnorm,
         )
 
         if not cal_table.exists():

--- a/flint/selfcal/casa.py
+++ b/flint/selfcal/casa.py
@@ -48,7 +48,7 @@ class GainCalOptions(BaseOptions):
     will be used to craft an appropriate ``select_spw=`` interval range. If larger
     than one, ``gaincal`` will be carried out against each interval and results will
     be appended to a common solutions file. """
-    solnorm: bool = False
+    solnorm: bool = True
     """Renormalise the distribution of the amplite gains so the mean is unity."""
 
 

--- a/tests/test_naming.py
+++ b/tests/test_naming.py
@@ -68,6 +68,37 @@ def test_create_largest_common_field_name() -> None:
     assert common_field == "Jack"
 
 
+def test_create_largest_common_field_name_different_strip() -> None:
+    """Tests to attempt to extract the longest field name present in a collection
+    of field names. Should it fail a default should be return from the helper
+    function. This makes sure the strip character works"""
+
+    fields: list[str | ProcessedNameComponents] = [
+        "G334_1666!A_1",
+        "G334_1666!B_1",
+        "G334_1666!C_1",
+    ]
+
+    common_field = create_largest_common_field_name(field_list=fields)
+    assert common_field == "G334_1666!"
+
+    common_field = create_largest_common_field_name(
+        field_list=fields, strip_characters=None
+    )
+    assert common_field == "G334_1666!"
+
+    common_field = create_largest_common_field_name(
+        field_list=fields, strip_characters="! _"
+    )
+    assert common_field == "G334_1666"
+
+    fields.append("ThisBreaksThings")
+    common_field = create_largest_common_field_name(
+        field_list=fields, field_default="Jack"
+    )
+    assert common_field == "Jack"
+
+
 def test_create_path_from_process_named_components():
     """Make sure we can create a name"""
     components = ProcessedNameComponents(

--- a/tests/test_naming.py
+++ b/tests/test_naming.py
@@ -19,6 +19,7 @@ from flint.naming import (
     create_fits_mask_names,
     create_image_cube_name,
     create_imaging_name_prefix,
+    create_largest_common_field_name,
     create_linmos_base_path,
     create_linmos_names,
     create_ms_name,
@@ -39,6 +40,32 @@ from flint.naming import (
     update_beam_resolution_field_in_path,
 )
 from flint.options import MS
+
+
+def test_create_largest_common_field_name() -> None:
+    """Tests to attempt to extract the longest field name present in a collection
+    of field names. Should it fail a default should be return from the helper
+    function"""
+
+    fields: list[str | ProcessedNameComponents] = [
+        "G334_1666_A_1",
+        "G334_1666_B_1",
+        "G334_1666_C_1",
+    ]
+
+    common_field = create_largest_common_field_name(field_list=fields)
+    assert common_field == "G334_1666"
+
+    common_field = create_largest_common_field_name(
+        field_list=fields, strip_characters=None
+    )
+    assert common_field == "G334_1666_"
+
+    fields.append("ThisBreaksThings")
+    common_field = create_largest_common_field_name(
+        field_list=fields, field_default="Jack"
+    )
+    assert common_field == "Jack"
 
 
 def test_create_path_from_process_named_components():

--- a/tests/test_wsclean.py
+++ b/tests/test_wsclean.py
@@ -29,6 +29,7 @@ from flint.imager.wsclean import (
     get_wsclean_output_source_list_path,
     merge_image_sets,
     rename_wsclean_prefix_in_image_set,
+    rotate_cube,
     split_and_get_image_set,
     split_image_set,
 )
@@ -36,6 +37,16 @@ from flint.logging import logger
 from flint.naming import create_imaging_name_prefix
 from flint.options import MS
 from flint.utils import get_packaged_resource_path
+
+
+def test_rotate_cube_no_exists() -> None:
+    """Should no cube exist this should exit safely with a warning.
+    This is not testing the actual rotation code, just the early
+    return."""
+    output_cube_path = Path("JackSparrowIsNotHere.fits")
+
+    _ = rotate_cube(output_cube_path=output_cube_path, inplace=False)
+    _ = rotate_cube(output_cube_path=output_cube_path, inplace=True)
 
 
 def test_get_wsclean_output_source_list_path():


### PR DESCRIPTION
Was asked to have a pass over some GASKAP processing. This required a couple small fixes that I think were 'in scope' for flint. The largest change was having to add a helper function to resolve what happens when multiple field names are found in the auto-magic common name generator. 

Separately there is a alrger correction that needs to be made to the gaskap measurement sets to remove unnecessary meta-data. That is included below for completeness. 

```
for ms in ms_list:
    print(ms)
    new_ms = out_dir / ms.name
    if new_ms.exists():
        shutil.rmtree(new_ms)
    shutil.copytree(ms, new_ms)

    feed_path = new_ms / "FEED"

    print(f"Processing {ms=}")
       
    # It appears that we need to update the B / C fields where those FIELD_IDs
    # are not zero for wsclean to work. No visibilities are gridded otherwise 
    with table(str(new_ms), readonly=False, ack=False) as main_tab:
        row_field_idxs = main_tab.getcol("FIELD_ID")
        field_idxs = np.unique(row_field_idxs)
        
        assert len(field_idxs) == 1
        field_id = field_idxs[0]
        field_idxs = np.zeros_like(row_field_idxs)
        main_tab.putcol("FIELD_ID", field_idxs)
        print("... finished main")
        
        
    with table(str(new_ms / "FIELD"), readonly=False, ack=False) as field_tab:
        all_rows = np.arange(len(field_tab))
        remove_mask = all_rows != field_id
        field_tab.removerows(all_rows[remove_mask])
        print("... finished field")
    
    # Drop the rows from the feed table that do not match the field id
    with table(str(new_ms), readonly=False, ack=False) as data_tab:
       base_time = data_tab.getcol("TIME", 0, 1)
       
    with table(str(feed_path), readonly=False, ack=False) as feed:
        # find the row closest in time to use as base receptor angle
        # This is done since there is not a FIELD_ID linking the data table
        # to the FEED table, and the FEED_ID in data table appears to
        # indicate the beam.
        base_idx = np.argmin(np.abs(base_time - feed.getcol("TIME")))
        
        RECEPTOR_ANGLE = feed.getcol("RECEPTOR_ANGLE")
        nrows = feed.nrows()
        row_idxs = np.arange(nrows)
        selected = (RECEPTOR_ANGLE == RECEPTOR_ANGLE[base_idx]).sum(axis=1).astype(bool)
        feed.removerows(row_idxs[~selected])
        print("... finished feed")
     
```