### PR TITLE
Holography cube creation in the RACS-All pipeline

### DIFF
--- a/flint/imager/wsclean.py
+++ b/flint/imager/wsclean.py
@@ -111,6 +111,8 @@ class WSCleanOptions(BaseOptions):
     """Threshold in Jy to stop cleaning"""
     channels_out: int = 4
     """Number of output channels"""
+    gain: float = 0.1
+    """Cleaning gain, ratio of peak that will be subtracted in each iteration"""
     mgain: float = 0.7
     """Major cycle gain"""
     nmiter: int = 15

--- a/flint/misc/holo.py
+++ b/flint/misc/holo.py
@@ -6,6 +6,7 @@ from argparse import ArgumentParser
 from dataclasses import dataclass
 from functools import partial
 from pathlib import Path
+from socket import gethostname
 
 import billiard
 import numpy as np
@@ -530,6 +531,7 @@ def concatenate_holography(concat_holo_options: ConcatHoloOptions) -> Path:
     """
 
     logger.info("Attempting to concatenate holography cubes")
+    logger.info(f"Running on host {gethostname()}")
 
     fits_cube_infos = load_and_sort_cubes(cube_paths=concat_holo_options.holo_cubes)
     spatial_header = construct_spatial_output_wcs(fits_cube_infos=fits_cube_infos)

--- a/flint/misc/holo.py
+++ b/flint/misc/holo.py
@@ -392,7 +392,7 @@ def create_placeholder_cube(
         # or OSX - the latter had a unit test failing when attempting
         # to fits.getdata on it, returning a buffer vs data shape mismatch.
         # Curious, pal.
-        f.seek(data_payload_size, 1)
+        f.seek(data_payload_size - 1, 1)  # The -1 makes space for empty byte below
         f.write(b"\x00")  # Writing out a byte fixes OSX issue
 
     logger.info(f"Start of data: {data_offset} bytes")

--- a/flint/misc/holo.py
+++ b/flint/misc/holo.py
@@ -439,22 +439,24 @@ def reproject_cubes(
     )  # 1 ppm tolerance for frequency matching
     shape_out_sky = (spatial_header["NAXIS2"], spatial_header["NAXIS1"])
 
-    for cube_idx, fits_cube_info in enumerate(fits_cube_infos):
-        logger.info(f"Reprojecting cube {cube_idx} - {fits_cube_info.path} ...")
+    # Using billiard Pool to allow a process pool executor like parallelism to be
+    # available when running under a dask-worker context. In such cases sub-processes
+    # may not normally be spawned - dask-workers start as a daemon and can not have
+    # children.
+    with billiard.Pool(max_workers) as pool:
+        for cube_idx, fits_cube_info in enumerate(fits_cube_infos):
+            logger.info(f"Reprojecting cube {cube_idx} - {fits_cube_info.path} ...")
 
-        ch_out, matched_indices = map_frequencies_to_channels(
-            freqs_1=frequency_grid.grid, freqs_2=fits_cube_info.freqs_hz, tol=tol
-        )
-        in_cube_header = _get_cube_header(fits_cube_info=fits_cube_info)
+            ch_out, matched_indices = map_frequencies_to_channels(
+                freqs_1=frequency_grid.grid, freqs_2=fits_cube_info.freqs_hz, tol=tol
+            )
+            in_cube_header = _get_cube_header(fits_cube_info=fits_cube_info)
 
-        reproject_interp_func = partial(
-            reproject_wrapper, output_projection=spatial_header, shape_out=shape_out_sky
-        )
-        # Using billiard Pool to allow a process pool executor like parallelism to be
-        # available when running under a dask-worker context. In such cases sub-processes
-        # may not normally be spawned - dask-workers start as a daemon and can not have
-        # children.
-        with billiard.Pool(max_workers) as pool:
+            reproject_interp_func = partial(
+                reproject_wrapper,
+                output_projection=spatial_header,
+                shape_out=shape_out_sky,
+            )
             for beam in range(nbeam):
                 pool_items = []
                 for stokes in range(nstokes):

--- a/flint/misc/holo.py
+++ b/flint/misc/holo.py
@@ -452,6 +452,10 @@ def reproject_cubes(
         reproject_interp_func = partial(
             reproject_wrapper, output_projection=spatial_header, shape_out=shape_out_sky
         )
+        # Using billiard Pool to allow a process pool executor like parallelism to be
+        # available when running under a dask-worker context. In such cases sub-processes
+        # may not normally be spawned - dask-workers start as a daemon and can not have
+        # children.
         # with ProcessPoolExecutor(max_workers=max_workers) as pool:
         with billiard.Pool(max_workers) as pool:
             for beam in range(nbeam):

--- a/flint/misc/holo.py
+++ b/flint/misc/holo.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from argparse import ArgumentParser
-from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
 from dataclasses import dataclass
 from functools import partial
 from pathlib import Path
@@ -18,8 +17,6 @@ from reproject import reproject_interp
 from reproject.mosaicking import find_optimal_celestial_wcs
 
 from flint.logging import logger
-
-_ = (ProcessPoolExecutor, ThreadPoolExecutor)
 
 
 class ConcatHoloOptions(BaseOptions):
@@ -456,7 +453,6 @@ def reproject_cubes(
         # available when running under a dask-worker context. In such cases sub-processes
         # may not normally be spawned - dask-workers start as a daemon and can not have
         # children.
-        # with ProcessPoolExecutor(max_workers=max_workers) as pool:
         with billiard.Pool(max_workers) as pool:
             for beam in range(nbeam):
                 pool_items = []

--- a/flint/misc/holo.py
+++ b/flint/misc/holo.py
@@ -12,6 +12,7 @@ import numpy as np
 from astropy.io import fits
 from astropy.wcs import WCS
 from capn_crunch import BaseOptions, add_options_to_parser, create_options_from_parser
+from loky import get_reusable_executor
 from numpy.typing import NDArray
 from reproject import reproject_interp
 from reproject.mosaicking import find_optimal_celestial_wcs
@@ -451,7 +452,7 @@ def reproject_cubes(
         reproject_interp_func = partial(
             reproject_wrapper, output_projection=spatial_header, shape_out=shape_out_sky
         )
-        with ProcessPoolExecutor(max_workers=max_workers) as pool:
+        with get_reusable_executor(max_workers=max_workers) as pool:
             for beam in range(nbeam):
                 pool_items = []
                 for stokes in range(nstokes):

--- a/flint/misc/holo.py
+++ b/flint/misc/holo.py
@@ -415,7 +415,7 @@ def reproject_cubes(
     final_fits_cube_info: FinalFITSCubeInfo,
     cdelt_tol: float = 1e-6,
     max_workers: int = 2,
-) -> None:
+) -> FinalFITSCubeInfo:
     """Reproject the input cubes onto a final output spatial grid, as defined by
     ``spatial_grid``.
 
@@ -427,7 +427,7 @@ def reproject_cubes(
         final_fits_cube_info (FinalFITSCubeInfo): The description of the final output cube
 
     Returns:
-        NDArray[np.floating]: The final reprojected array
+        FinalFITSCubeInfo: The final FITS cube info that was provided as input
     """
 
     # Axis order follows FITS convention reversed for numpy:
@@ -487,7 +487,7 @@ def reproject_cubes(
                     f"({len(matched_indices)} channels x {nstokes} Stokes planes)"
                 )
 
-    return None
+    return final_fits_cube_info
 
 
 def create_output_header(

--- a/flint/misc/holo.py
+++ b/flint/misc/holo.py
@@ -21,10 +21,10 @@ from flint.logging import logger
 _ = (ProcessPoolExecutor, ThreadPoolExecutor)
 
 
-class ConcatHolo(BaseOptions):
+class ConcatHoloOptions(BaseOptions):
     """Options to use to concatenate holography cubes today"""
 
-    out_path: Path
+    output_path: Path
     """Output holography cube to make"""
     holo_cubes: tuple[Path, ...]
     """The path to the holography IQUV cubes to concatenate together"""
@@ -515,13 +515,13 @@ def create_output_header(
     return out_header
 
 
-def concatenate_holography(concat_holo_options: ConcatHolo) -> Path:
+def concatenate_holography(concat_holo_options: ConcatHoloOptions) -> Path:
     """Reproject a set of ASKAP IQUV primary beam cubes into a single output cube.
     An optimal spatial grid is computed internally through ``reproject``, and input
     cubes are placed onto a consistent channel frequency gride.
 
     Args:
-        concat_holo_options (ConcatHolo): Options to direction the concatenation of the holography cubes.
+        concat_holo_options (ConcatHoloOptions): Options to direction the concatenation of the holography cubes.
 
     Returns:
         Path: Path to the output cube formed
@@ -537,7 +537,7 @@ def concatenate_holography(concat_holo_options: ConcatHolo) -> Path:
         fits_cube_infos=fits_cube_infos,
         spatial_header=spatial_header,
         frequency_grid=frequency_grid,
-        output_path=concat_holo_options.out_path,
+        output_path=concat_holo_options.output_path,
     )
 
     reproject_cubes(
@@ -549,14 +549,14 @@ def concatenate_holography(concat_holo_options: ConcatHolo) -> Path:
         max_workers=concat_holo_options.max_workers,
     )
 
-    logger.info(f"Finished writing {concat_holo_options.out_path}")
-    return concat_holo_options.out_path
+    logger.info(f"Finished writing {concat_holo_options.output_path}")
+    return concat_holo_options.output_path
 
 
 def get_parser() -> ArgumentParser:
     parser = ArgumentParser(description="Helper utilities around holography")
 
-    parser = add_options_to_parser(parser=parser, options_class=ConcatHolo)
+    parser = add_options_to_parser(parser=parser, options_class=ConcatHoloOptions)
 
     return parser
 
@@ -567,7 +567,7 @@ def cli() -> None:
     args = parser.parse_args()
 
     concat_holo_options = create_options_from_parser(
-        parser_namespace=args, options_class=ConcatHolo
+        parser_namespace=args, options_class=ConcatHoloOptions
     )
 
     concatenate_holography(concat_holo_options=concat_holo_options)

--- a/flint/misc/holo.py
+++ b/flint/misc/holo.py
@@ -8,11 +8,11 @@ from dataclasses import dataclass
 from functools import partial
 from pathlib import Path
 
+import billiard
 import numpy as np
 from astropy.io import fits
 from astropy.wcs import WCS
 from capn_crunch import BaseOptions, add_options_to_parser, create_options_from_parser
-from loky import get_reusable_executor
 from numpy.typing import NDArray
 from reproject import reproject_interp
 from reproject.mosaicking import find_optimal_celestial_wcs
@@ -452,7 +452,8 @@ def reproject_cubes(
         reproject_interp_func = partial(
             reproject_wrapper, output_projection=spatial_header, shape_out=shape_out_sky
         )
-        with get_reusable_executor(max_workers=max_workers) as pool:
+        # with ProcessPoolExecutor(max_workers=max_workers) as pool:
+        with billiard.Pool(max_workers) as pool:
             for beam in range(nbeam):
                 pool_items = []
                 for stokes in range(nstokes):

--- a/flint/options.py
+++ b/flint/options.py
@@ -301,7 +301,7 @@ class RACSAllOptions(BaseOptions):
     coadd_cubes: bool = False
     """Co-add cubes formed throughout imaging together. Cubes will be smoothed channel-wise to a common resolution. Only performed on final set of images"""
     holofile: Path | None = None
-    """Place holder for the moment"""
+    """The oath to a concatenated holography FITS file that contains low-, mid- and high-band cubes"""
 
 
 def dump_field_options_to_yaml(

--- a/flint/prefect/common/imaging.py
+++ b/flint/prefect/common/imaging.py
@@ -735,6 +735,7 @@ def task_linmos_images(
     field_summary: FieldSummary | None = None,
     suffix_str: str | None = None,
     parset_output_path: str | None = None,
+    holofile: Path | None = None,
 ) -> LinmosResult:
     """Linmos together a set of input images.
 
@@ -748,6 +749,7 @@ def task_linmos_images(
         field_summary (FieldSummary | None, optional): Description of the field, used to get the ``pol_axis`` of the field. Defaults to None.
         suffix_str (str | None, optional): Additional suffix str to add when generating the output file names. Defaults to None.
         parset_output_path (str | None, optional): The output parameter set that will be generated. Defaults to None.
+        holofile (Path | None, optional): Path to a holofile that will overwrite the one specified  in linmos options. Defaults to None.
 
     Returns:
         LinmosResult: Collection of linmos items generated
@@ -770,6 +772,9 @@ def task_linmos_images(
         base_output_name=output_path,
         pol_axis=field_summary.pol_axis if field_summary else None,
     )
+    if holofile is not None:
+        # Only update if one is set
+        linmos_options = linmos_options.with_options(holofile=holofile)
 
     linmos_result = linmos_images(
         images=image_list,
@@ -792,6 +797,7 @@ def convolve_then_linmos(
     trim_linmos_fits: bool = True,
     remove_original_images: bool = False,
     cleanup_linmos: bool = False,
+    holofile: Path | None = None,
 ) -> LinmosResult:
     """An internal function that launches the convolution to a common resolution
     and subsequent linmos of the wsclean residual images.
@@ -808,6 +814,7 @@ def convolve_then_linmos(
         trim_linmos_fits (bool, optional): Attempt to trim the output linmos files of as much empty space as possible. Defaults to True.
         remove_original_images (bool, optional): If True remove the original image after they have been convolved. Defaults to False.
         cleanup_linmos (bool, optional): Clean up items created throughout linmos, including the per-channel weight text files for each input image. Defaults to False.
+        holofile (Path | None, optional): Path of a holography file. If provided will override the one presented by field_options. Defaults to None.
 
     Returns:
         LinmosResult: Resulting linmos command parset
@@ -838,6 +845,7 @@ def convolve_then_linmos(
         suffix_str=linmos_suffix_str,
         linmos_options=linmos_options,
         field_summary=field_summary,
+        holofile=holofile,
     )  # type: ignore
 
     return parset
@@ -899,6 +907,7 @@ def create_convol_linmos_images(
     field_options: FieldOptions,
     field_summary: FieldSummary | None = None,
     additional_linmos_suffix_str: str | None = None,
+    holofile: Path | None = None,
 ) -> list[LinmosResult]:
     """Derive the appropriate set of beam shapes and then produce corresponding
     convolved and co-added images
@@ -908,6 +917,7 @@ def create_convol_linmos_images(
         field_options (FieldOptions): Set of field imaging options, containing details of the beam/s
         field_summary (Optional[FieldSummary], optional): Summary of the MSs, importantly containing their third-axis rotation. Defaults to None.
         additional_linmos_suffix_str (Optional[str], optional): An additional string added to the end of the auto-generated linmos base name. Defaults to None.
+        holofile (Optional[Path], optional): The path to the holofile. If provided will override one presented by field_options. Defaults to None.
 
     Returns:
         List[LinmosResult]: The collection of linmos commands executed.
@@ -942,6 +952,7 @@ def create_convol_linmos_images(
                 convol_mode="residual",
                 convol_filter=".MFS.",
                 convol_suffix_str=convol_suffix_str,
+                holofile=holofile,
             )
         )
     parsets.append(
@@ -954,6 +965,7 @@ def create_convol_linmos_images(
             convol_mode="image",
             convol_filter=".MFS.",
             convol_suffix_str=convol_suffix_str,
+            holofile=holofile,
         )
     )
 
@@ -1011,6 +1023,7 @@ def create_convolve_linmos_cubes(
     field_options: FieldOptions,
     current_round: int | None = None,
     additional_linmos_suffix_str: str | None = "cube",
+    holofile: Path | None = None,
 ):
     suffixes = [f"round{current_round}" if current_round is not None else "noselfcal"]
     if additional_linmos_suffix_str:
@@ -1037,6 +1050,7 @@ def create_convolve_linmos_cubes(
         container=field_options.yandasoft_container,
         suffix_str=linmos_suffix_str,
         linmos_options=linmos_options,
+        holofile=holofile,
     )
     return parset
 

--- a/flint/prefect/common/utils.py
+++ b/flint/prefect/common/utils.py
@@ -13,6 +13,7 @@ from prefect.artifacts import create_markdown_artifact
 
 from flint.archive import copy_sbid_files_archive, create_sbid_tar_archive
 from flint.logging import logger
+from flint.misc.holo import ConcatHoloOptions, concatenate_holography
 from flint.misc.interopt import flag_antenna_from_casda_bandpass_table
 from flint.naming import (
     add_timestamp_to_path,
@@ -37,6 +38,19 @@ SUPPORTED_IMAGE_TYPES = ("png",)
 task_flag_antenna_from_casda_bandpass_table = task(
     flag_antenna_from_casda_bandpass_table
 )
+
+
+@task
+def task_concatenate_holography(
+    output_path: Path,
+    holo_cubes: list[Path],
+) -> Path:
+    logger.info("Attempting to concatenate holography cubes")
+    concat_holo_options = ConcatHoloOptions(
+        output_path=output_path, holo_cubes=holo_cubes, max_workers=8
+    )
+
+    return concatenate_holography(concat_holo_options=concat_holo_options)
 
 
 @task

--- a/flint/prefect/flows/racs_all_continuum_selfcal.py
+++ b/flint/prefect/flows/racs_all_continuum_selfcal.py
@@ -313,7 +313,7 @@ def process_racs_all_field(racs_all_options: RACSAllOptions) -> None:
         racs_all_options=racs_all_options, output_science_path=output_science_path
     )
     if isinstance(holography_path, Path):
-        holography_path = task_concatenate_holography.submit(
+        holography_path = task_concatenate_holography(
             output_path=holography_path,
             holo_cubes=[
                 racs_all_options.low_holofile,

--- a/flint/prefect/flows/racs_all_continuum_selfcal.py
+++ b/flint/prefect/flows/racs_all_continuum_selfcal.py
@@ -241,6 +241,17 @@ def all_holography_available(
         logger.info("Insufficient holography available - not concatenating together")
         return None
 
+    if not all(
+        holo is not None and holo.exists()
+        for holo in (
+            racs_all_options.low_holofile,
+            racs_all_options.mid_holofile,
+            racs_all_options.high_holofile,
+        )
+    ):
+        msg = "Holography patch for low-, mid- and high-band data have to exist. Some are missing."
+        raise ValueError(msg)
+
     assert isinstance(racs_all_options.low_holofile, Path), (
         "Expected Path for low-band holography"
     )

--- a/flint/prefect/flows/racs_all_continuum_selfcal.py
+++ b/flint/prefect/flows/racs_all_continuum_selfcal.py
@@ -52,6 +52,7 @@ from flint.prefect.common.imaging import (
 )
 from flint.prefect.common.ms import task_describe_ms
 from flint.prefect.common.utils import (
+    task_concatenate_holography,
     task_create_beam_summary,
     task_create_field_summary,
     task_update_field_summary,
@@ -224,6 +225,35 @@ def _ensure_all_casda_format(mss_by_beams: MSsByBeam) -> None:
                 raise ValueError(f"Was expecting only CASDA MSs, got {components}")
 
 
+def all_holography_available(
+    racs_all_options: RACSAllOptions,
+    output_science_path: Path,
+) -> Path | None:
+
+    if any(
+        not isinstance(holo, Path)
+        for holo in (
+            racs_all_options.low_holofile,
+            racs_all_options.mid_holofile,
+            racs_all_options.high_holofile,
+        )
+    ):
+        logger.info("Insufficient holography available - not concatenating together")
+        return None
+
+    assert isinstance(racs_all_options.low_holofile, Path), (
+        "Expected Path for low-band holography"
+    )
+
+    holo_output_path = output_science_path / racs_all_options.low_holofile.name
+    holo_output_path = holo_output_path.with_suffix(".concatenated.fits")
+    logger.info(
+        f"Holography cubes exist, output concatenated cube will be {holo_output_path=}"
+    )
+
+    return holo_output_path
+
+
 @flow
 def process_racs_all_field(racs_all_options: RACSAllOptions) -> None:
     # Any sanity checks will go in here, mateee
@@ -267,6 +297,20 @@ def process_racs_all_field(racs_all_options: RACSAllOptions) -> None:
     # Ya sea dog, we will only be handling CASDA measurementsets for the moment.
     # We will consider bandpass applications later
     _ensure_all_casda_format(mss_by_beams=science_mss_by_beam)
+
+    holography_path = all_holography_available(
+        racs_all_options=racs_all_options, output_science_path=output_science_path
+    )
+    if isinstance(holography_path, Path):
+        holography_path = task_concatenate_holography.submit(
+            output_path=holography_path,
+            holo_cubes=[
+                racs_all_options.low_holofile,
+                racs_all_options.mid_holofile,
+                racs_all_options.high_holofile,
+            ],
+        )
+        racs_all_options = racs_all_options.with_options(holofile=holography_path)
 
     ms_summaries: list = []
     imaging_results: dict[int, list[LoopFutures]] = {}

--- a/flint/prefect/flows/racs_all_continuum_selfcal.py
+++ b/flint/prefect/flows/racs_all_continuum_selfcal.py
@@ -313,7 +313,7 @@ def process_racs_all_field(racs_all_options: RACSAllOptions) -> None:
         racs_all_options=racs_all_options, output_science_path=output_science_path
     )
     if isinstance(holography_path, Path):
-        holography_path = task_concatenate_holography(
+        holography_path = task_concatenate_holography.submit(
             output_path=holography_path,
             holo_cubes=[
                 racs_all_options.low_holofile,
@@ -321,7 +321,9 @@ def process_racs_all_field(racs_all_options: RACSAllOptions) -> None:
                 racs_all_options.high_holofile,
             ],
         )
-        racs_all_options = racs_all_options.with_options(holofile=holography_path)
+        racs_all_options = racs_all_options.with_options(
+            holofile=holography_path
+        ).result()
 
     ms_summaries: list = []
     imaging_results: dict[int, list[LoopFutures]] = {}

--- a/flint/prefect/flows/racs_all_continuum_selfcal.py
+++ b/flint/prefect/flows/racs_all_continuum_selfcal.py
@@ -321,9 +321,6 @@ def process_racs_all_field(racs_all_options: RACSAllOptions) -> None:
                 racs_all_options.high_holofile,
             ],
         )
-        racs_all_options = racs_all_options.with_options(
-            holofile=holography_path.result()
-        )
 
     ms_summaries: list = []
     imaging_results: dict[int, list[LoopFutures]] = {}
@@ -490,6 +487,7 @@ def process_racs_all_field(racs_all_options: RACSAllOptions) -> None:
                         racs_all_options.rounds if racs_all_options.rounds else None
                     ),
                     additional_linmos_suffix_str="cube",
+                    holofile=holography_path,
                 )
 
         for selfcal_round, final_beam_imaging_results in imaging_results.items():
@@ -504,7 +502,8 @@ def process_racs_all_field(racs_all_options: RACSAllOptions) -> None:
                 wsclean_results=wsclean_results,
                 field_options=racs_all_options,
                 field_summary=field_summary,
-                additional_linmos_suffix_str=additional_linmos_suffix,  # indicate in output linmos name no selfcal
+                additional_linmos_suffix_str=additional_linmos_suffix,
+                holofile=holography_path,  # indicate in output linmos name no selfcal
             )
             logger.info(
                 f"Self-cal round {selfcal_round}, number of parsets {len(parsets)}"

--- a/flint/prefect/flows/racs_all_continuum_selfcal.py
+++ b/flint/prefect/flows/racs_all_continuum_selfcal.py
@@ -322,8 +322,8 @@ def process_racs_all_field(racs_all_options: RACSAllOptions) -> None:
             ],
         )
         racs_all_options = racs_all_options.with_options(
-            holofile=holography_path
-        ).result()
+            holofile=holography_path.result()
+        )
 
     ms_summaries: list = []
     imaging_results: dict[int, list[LoopFutures]] = {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
     "crystalball>=0.4.3",
     "jolly-roger>=0.10.1",
     "capn-crunch>=1.1.0",
-    "loky"
+    "billiard"
 ]
 
 [tool.hatch]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ dependencies = [
     "crystalball>=0.4.3",
     "jolly-roger>=0.10.1",
     "capn-crunch>=1.1.0",
+    "loky"
 ]
 
 [tool.hatch]


### PR DESCRIPTION
This PR adds a task to create a concatenated holography cube to the RACS-All pipeline, formed from the low-, mid- and high-band cubes. 

This is largely a straight forward PR, which the exception that I have moved away from `concurrent.futures.ProcessPoolExecutor` to `billiard.Pool`. The reason behind this was the when a `dask-worker` starts with a corresponding `nanny` process, the worker is set up in `daemon` mode and is unable to spawn child processes. The `billiard` package has its own implementation of a `Pool` that does not have such a limitation. 

The `billiard` package itself is supported by the `celery` package/team and its pretty popular. For the moment I'd like to move forward with this, and in the future we can port it to a `dask.delayed` approach should this become a major problem or we want to lower the dependency footprint. 