### PR TITLE
Better handling of the casda bandpass table flagging and carrying per-baseline channel flagging forward

### DIFF
--- a/flint/flagging.py
+++ b/flint/flagging.py
@@ -33,6 +33,86 @@ class AOFlaggerCommand(NamedTuple):
     """The path to the aoflagging strategy file to use"""
 
 
+# These get_all_chans_flagged_by_baseline and set_all_chans_flagged_by_baseline functions are used to get and set
+# were written to deal with oddities in flags applied from reference field calibration. It _appears__ that after
+# reference field calibration was introduced it is common for uncalibrated data in the MS to be marked as flagged
+# but otherwise not modified. In resetting the flags in aoflagger it is possible for the uncalibrated data to
+# end up unflagged. These fybctuibs can characterise when all timesteps per channel are flagged, and ensure they
+# remain after.
+def get_all_chans_flagged_by_baseline(
+    ms: MS,
+) -> dict[tuple[int, int], NDArray[np.bool]]:
+    """Get a dictionary of all the baselines in a measurement set and the channels that are flagged for all timesteps.
+
+    The FLAG column is inspected, which takes the shape (nrow, nchan, npol). Each baseline is iterated over to select
+    just the rows for that antenna pair. These make the indices of the returned dictionary, and the values are boolean arrays
+    of shape (nchan,) indicating which channels are flagged for all timesteps.
+
+    Args:
+        ms (MS): The measurement set to inspect
+
+    Returns:
+        dict[tuple[int,int], NDArray[np.bool]]: A dictionary where the keys are tuples of (ANTENNA1, ANTENNA2) and the values are boolean arrays of shape (nchan,) indicating which channels are flagged for all timesteps.
+    """
+
+    ms = MS.cast(ms)
+
+    logger.info(f"Identifying channels completely flagged by baseline in {ms.path!s}")
+
+    with table(str(ms.path), readonly=True, ack=False) as tab:
+        ant1 = tab.getcol("ANTENNA1")
+        ant2 = tab.getcol("ANTENNA2")
+        flags = tab.getcol("FLAG")
+
+        baseline_keys = set(zip(ant1, ant2))
+        logger.info(f"Found {len(baseline_keys)} baselines in {ms.path!s}")
+
+        beam_ant_idxs: dict[tuple[int, int], NDArray[np.bool]] = {}
+
+        for baseline in baseline_keys:
+            baseline_mask = (ant1 == baseline[0]) & (ant2 == baseline[1])
+            baseline_flags = flags[baseline_mask, :, :]
+            # Reduce the flags to a single boolean array of shape (nchan,) indicating which channels are flagged for all timesteps
+            beam_ant_flagged = np.all(baseline_flags, axis=(0, 2))
+            beam_ant_idxs[baseline] = beam_ant_flagged
+
+    return beam_ant_idxs
+
+
+def set_all_chans_flagged_by_baseline(
+    ms: MS, baseline_flags: dict[tuple[int, int], NDArray[np.bool]]
+) -> MS:
+    """Set the FLAG column in a measurement set based on a dictionary of baselines and their flagged channels.
+
+    The FLAG column is inspected, which takes the shape (nrow, nchan, npol). Each baseline is iterated over to select
+    just the rows for that antenna pair. The corresponding channels are then flagged for all timesteps.
+
+    Args:
+        ms (MS): The measurement set to modify
+        baseline_flags (dict[tuple[int,int], NDArray[np.bool]]): A dictionary where the keys are tuples of (ANTENNA1, ANTENNA2) and the values are boolean arrays of shape (nchan,) indicating which channels should be flagged for all timesteps.
+
+    Returns:
+        MS: The modified measurement set with the updated FLAG column
+    """
+
+    ms = MS.cast(ms)
+    logger.info(f"Setting channels completely flagged by baseline in {ms.path!s}")
+
+    with table(str(ms.path), readonly=False, ack=False) as tab:
+        ant1 = tab.getcol("ANTENNA1")
+        ant2 = tab.getcol("ANTENNA2")
+        flags = tab.getcol("FLAG")
+
+        for baseline, chan_flags in baseline_flags.items():
+            baseline_mask = (ant1 == baseline[0]) & (ant2 == baseline[1])
+            # Set the FLAG column for the selected rows and channels
+            flags[baseline_mask, :, :] |= chan_flags[np.newaxis, :, np.newaxis]
+
+        tab.putcol("FLAG", flags)
+
+    return ms
+
+
 def flag_ms_zero_uvws(ms: MS, chunk_size: int = 2500) -> MS:
     """Flag out the UVWs in a measurement set that have values of zero.
     This happens when some data are flagged before it reaches the TOS.
@@ -289,8 +369,12 @@ def flag_ms_aoflagger(ms: MS, container: Path) -> MS:
     logger.info(f"Will flag column {ms.column} in {ms.path!s}.")
     aoflagger_cmd = create_aoflagger_cmd(ms=ms)
 
+    baseline_chans_flagged = get_all_chans_flagged_by_baseline(ms=ms)
+
     logger.info("Flagging command constructed. ")
     run_aoflagger_cmd(aoflagger_cmd=aoflagger_cmd, container=container)
+
+    ms = set_all_chans_flagged_by_baseline(ms=ms, baseline_flags=baseline_chans_flagged)
 
     # TODO: This should be moved to the aoflagger lua file once it has
     # been implemented

--- a/flint/misc/interopt.py
+++ b/flint/misc/interopt.py
@@ -70,18 +70,19 @@ def get_flagged_antenna_casda_solutions(
         # the appropriate valid column
         flag_col_name = _find_casda_bandpass_table_type(columns)
 
-        # Remember that VALID is opposite to FLAG
-        flags = ~tab.getcol(flag_col_name)
+        # Remember that VALID is opposite to FLAG, so calling
+        # mask to try to highlight difference
+        mask = ~tab.getcol(flag_col_name)
 
-        # Flag shape will be (TIME, BEAM, ANT, GAIN).
-        assert flags.shape[0] == 1, f"More then one TIME interval in {flags.shape=}"
-        assert len(flags.shape) == 4, (
-            f"Expected dimensionality of 4, but got {flags.shape=}"
+        # Flag shape will be (TIME, BEAM, ANT, JONES_ELEMENT).
+        assert mask.shape[0] == 1, f"More then one TIME interval in {mask.shape=}"
+        assert len(mask.shape) == 4, (
+            f"Expected dimensionality of 4, but got {mask.shape=}"
         )
 
-        # Shape now (BEAM, ANT, GAIN)
-        flags = np.squeeze(flags)
-        beam_ant_flagged = np.all(flags, axis=2)
+        # Shape now (BEAM, ANT, JONES_ELEMENT)
+        mask = np.squeeze(mask)
+        beam_ant_flagged = np.all(mask, axis=2)
 
         for beam, ant_flags in enumerate(beam_ant_flagged):
             beam_ant_idxs[beam] = np.squeeze(np.argwhere(ant_flags))

--- a/flint/misc/interopt.py
+++ b/flint/misc/interopt.py
@@ -68,11 +68,11 @@ def get_flagged_antenna_casda_solutions(
         columns = tab.colnames()
         # Determined the type of bandpass table we found and find
         # the appropriate valid column
-        flag_col_name = _find_casda_bandpass_table_type(columns)
+        valid_col_name = _find_casda_bandpass_table_type(columns)
 
-        # Remember that VALID is opposite to FLAG, so calling
-        # mask to try to highlight difference
-        mask = ~tab.getcol(flag_col_name)
+        # Remember that VALID column is opposite in meaning
+        # to the FLAG column, so calling mask to try to highlight difference
+        mask = ~tab.getcol(valid_col_name)
 
         # Flag shape will be (TIME, BEAM, ANT, JONES_ELEMENT).
         assert mask.shape[0] == 1, f"More then one TIME interval in {mask.shape=}"

--- a/flint/misc/interopt.py
+++ b/flint/misc/interopt.py
@@ -3,6 +3,7 @@ data sets"""
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from pathlib import Path
 
 import numpy as np
@@ -11,6 +12,34 @@ from numpy.typing import NDArray
 
 from flint.logging import logger
 from flint.ms import MS, get_beam_from_ms
+
+
+def _find_casda_bandpass_table_type(column_name: Sequence[str]) -> str:
+    """Examine the bandpass table to determine if it is a CASDA provided table or not.
+    This is done by examining the columns of the table and looking for the expected
+    columns that are present in a CASDA provided bandpass table.
+
+    Args:
+        column_name (Sequence[str]): The columns of the bandpass table to examine
+
+    Raises:
+        ValueError: Raised if the table does not appear to be from CASDA
+
+    Returns:
+        str: The name of the column with the validity flags for the bandpass solutions. These could be 'BANDPASS_VALID' or 'BPLEAKAGE_VALID' for CASDA provided tables.
+
+    """
+    expected_columns: dict[str, Sequence[str]] = {
+        "BANDPASS_VALID": ("TIME", "BANDPASS", "BANDPASS_VALID"),
+        "BPLEAKAGE_VALID": ("TIME", "BPLEAKAGE", "BPLEAKAGE_VALID"),
+    }
+
+    for col_name, expected_cols in expected_columns.items():
+        if all(col in column_name for col in expected_cols):
+            return col_name
+
+    msg = f"Unable to determine bandpass flag column given input {column_name=}. Expected one of {list(expected_columns.values())=}"
+    raise ValueError(msg)
 
 
 def get_flagged_antenna_casda_solutions(
@@ -35,15 +64,14 @@ def get_flagged_antenna_casda_solutions(
     """
 
     beam_ant_idxs: dict[int, NDArray[np.bool]] = {}
-    expected_columns = ("TIME", "BANDPASS", "BANDPASS_VALID")
     with table(str(bandpass_table), ack=False, readonly=True) as tab:
         columns = tab.colnames()
+        # Determined the type of bandpass table we found and find
+        # the appropriate valid column
+        flag_col_name = _find_casda_bandpass_table_type(columns)
 
-        if not all(col in columns for col in expected_columns):
-            msg = f"{expected_columns=}, but found {columns=}"
-            raise ValueError(msg)
-
-        flags = ~tab.getcol("BANDPASS_VALID")
+        # Remember that VALID is opposite to FLAG
+        flags = ~tab.getcol(flag_col_name)
 
         # Flag shape will be (TIME, BEAM, ANT, GAIN).
         assert flags.shape[0] == 1, f"More then one TIME interval in {flags.shape=}"

--- a/tests/test_flagging.py
+++ b/tests/test_flagging.py
@@ -12,9 +12,58 @@ from flint.containers import get_known_container_path
 from flint.flagging import (
     flag_ms_aoflagger,
     flag_ms_zero_uvws,
+    get_all_chans_flagged_by_baseline,
     nan_zero_extreme_flag_ms,
+    set_all_chans_flagged_by_baseline,
 )
 from flint.ms import MS
+
+
+def test_get_all_chans_flagged_by_baseline(ms_example) -> None:
+    """Test that the function correctly identifies channels that are flagged across all timesteps per baseline"""
+
+    with table(str(ms_example), ack=False, readonly=False) as tab:
+        original_flags = tab.getcol("FLAG")
+        original_flags = np.zeros_like(original_flags, dtype=bool)
+        original_flags[:, 110:120, :] = (
+            True  # Flag the first channel for all timesteps of the first baseline
+        )
+
+        tab.putcol("FLAG", original_flags)
+
+    result = get_all_chans_flagged_by_baseline(ms=ms_example)
+
+    assert isinstance(result, dict)
+
+    for baseline, channels in result.items():
+        assert isinstance(baseline, tuple)
+        assert isinstance(channels, np.ndarray)
+        assert channels.dtype == bool
+        assert channels.shape[0] == original_flags.shape[1]
+        assert np.all(channels[110:120])
+
+
+def test_set_all_chans_flagged_by_baseline(ms_example) -> None:
+    """Test that the function correctly sets channels flagged across all timesteps per baseline"""
+
+    with table(str(ms_example), ack=False, readonly=False) as tab:
+        original_flags = tab.getcol("FLAG")
+        original_flags = np.zeros_like(original_flags, dtype=bool)
+        tab.putcol("FLAG", original_flags)
+
+    baseline_flags = get_all_chans_flagged_by_baseline(ms=ms_example)
+    for baseline, channels in baseline_flags.items():
+        baseline_flags[baseline][:] = False
+        baseline_flags[baseline][110:120] = True
+
+    ms_modified = set_all_chans_flagged_by_baseline(
+        ms=ms_example, baseline_flags=baseline_flags
+    )
+
+    with table(str(ms_modified.path), ack=False) as tab:
+        modified_flags = tab.getcol("FLAG")
+
+    assert np.all(modified_flags[:, 110:120, :])
 
 
 def test_flag_ms_zero_uvws(ms_example):

--- a/tests/test_misc_interopt.py
+++ b/tests/test_misc_interopt.py
@@ -11,6 +11,7 @@ import pytest
 from casacore.tables import table
 
 from flint.misc.interopt import (
+    _find_casda_bandpass_table_type,
     flag_antenna_from_casda_bandpass_table,
     get_flagged_antenna_casda_solutions,
 )
@@ -32,6 +33,33 @@ def casda_bandpass_table(tmpdir):
     bandpass_table_path = Path(outpath) / "calparameters.1934_bp.SB83782.tab"
 
     return bandpass_table_path
+
+
+def test_find_casda_bandpass_table_type_raise_error() -> None:
+    """Make sure that an exception is raised when a unknown set of
+    column names are passed"""
+    with pytest.raises(ValueError):
+        _find_casda_bandpass_table_type(["TIME", "JACKSPARROW"])
+
+
+def test_find_casda_bandpass_table_type(casda_bandpass_table) -> None:
+    """Check that the function can identify the correct column name for the flagging
+    information in a casda bandpass table"""
+    with table(str(casda_bandpass_table), ack=False, readonly=True) as tab:
+        columns = tab.colnames()
+
+    result = _find_casda_bandpass_table_type(columns)
+
+    assert result == "BANDPASS_VALID"
+
+    result = _find_casda_bandpass_table_type(["TIME", "BPLEAKAGE", "BPLEAKAGE_VALID"])
+    assert result == "BPLEAKAGE_VALID"
+
+    # This tests for a super set of column names
+    result = _find_casda_bandpass_table_type(
+        ["TIME", "BPLEAKAGE", "BPLEAKAGE_VALID", "JACKSPARROW"]
+    )
+    assert result == "BPLEAKAGE_VALID"
 
 
 def test_get_flagged_antenna_casda_solutions(casda_bandpass_table) -> None:


### PR DESCRIPTION
For a long time we have configured aoflagger to reset the flag column when flagging visibility data. In the past any technical issues around the instrument, like bad intervals, missing antenna etc the data in the measurement set would have some other indicator or 'badness', including:
- (u,v,w) = (0,0,0)
- visibilities zero'd
- combinations of the two

So once aoflagger runs, in which is sets flags, we would always flag data based on the criteria above.

Since the usage of reference field calibration I have noticed this procedure can break. I believe there are situations where (for example) an antenna may be unavailable during the observation of the reference field, so bandpass table would flag visibility data when applying the solutions. If said antenna then became available in science observations, there are now visibilities that look real enough so wont be flagged by aoflagger, but they are uncalibrated. Inspecting the bandpass table applied to the data is one way of identifying such instances and re-flagging.

This PR does two thing:

    makes the examination of the casda supplied bandpass table more robust in how it searches and applies the VALID column examines the visibilities per-baseline directly to identeify instances where channels are flagged across all timesteps, and carries these flags forward after aoflagger.
