### PR TITLE
Parallel cube linmos

### DIFF
--- a/flint/imager/wsclean.py
+++ b/flint/imager/wsclean.py
@@ -42,6 +42,7 @@ from flint.exceptions import (
 from flint.logging import logger
 from flint.ms import MS, standardise_ms_to_list_ms
 from flint.naming import (
+    ProcessedNameComponents,
     create_image_cube_name,
     create_imaging_name_prefix,
     extract_components_from_name,
@@ -402,7 +403,11 @@ def transpose_and_sort_channel_images(
     """
 
     def _channel_key(path: Path) -> int:
-        channel_range = extract_components_from_name(path).channel_range
+        processed_name = extract_components_from_name(path)
+        if not isinstance(processed_name, ProcessedNameComponents):
+            msg = f"Expected Flint-named images e.g. ProcessedNameComponents. Got {type(processed_name)}"
+            raise ValueError(msg)
+        channel_range = processed_name.channel_range
         assert channel_range is not None, f"No channel range in {path=}"
         return channel_range[0]
 

--- a/flint/imager/wsclean.py
+++ b/flint/imager/wsclean.py
@@ -44,6 +44,7 @@ from flint.ms import MS, standardise_ms_to_list_ms
 from flint.naming import (
     create_image_cube_name,
     create_imaging_name_prefix,
+    extract_components_from_name,
     split_images,
 )
 from flint.options import (
@@ -382,6 +383,36 @@ def split_and_get_image_set(
         raise NamingException(f"Failed to get {get=} from {split_dict=}")
 
     return split_list
+
+
+def transpose_and_sort_channel_images(
+    beam_channel_images: list[list[Path]],
+) -> list[list[Path]]:
+    """Regroup per-beam lists of sub-band channel images into per-channel lists
+    of beam images, ready to be co-added one channel at a time.
+
+    Each beam's images are sorted by their channel range, and every beam must
+    contribute the same number of channels.
+
+    Args:
+        beam_channel_images (list[list[Path]]): For each beam, the list of its per-channel images.
+
+    Returns:
+        list[list[Path]]: For each channel, the list of beam images at that channel.
+    """
+
+    def _channel_key(path: Path) -> int:
+        channel_range = extract_components_from_name(path).channel_range
+        assert channel_range is not None, f"No channel range in {path=}"
+        return channel_range[0]
+
+    sorted_beams = [sorted(images, key=_channel_key) for images in beam_channel_images]
+    channel_counts = {len(images) for images in sorted_beams}
+    assert len(channel_counts) == 1, (
+        f"Beams contribute differing channel counts: {channel_counts}"
+    )
+
+    return [list(channel_group) for channel_group in zip(*sorted_beams)]
 
 
 def get_wsclean_output_source_list_path(

--- a/flint/prefect/common/imaging.py
+++ b/flint/prefect/common/imaging.py
@@ -39,6 +39,7 @@ from flint.imager.wsclean import (
     merge_image_sets,
     merge_image_sets_from_results,
     split_and_get_image_set,
+    transpose_and_sort_channel_images,
     wsclean_imager,
 )
 from flint.logging import logger
@@ -57,6 +58,7 @@ from flint.ms import (
 )
 from flint.naming import (
     FITSMaskNames,
+    create_name_from_common_fields,
     get_beam_resolution_str,
     get_fits_cube_from_paths,
 )
@@ -68,6 +70,7 @@ from flint.source_finding.aegean import AegeanOutputs, run_bane_and_aegean
 from flint.summary import FieldSummary
 from flint.utils import (
     flatten_items,
+    remove_files_folders,
     zip_folder,
 )
 from flint.validation import (
@@ -95,6 +98,9 @@ task_image_set_from_result = task(image_set_from_result)
 task_combine_images_to_cube = task(combine_images_to_cube)
 task_merge_image_sets = task(merge_image_sets)
 task_merge_image_sets_from_results = task(merge_image_sets_from_results)
+task_transpose_and_sort_channel_images = task(transpose_and_sort_channel_images)
+task_create_name_from_common_fields = task(create_name_from_common_fields)
+task_remove_files_folders = task(remove_files_folders)
 
 # Tasks below are extracting componented from earlier stages, or are
 # otherwise doing something important

--- a/flint/prefect/flows/polarisation_pipeline.py
+++ b/flint/prefect/flows/polarisation_pipeline.py
@@ -7,7 +7,7 @@ from configargparse import ArgumentParser
 from prefect import flow, tags, unmapped
 from prefect.futures import PrefectFuture
 
-from flint.coadd.linmos import LinmosOptions, LinmosResult
+from flint.coadd.linmos import LinmosOptions
 from flint.configuration import (
     POLARISATION_MAPPING,
     get_options_from_strategy,
@@ -35,19 +35,20 @@ from flint.prefect.clusters import get_dask_runner
 from flint.prefect.common.imaging import (
     task_combine_images_to_cube,
     task_convolve_images,
+    task_create_name_from_common_fields,
     task_get_channel_images_from_paths,
     task_get_common_beam_from_image_set,
     task_linmos_images,
     task_merge_image_sets,
     task_preprocess_askap_ms,
+    task_remove_files_folders,
     task_split_and_get_image_set,
+    task_transpose_and_sort_channel_images,
     task_wsclean_imager,
 )
 from flint.prefect.common.utils import (
     task_create_field_summary,
-    task_create_object,
     task_getattr,
-    task_rename_linear_to_stokes,
 )
 
 
@@ -174,7 +175,10 @@ def process_science_fields_pol(
         fixed_beam_shape=pol_field_options.fixed_beam_shape,
     )
 
-    stokes_beam_cubes: dict[str, list[PrefectFuture[Path]]] = {}
+    # Convolve every beam's sub-band images to the common beam, keeping the
+    # per-channel images (rather than cubing per beam) so we can co-add across
+    # beams one channel at a time.
+    stokes_beam_channel_images: dict[str, list[PrefectFuture[list[Path]]]] = {}
     for polarisation, image_set_list in image_sets_dict.items():
         with tags(f"polarisation-{polarisation}"):
             # Get the individual Stokes parameters in case of joint imaging
@@ -183,7 +187,7 @@ def process_science_fields_pol(
             stokes_list = list(POLARISATION_MAPPING[polarisation])
             for stokes in stokes_list:
                 with tags(f"stokes-{stokes}"):
-                    beam_cubes: list[PrefectFuture[Path]] = []
+                    beam_channel_images: list[PrefectFuture[list[Path]]] = []
                     for image_set in image_set_list:
                         stokes_image_list = task_split_and_get_image_set.submit(
                             image_set=image_set,
@@ -196,55 +200,84 @@ def process_science_fields_pol(
                             beam_shape=common_beam_shape,
                             cutoff=pol_field_options.beam_cutoff,
                         )
-                        # TODO: Consider accerating this by doing a linmos per-channel, then combining
                         channel_image_list = task_get_channel_images_from_paths.submit(
                             paths=convolved_image_list
                         )
-                        prefix = task_getattr.submit(image_set, "prefix")
+                        beam_channel_images.append(channel_image_list)
+                    stokes_beam_channel_images[stokes] = beam_channel_images
 
-                        if polarisation == "linear":
-                            # Get single Stokes prefix - the original prefix is the linear prefix
-                            # i.e. `.qu.` -> `.q.` or `.u.` depending on the stokes
-                            prefix = task_rename_linear_to_stokes.submit(
-                                linear_name=prefix,
-                                stokes=stokes,
-                            )
-                        cube_path = task_combine_images_to_cube.submit(
-                            images=channel_image_list,
-                            prefix=prefix,
-                            mode="image",
-                            remove_original_images=True,
-                        )
-                        beam_cubes.append(cube_path)
-                stokes_beam_cubes[stokes] = beam_cubes
+    # Regroup each Stokes' per-beam channel images into per-channel beam groups
+    # so linmos can run one channel at a time in parallel. Resolving here blocks
+    # until the convolutions above have completed.
+    stokes_channel_groups: dict[str, list[list[Path]]] = {
+        stokes: task_transpose_and_sort_channel_images.submit(
+            beam_channel_images=beam_channel_images
+        ).result()
+        for stokes, beam_channel_images in stokes_beam_channel_images.items()
+    }
 
-    linmos_result_list: list[PrefectFuture[LinmosResult]] = []
-    # We run linmos now to ensure we have Stokes I images for leakage correction
-    # If we have not imaged Stokes I, we cannot do leakage correction
-    force_remove_leakage: bool | None = None
-    if "i" not in stokes_beam_cubes.keys():
-        force_remove_leakage = False
+    # Stokes I beam images (per channel) are needed to correct widefield leakage
+    # in the Stokes Q/U mosaics. If Stokes I was not imaged we cannot do this.
+    i_channel_groups = stokes_channel_groups.get("i")
+    force_remove_leakage: bool | None = None if i_channel_groups else False
 
-    linmos_options = task_create_object(
-        object=LinmosOptions,
-        holofile=pol_field_options.holofile,
-        cutoff=pol_field_options.pb_cutoff,
-        stokesi_images=stokes_beam_cubes.get("i"),
-        force_remove_leakage=force_remove_leakage,
-        trim_linmos_fits=pol_field_options.trim_linmos_fits,
-    )
-    for stokes, beam_cubes in stokes_beam_cubes.items():
-        with tags(f"stokes-{stokes}"):
-            linmos_result = task_linmos_images.submit(
-                image_list=beam_cubes,
-                container=pol_field_options.yandasoft_container,
-                linmos_options=linmos_options,
-                field_summary=field_summary,
+    cube_results: list[PrefectFuture[Path]] = []
+    all_input_images: list[Path] = []
+    for stokes, channel_groups in stokes_channel_groups.items():
+        if i_channel_groups is not None:
+            assert len(i_channel_groups) == len(channel_groups), (
+                f"Stokes {stokes} has {len(channel_groups)} channels, "
+                f"but Stokes I has {len(i_channel_groups)}"
             )
-            linmos_result_list.append(linmos_result)
+        with tags(f"stokes-{stokes}"):
+            image_planes: list[PrefectFuture[Path]] = []
+            weight_planes: list[PrefectFuture[Path]] = []
+            for channel_idx, beam_images in enumerate(channel_groups):
+                all_input_images.extend(beam_images)
+                linmos_options = LinmosOptions(
+                    holofile=pol_field_options.holofile,
+                    cutoff=pol_field_options.pb_cutoff,
+                    stokesi_images=i_channel_groups[channel_idx]
+                    if i_channel_groups is not None
+                    else None,
+                    force_remove_leakage=force_remove_leakage,
+                    trim_linmos_fits=pol_field_options.trim_linmos_fits,
+                    cleanup=True,
+                )
+                linmos_result = task_linmos_images.submit(
+                    image_list=beam_images,
+                    container=pol_field_options.yandasoft_container,
+                    linmos_options=linmos_options,
+                    field_summary=field_summary,
+                )
+                image_planes.append(task_getattr.submit(linmos_result, "image_fits"))
+                weight_planes.append(task_getattr.submit(linmos_result, "weight_fits"))
 
-    # wait for all linmos results to be completed
-    _ = [linmos_result.result() for linmos_result in linmos_result_list]
+            # Stack the per-channel mosaics back into image and weight cubes,
+            # removing the per-channel mosaics once cubed.
+            cube_prefix = task_create_name_from_common_fields.submit(
+                in_paths=image_planes
+            )
+            image_cube = task_combine_images_to_cube.submit(
+                images=image_planes,
+                prefix=cube_prefix,
+                mode="image",
+                remove_original_images=True,
+            )
+            weight_cube = task_combine_images_to_cube.submit(
+                images=weight_planes,
+                prefix=cube_prefix,
+                mode="weight",
+                remove_original_images=True,
+            )
+            cube_results.extend([image_cube, weight_cube])
+
+    # Remove the convolved per-beam channel images now that every cube is built.
+    # Stokes I images are kept until here as they feed the Q/U leakage correction.
+    task_remove_files_folders.submit(*all_input_images, wait_for=cube_results)
+
+    # wait for all cubes to be completed
+    _ = [cube_result.result() for cube_result in cube_results]
 
 
 def setup_run_process_science_field(

--- a/tests/test_wsclean.py
+++ b/tests/test_wsclean.py
@@ -33,11 +33,43 @@ from flint.imager.wsclean import (
     rotate_cube,
     split_and_get_image_set,
     split_image_set,
+    transpose_and_sort_channel_images,
 )
 from flint.logging import logger
 from flint.naming import create_imaging_name_prefix
 from flint.options import MS
 from flint.utils import get_packaged_resource_path
+
+
+def test_transpose_and_sort_channel_images() -> None:
+    """Per-beam channel image lists should regroup into per-channel beam groups,
+    sorted by channel range and independent of the input ordering."""
+    base = (
+        "SB39400.RACS_0000-123.beam{beam}.round3.i.ch{lo:04d}-{hi:04d}.image.conv.fits"
+    )
+    channels = [(0, 1), (2, 3), (4, 5)]
+
+    def beam_list(beam: int, order: list[tuple[int, int]]) -> list[Path]:
+        return [Path(base.format(beam=beam, lo=lo, hi=hi)) for lo, hi in order]
+
+    # Beam 0 in order, beam 1 shuffled - both must sort to the same channel order
+    beam_channel_images = [
+        beam_list(0, channels),
+        beam_list(1, [channels[2], channels[0], channels[1]]),
+    ]
+
+    channel_groups = transpose_and_sort_channel_images(beam_channel_images)
+
+    assert len(channel_groups) == len(channels)
+    for group, (lo, hi) in zip(channel_groups, channels):
+        assert len(group) == 2
+        assert all(f"ch{lo:04d}-{hi:04d}" in str(p) for p in group)
+        assert [f"beam{b}" in str(p) for b, p in enumerate(group)] == [True, True]
+
+    with pytest.raises(AssertionError):
+        transpose_and_sort_channel_images(
+            [beam_list(0, channels), beam_list(1, channels[:2])]
+        )
 
 
 def test_get_cli_parser() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -140,6 +140,7 @@ dependencies = [
     { name = "aegeantools" },
     { name = "astropy" },
     { name = "astroquery" },
+    { name = "billiard" },
     { name = "capn-crunch" },
     { name = "configargparse" },
     { name = "crystalball" },
@@ -190,6 +191,7 @@ requires-dist = [
     { name = "aegeantools", specifier = "==2.3.0" },
     { name = "astropy", specifier = ">=6.1.3" },
     { name = "astroquery", specifier = ">=0.4.8.dev0" },
+    { name = "billiard" },
     { name = "capn-crunch", specifier = ">=1.1.0" },
     { name = "configargparse", specifier = ">=1.7" },
     { name = "crystalball", specifier = ">=0.4.3" },
@@ -404,6 +406,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b0/1c6a16426d389813b48d95e26898aff79abbde42ad353958ad95cc8c9b21/beautifulsoup4-4.14.3.tar.gz", hash = "sha256:6292b1c5186d356bba669ef9f7f051757099565ad9ada5dd630bd9de5fa7fb86", size = 627737, upload-time = "2025-11-30T15:08:26.084Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl", hash = "sha256:0918bfe44902e6ad8d57732ba310582e98da931428d231a5ecb9e7c703a735bb", size = 107721, upload-time = "2025-11-30T15:08:24.087Z" },
+]
+
+[[package]]
+name = "billiard"
+version = "4.2.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/23/b12ac0bcdfb7360d664f40a00b1bda139cbbbced012c34e375506dbd0143/billiard-4.2.4.tar.gz", hash = "sha256:55f542c371209e03cd5862299b74e52e4fbcba8250ba611ad94276b369b6a85f", size = 156537, upload-time = "2025-11-30T13:28:48.52Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/87/8bab77b323f16d67be364031220069f79159117dd5e43eeb4be2fef1ac9b/billiard-4.2.4-py3-none-any.whl", hash = "sha256:525b42bdec68d2b983347ac312f892db930858495db601b5836ac24e6477cde5", size = 87070, upload-time = "2025-11-30T13:28:47.016Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Fixes an outstanding `TODO` in the polarisation pipeline - we were previously making cubes and then giving to linmos. We were therefore missing an opportunity to parallelise by instead linmos-ing images then forming a cube from the mosicked channels.

Old: per beam → cube → one linmos per stokes crunching all ~288 channels in a single serial process.

New:

1. Per beam: split → convolve → keep per-channel images (no per-beam cube).
2. Transpose beam×channel → channel×beam (transpose_and_sort_channel_images, sorted by channel range).
3. One linmos per channel across beams — fanned out in parallel via `.submit()`.
4. Stack per-channel mosaics into image + weight cubes.
5. Cleanup: per-channel weight files (`LinmosOptions.cleanup=True`), mosaics (`remove_original_images=True` on the cube step), and convolved beam images (final task_remove_files_folders, gated on all cubes).
6. Correctness preserved: Q/U leakage correction now passes the matching per-channel Stokes-I beam images as `stokesi_images`; `force_remove_leakage=False` when I isn't imaged; Stokes-I inputs kept until Q/U consume them. A `.result()` barrier after convolution guarantees all files exist on disk before any linmos runs.

New code: `transpose_and_sort_channel_images` in `wsclean.py` (+ test), and three thin `task(...)` wrappers in `imaging.py`. Dropped the now-unneeded `task_rename_linear_to_stokes`/`task_create_object` hack — names derive from the actual per-stokes files.