### PR TITLE
RACS-all polarisation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,20 @@
+# CLAUDE.md
+
+Guidance for Claude Code working in this repository.
+
+## Style
+
+Keep it simple.
+
+**Docstrings.** A one-liner wherever one will do. Terse, but written for a
+person to read: plain words, no jargon, no filler.
+
+**Comments.** Only to explain a *why* that the code cannot show. Think twice
+before adding one at all — prefer code that says it itself. Anything you do add
+follows the docstring rules above.
+
+**Private names.** A leading underscore is for tiny helpers. Anything larger is
+a normal function.
+
+**Global constants.** Do not add one unless it is actually needed. A value used
+in a single place is a local.

--- a/docs/quickstart/deployment.md
+++ b/docs/quickstart/deployment.md
@@ -294,7 +294,7 @@ In general usage the following `prefect` configuration settings may be of use, p
 ```bash
 export PREFECT_API_URL="http://${YOUR_MACHINE_ADDRESS}:4200/api"
 export PREFECT_HOME="$(pwd)/prefect"
-export PREFECT_LOGGING_EXTRA_LOGGERS="flint,fixms"
+export PREFECT_LOGGING_EXTRA_LOGGERS="flint,fixms,rm-lite"
 export PREFECT_LOGGING_LEVEL="INFO"
 export PREFECT_RESULTS_PERSIST_BY_DEFAULT=true
 ```

--- a/docs/quickstart/polarisation.md
+++ b/docs/quickstart/polarisation.md
@@ -31,6 +31,36 @@ polarisation:
     wsclean: {}
 ```
 
+## Angular resolution
+
+The restoring beam of an ASKAP image varies across the footprint and with
+frequency, so the per-beam channel images have to be brought to a common
+resolution before `linmos` co-adds them. `flint` does this in the 'natural'
+sense of [`RACS-tools`](https://github.com/AlecThomson/RACS-tools): one common
+beam is solved **per channel** and the cube keeps its frequency-dependent
+resolution, rather than every channel being dragged out to the coarsest beam in
+the band.
+
+A channel's beam is solved over every footprint beam of every Stokes at that
+channel, so channel N of I, Q and U share one resolution and a per-channel
+polarisation product (e.g. polarised intensity) is meaningful.
+
+Two options steer this:
+
+- `--beam-cutoff`: a beam coarser than this, in arcseconds, is left out of the
+  solve and its image is blanked instead of convolved. A channel where every
+  image is beyond the cutoff has no beam to convolve to at all, so the whole
+  channel is blanked and marked as carrying no PSF.
+- `--fixed-beam-shape`: convolve every channel to this `(arcsec, arcsec, deg)`
+  beam instead of solving one, which gives a cube of constant resolution.
+
+RM-synthesis is only meaningful when every channel shares one beam, so the
+rm-synth stage brings its own inputs to a single 'total' beam covering the whole
+band. It writes those as new `.conv.fits` cubes and leaves the natural-resolution
+cubes alone, so both are available: the natural cubes to archive, the total cubes
+to synthesise from. See `RMSynthFieldOptions.beam_cutoff` to drop the coarsest
+channels from that solve rather than smoothing the whole band to reach them.
+
 ## Spectro-polarimetric imaging in WSClean
 
 We encourage users to carefully read the [WSclean documentation](https://wsclean.readthedocs.io/en/latest/). In practice, we have encountered a few common 'gotchas' when producing polarisation cube. As always, a user should pay attention to the output logs to see e.g. how many iterations have been performed and what the stopping criterion was. We also encourage the inspection of image, model, and residual products to see how well (or not) deconvolution has performed.

--- a/flint/bane.py
+++ b/flint/bane.py
@@ -28,6 +28,7 @@ from radio_beam import Beam
 from radio_beam.beam import NoBeamException
 from scipy import ndimage
 
+from flint.convol import header_beam_is_usable
 from flint.logging import logger
 from flint.naming import create_aegean_names
 from flint.options import FFTBANEOptions
@@ -292,6 +293,12 @@ def _bane_round(
     return background, rms
 
 
+def _needs_a_beam(fft_bane_options: FFTBANEOptions) -> bool:
+    """Whether ``get_kernel`` will read the beam, rather than take both sizes as given"""
+    step_size, box_size = fft_bane_options.step_size, fft_bane_options.box_size
+    return step_size is None or step_size < 0 or box_size is None or box_size < 0
+
+
 def robust_bane(
     image: NDArray[np.float32],
     header: fits.Header | dict[str, Any],
@@ -304,6 +311,9 @@ def robust_bane(
     Two passes: the first clips sources against one background and noise for the
     plane, the second against the maps the first produced.
 
+    A plane with no usable beam gets blank maps, unless both sizes are given
+    outright and so no beam is needed to size the kernel.
+
     Args:
         image (NDArray[np.float32]): The image plane to measure
         header (fits.Header | dict[str, Any]): Its header, for the beam and pixel scale
@@ -315,6 +325,16 @@ def robust_bane(
         tuple[NDArray[np.float32], NDArray[np.float32]]: Background and RMS, shaped like `image`
     """
     fft_bane_options = fft_bane_options or FFTBANEOptions()
+
+    if _needs_a_beam(fft_bane_options) and not header_beam_is_usable(header=header):
+        # A blank channel is marked with a zero beam, or loses its beam keywords
+        # altogether once linmos has co-added it. There is no resolution to size
+        # a kernel against and no signal to measure, so the maps are blank too.
+        # Blank rather than absent so the plane still stacks into a cube
+        logger.warning("No usable beam to size the BANE kernel, returning blank maps")
+        blank = np.full_like(image, np.nan, dtype=np.float32)
+        return blank, blank.copy()
+
     kernel, step_size_pix = get_kernel(
         header=header,
         step_size=fft_bane_options.step_size,

--- a/flint/bane.py
+++ b/flint/bane.py
@@ -1,0 +1,396 @@
+"""BANE, the background and noise estimator, computed with FFTs.
+
+Ported from ``AegeanTools.BANE_fft`` (AlecThomson/Aegean, ``dask`` branch). Here
+``step`` is a downsampling factor and ``box`` a kernel size, and the box average
+is a convolution. Only the 2D single-plane routines: callers run this per channel.
+
+``rocket_fft`` is imported for its side effect of teaching numba ``numpy.fft``,
+without which every ``njit`` here fails to compile.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any, NamedTuple
+
+import astropy.units as u
+import numba as nb
+import numpy as np
+import rocket_fft  # noqa: F401
+from astropy.io import fits
+from astropy.stats import mad_std
+from astropy.wcs import WCS
+from astropy.wcs.utils import proj_plane_pixel_scales
+from numpy import fft
+from numpy.typing import NDArray
+from radio_beam import Beam
+from radio_beam.beam import NoBeamException
+from scipy import ndimage
+
+from flint.logging import logger
+from flint.naming import create_aegean_names
+from flint.options import FFTBANEOptions
+
+
+class BANEMaps(NamedTuple):
+    """The pair of maps ``bane_fits_image`` writes"""
+
+    bkg_image: Path
+    """Background map"""
+    rms_image: Path
+    """RMS noise map"""
+
+
+@nb.njit(fastmath=True, cache=True)
+def _ft_kernel(kernel: NDArray[np.float32], shape: tuple) -> NDArray[np.float32]:
+    """FFT of `kernel`, zero-padded out to `shape`"""
+    return fft.rfft2(kernel, s=shape)
+
+
+@nb.njit(
+    nb.float32[:, :](
+        nb.float32[:, :],
+        nb.types.UniTuple(nb.int64, 2),
+    ),
+    fastmath=True,
+    cache=True,
+)
+def pad_reflect(
+    array: NDArray[np.float32],
+    pad_width: tuple[int, int],
+) -> NDArray[np.float32]:
+    """``np.pad(array, pad_width, mode="reflect")``, in a form numba can compile"""
+    nx, ny = array.shape
+    px, py = pad_width
+
+    padded = np.empty((nx + 2 * px, ny + 2 * py), dtype=array.dtype)
+    padded[px : px + nx, py : py + ny] = array
+
+    for i in range(px):
+        padded[px - 1 - i, py : py + ny] = array[i + 1, :]
+        padded[nx + px + i, py : py + ny] = array[nx - 2 - i, :]
+
+    for j in range(py):
+        padded[:, py - 1 - j] = padded[:, py + j + 1]
+        padded[:, ny + py + j] = padded[:, ny + py - 2 - j]
+
+    return padded
+
+
+@nb.njit(
+    nb.float32[:, :](nb.float32[:, :], nb.float32[:, :]),
+    fastmath=True,
+    cache=True,
+)
+def fft_average(
+    image: NDArray[np.float32], kernel: NDArray[np.float32]
+) -> NDArray[np.float32]:
+    """Convolve `image` by `kernel`, normalised so a flat image is unchanged.
+
+    Reflect-padded by the kernel size so the FFT's periodic wrap does not fold
+    the far edge of the image back onto the near one.
+    """
+    pad_x, pad_y = kernel.shape
+    image_padded = pad_reflect(array=image, pad_width=(pad_x, pad_y))
+
+    image_fft = fft.rfft2(image_padded)
+    kernel_fft = _ft_kernel(kernel, shape=image_padded.shape)
+    smooth = fft.irfft2(image_fft * kernel_fft, s=image_padded.shape) / kernel.sum()
+
+    return smooth[pad_x:-pad_x, pad_y:-pad_y]
+
+
+@nb.njit(
+    nb.types.UniTuple(nb.float32[:, :], 2)(
+        nb.float32[:, :], nb.float32[:, :], nb.float32[:, :]
+    ),
+    fastmath=True,
+    cache=True,
+)
+def bane_fft(
+    image: NDArray[np.float32],
+    kernel: NDArray[np.float32],
+    valid: NDArray[np.float32],
+) -> tuple[NDArray[np.float32], NDArray[np.float32]]:
+    """Background and RMS of `image`, as `kernel`-weighted local averages.
+
+    `image` must be zero wherever `valid` is zero. Dividing by the smoothed
+    validity mask stops a blank counting as a measured zero, which would
+    otherwise drag the background down within a kernel width of every blank.
+    """
+    weight = fft_average(valid, kernel)
+    weight = np.where(weight > 0, weight, np.nan).astype(np.float32)
+
+    mean = (fft_average(image, kernel) / weight).astype(np.float32)
+    # Blanked pixels hold zero, not the mean, so their residual has to be
+    # zeroed too or it would enter the sum as the full mean squared. Selected
+    # rather than multiplied by `valid`: `mean` is NaN where nothing was valid,
+    # and NaN * 0 is NaN, which the FFT would then spread over the whole plane
+    resid = np.where(valid > 0, (image - mean) ** 2, np.float32(0.0)).astype(np.float32)
+    rms = np.sqrt(fft_average(resid, kernel) / weight).astype(np.float32)
+
+    return mean, rms
+
+
+def tophat_kernel(diameter: int) -> NDArray[np.float32]:
+    """Circular tophat kernel of `diameter` pixels"""
+    radius = diameter // 2
+    kernel = np.zeros((radius * 2 + 1, radius * 2 + 1), dtype=np.float32)
+    xx = np.arange(-radius, radius + 1)
+    X, Y = np.meshgrid(xx, xx)
+    kernel[radius**2 >= X**2 + Y**2] = 1
+    return kernel
+
+
+def gaussian_kernel(fwhm: int) -> NDArray[np.float32]:
+    """Gaussian kernel of `fwhm` pixels"""
+    xx = np.arange(-fwhm, fwhm + 1)
+    X, Y = np.meshgrid(xx, xx)
+    kernel = np.exp(-4 * np.log(2) * (X**2 + Y**2) / fwhm**2)
+    return kernel.astype(np.float32)
+
+
+def get_kernel(
+    header: fits.Header | dict[str, Any],
+    step_size: int | None = None,
+    box_size: int | None = None,
+    kernel_func: Callable[[int], NDArray[np.float32]] = gaussian_kernel,
+) -> tuple[NDArray[np.float32], int]:
+    """The convolution kernel and downsampling factor, in pixels.
+
+    ``step_size`` is the downsampling factor and ``box_size`` the kernel size.
+    Either being None or negative sizes it from the restoring beam instead, at
+    3 and 10 beams respectively, or at ``abs(value)`` beams when negative.
+
+    Args:
+        header (fits.Header | dict[str, Any]): Header of the image, for the beam and pixel scale
+        step_size (int | None, optional): Downsampling factor in pixels. Defaults to 3 beams.
+        box_size (int | None, optional): Kernel size in pixels. Defaults to 10 beams.
+        kernel_func (Callable, optional): Kernel shape. Defaults to ``gaussian_kernel``.
+
+    Returns:
+        tuple[NDArray[np.float32], int]: The kernel, peak-normalised, and the step size in pixels
+    """
+    if step_size is None or step_size < 0 or box_size is None or box_size < 0:
+        try:
+            beam = Beam.from_fits_header(header)
+            scales = proj_plane_pixel_scales(WCS(header)) * u.deg / u.pixel
+            pix_per_beam = beam.minor / scales.min()
+        except (ValueError, NoBeamException) as error:
+            # radio_beam raises NoBeamException, which is not a ValueError, so
+            # catching ValueError alone lets a header with no beam through
+            msg = "Could not parse beam from header - try specifying step size"
+            raise ValueError(msg) from error
+        logger.info(f"{beam!r}, {pix_per_beam:0.1f} pixels per beam")
+
+    if step_size is None or step_size < 0:
+        nbeam_step = 3 if step_size is None else abs(step_size)
+        step_size_pix = int(np.ceil((nbeam_step * pix_per_beam).to(u.pix).value))
+    else:
+        step_size_pix = step_size
+
+    if box_size is None or box_size < 0:
+        nbeam_box = 10 if box_size is None else abs(box_size)
+        scaler = step_size_pix if step_size_pix > 0 else 1
+        box_size_pix = abs(int(np.ceil(pix_per_beam.value * nbeam_box / scaler)))
+    else:
+        box_size_pix = box_size
+
+    logger.info(f"BANE {step_size_pix=} {box_size_pix=} (box is post-downsampling)")
+
+    kernel = kernel_func(box_size_pix)
+    kernel /= kernel.max()
+
+    return kernel, step_size_pix
+
+
+def _downsample_slices(
+    shape: tuple[int, int], step_size_pix: int
+) -> tuple[slice, slice]:
+    """Slices taking every `step_size_pix` pixel, trimmed to an even count.
+
+    The sampled region runs from `step_size_pix` to `length - step_size_pix`
+    while the zoom back up stretches it over the whole image. That is the likely
+    cause of the offset upstream records as a TODO; sampling half a cell in
+    instead measured worse, so this keeps upstream's grid.
+    """
+    slices = []
+    for length in (shape[0], shape[1]):
+        stop = length - step_size_pix
+        while (stop // step_size_pix) % 2 != 0:
+            stop -= 1
+        slices.append(slice(step_size_pix, stop, step_size_pix))
+    return slices[0], slices[1]
+
+
+def _bane_round(
+    filled: NDArray[np.float32],
+    valid: NDArray[np.float32],
+    nan_mask: NDArray[np.bool_],
+    background: NDArray[np.float32],
+    rms: NDArray[np.float32],
+    kernel: NDArray[np.float32],
+    step_size_pix: int,
+    clip_sigma: float,
+    rng: np.random.Generator,
+    round_number: int,
+) -> tuple[NDArray[np.float32], NDArray[np.float32]]:
+    """One clip-refill-smooth pass, clipping against the given background and RMS.
+
+    The refill carries the local background: zero-mean noise would drag the
+    background down wherever a source was removed.
+    """
+    with np.errstate(invalid="ignore", divide="ignore"):
+        source_mask = (np.abs(filled - background) / rms > clip_sigma) & ~nan_mask
+    logger.info(
+        f"BANE round {round_number}: refilling {source_mask.sum()} "
+        f"({source_mask.sum() / filled.size * 100:0.1f}%) source pixels with noise"
+    )
+
+    clipped = filled.copy()
+    clipped[source_mask] = (
+        background[source_mask]
+        + rng.normal(loc=0, scale=1, size=source_mask.sum()) * rms[source_mask]
+    )
+    # Blanked pixels must stay at zero: bane_fft normalises by the smoothed
+    # validity mask and assumes they contribute nothing
+    clipped[nan_mask] = 0.0
+
+    zoom: tuple[float, float] | None = None
+    round_valid = valid
+    if step_size_pix > 0:
+        y_slice, x_slice = _downsample_slices(clipped.shape, step_size_pix)
+        zoom = (
+            clipped.shape[0] / clipped[y_slice, x_slice].shape[0],
+            clipped.shape[1] / clipped[y_slice, x_slice].shape[1],
+        )
+        clipped, round_valid = clipped[y_slice, x_slice], valid[y_slice, x_slice]
+
+    # pad_reflect is njit-ed without bounds checking, so a kernel wider than the
+    # image reads off the end and returns quietly wrong maps rather than raising
+    if any(pad >= length for pad, length in zip(kernel.shape, clipped.shape)):
+        msg = (
+            f"A {kernel.shape} kernel does not fit the {clipped.shape} image it "
+            "smooths. Lower step_size so less is downsampled away, or box_size "
+            "for a smaller kernel."
+        )
+        raise ValueError(msg)
+
+    background, rms = bane_fft(
+        np.ascontiguousarray(clipped), kernel, np.ascontiguousarray(round_valid)
+    )
+    background = np.nan_to_num(background, nan=0.0)
+    rms = np.nan_to_num(rms, nan=0.0)
+
+    if zoom is not None:
+        background = ndimage.zoom(
+            background, zoom, order=3, grid_mode=True, mode="reflect"
+        )
+        rms = ndimage.zoom(rms, zoom, order=3, grid_mode=True, mode="reflect")
+
+    return background, rms
+
+
+def robust_bane(
+    image: NDArray[np.float32],
+    header: fits.Header | dict[str, Any],
+    fft_bane_options: FFTBANEOptions | None = None,
+    kernel_func: Callable[[int], NDArray[np.float32]] = gaussian_kernel,
+    rms_estimator: Callable[[NDArray[np.float32]], float] = mad_std,
+) -> tuple[NDArray[np.float32], NDArray[np.float32]]:
+    """Background and RMS maps of a single image plane.
+
+    Two passes: the first clips sources against one background and noise for the
+    plane, the second against the maps the first produced.
+
+    Args:
+        image (NDArray[np.float32]): The image plane to measure
+        header (fits.Header | dict[str, Any]): Its header, for the beam and pixel scale
+        fft_bane_options (FFTBANEOptions | None, optional): Step, box, clip and seed. Defaults to ``FFTBANEOptions()``.
+        kernel_func (Callable, optional): Kernel shape. Defaults to ``gaussian_kernel``.
+        rms_estimator (Callable, optional): First-pass RMS estimator. Defaults to ``mad_std``.
+
+    Returns:
+        tuple[NDArray[np.float32], NDArray[np.float32]]: Background and RMS, shaped like `image`
+    """
+    fft_bane_options = fft_bane_options or FFTBANEOptions()
+    kernel, step_size_pix = get_kernel(
+        header=header,
+        step_size=fft_bane_options.step_size,
+        box_size=fft_bane_options.box_size,
+        kernel_func=kernel_func,
+    )
+
+    nan_mask = ~np.isfinite(image)
+    valid = (~nan_mask).astype(np.float32)
+    filled = np.where(nan_mask, 0.0, image).astype(np.float32)
+    finite = image[~nan_mask].ravel()
+
+    # The median matters: testing |image| rather than |image - background| makes
+    # every pixel a source as soon as the plane carries a DC offset
+    background = np.full_like(filled, float(np.median(finite)))
+    rms = np.full_like(filled, float(rms_estimator(finite)))
+
+    # A mosaic's noise rises with the primary beam, so one threshold clips real
+    # noise at the edge while missing faint sources in the middle
+    rng = np.random.default_rng(fft_bane_options.seed)
+    for round_number in (1, 2):
+        background, rms = _bane_round(
+            filled=filled,
+            valid=valid,
+            nan_mask=nan_mask,
+            background=background,
+            rms=rms,
+            kernel=kernel,
+            step_size_pix=step_size_pix,
+            clip_sigma=fft_bane_options.clip_sigma,
+            rng=rng,
+            round_number=round_number,
+        )
+
+    background[nan_mask] = np.nan
+    rms[nan_mask] = np.nan
+
+    return background, rms
+
+
+def bane_fits_image(
+    image: Path,
+    fft_bane_options: FFTBANEOptions | None = None,
+) -> BANEMaps:
+    """Write the background and RMS maps of a single-plane FITS image.
+
+    Named ``_bkg.fits`` and ``_rms.fits`` beside the input, as the aegean BANE
+    names them, so the two are interchangeable downstream.
+
+    Args:
+        image (Path): Single-plane FITS image to measure
+        fft_bane_options (FFTBANEOptions | None, optional): Step, box, clip and seed. Defaults to ``FFTBANEOptions()``.
+
+    Returns:
+        BANEMaps: The background and RMS maps written
+    """
+    logger.info(f"Running FFT BANE on {image}")
+    with fits.open(image, memmap=True, mode="denywrite") as hdul:
+        header = hdul[0].header
+        # A linmos plane carries degenerate Stokes/frequency axes; the maps are
+        # written back with them so they stack like the image they came from
+        original_shape = hdul[0].data.shape
+        data = np.squeeze(hdul[0].data).astype(np.float32)
+
+    if data.ndim != 2:
+        msg = f"{image} has a {data.ndim}D image once squeezed, expected a single plane"
+        raise ValueError(msg)
+
+    background, rms = robust_bane(
+        image=data, header=header, fft_bane_options=fft_bane_options
+    )
+
+    names = create_aegean_names(base_output=str(image.parent / image.stem))
+    for data_out, path in ((background, names.bkg_image), (rms, names.rms_image)):
+        # The input header, so the maps stay on its pixel grid
+        fits.writeto(path, data_out.reshape(original_shape), header, overwrite=True)
+        logger.info(f"Wrote {path}")
+
+    return BANEMaps(bkg_image=names.bkg_image, rms_image=names.rms_image)

--- a/flint/bane.py
+++ b/flint/bane.py
@@ -289,6 +289,12 @@ def _bane_round(
             background, zoom, order=3, grid_mode=True, mode="reflect"
         )
         rms = ndimage.zoom(rms, zoom, order=3, grid_mode=True, mode="reflect")
+        # The cubic spline rings across the step the nan_to_num above puts at
+        # the footprint edge, and undershoots to a negative noise. A negative
+        # error squares to a small positive variance, so an inverse-variance
+        # weight downstream comes out orders of magnitude too large rather than
+        # obviously wrong
+        rms = np.clip(rms, 0.0, None)
 
     return background, rms
 
@@ -314,10 +320,15 @@ def robust_bane(
     A plane with no usable beam gets blank maps, unless both sizes are given
     outright and so no beam is needed to size the kernel.
 
+    Blank pixels are those that are not finite and, unless
+    ``fft_bane_options.invalidate_zeros`` is unset, those of exactly zero. A
+    plane that is blank throughout gets blank maps, there being nothing to
+    measure.
+
     Args:
         image (NDArray[np.float32]): The image plane to measure
         header (fits.Header | dict[str, Any]): Its header, for the beam and pixel scale
-        fft_bane_options (FFTBANEOptions | None, optional): Step, box, clip and seed. Defaults to ``FFTBANEOptions()``.
+        fft_bane_options (FFTBANEOptions | None, optional): Step, box, clip, seed and zero blanking. Defaults to ``FFTBANEOptions()``.
         kernel_func (Callable, optional): Kernel shape. Defaults to ``gaussian_kernel``.
         rms_estimator (Callable, optional): First-pass RMS estimator. Defaults to ``mad_std``.
 
@@ -343,9 +354,27 @@ def robust_bane(
     )
 
     nan_mask = ~np.isfinite(image)
+    if fft_bane_options.invalidate_zeros:
+        # linmos fills outside its primary beam cutoff with exact zeros rather
+        # than nans, and a measured zero is not a blank: it drags the seed
+        # median and mad_std below down towards zero, and past half the plane
+        # being blank it takes both to exactly zero, whereupon round one clips
+        # every pixel as a source and refills it with zero-scaled noise. The
+        # maps come back identically zero, which reads downstream as noiseless
+        nan_mask = nan_mask | (image == 0.0)
     valid = (~nan_mask).astype(np.float32)
     filled = np.where(nan_mask, 0.0, image).astype(np.float32)
     finite = image[~nan_mask].ravel()
+
+    if finite.size == 0:
+        # Nothing was measured, so there are no seeds to take a median and a
+        # mad_std of. Both would come back NaN off an empty slice and propagate
+        # to the same blank maps, but noisily, by way of a pair of numpy
+        # RuntimeWarnings. A plane blanked by linmos rather than by the beam
+        # cutoff reaches this once its zeros count as blank
+        logger.warning("Every pixel of the plane is blank, returning blank maps")
+        blank = np.full_like(image, np.nan, dtype=np.float32)
+        return blank, blank.copy()
 
     # The median matters: testing |image| rather than |image - background| makes
     # every pixel a source as soon as the plane carries a DC offset

--- a/flint/bane.py
+++ b/flint/bane.py
@@ -99,7 +99,11 @@ def fft_average(
     kernel_fft = _ft_kernel(kernel, shape=image_padded.shape)
     smooth = fft.irfft2(image_fft * kernel_fft, s=image_padded.shape) / kernel.sum()
 
-    return smooth[pad_x:-pad_x, pad_y:-pad_y]
+    # `_ft_kernel` pads from index zero, not about the origin, so the result
+    # comes back half a kernel along each axis
+    nx, ny = image.shape
+    start_x, start_y = pad_x + pad_x // 2, pad_y + pad_y // 2
+    return smooth[start_x : start_x + nx, start_y : start_y + ny]
 
 
 @nb.njit(
@@ -211,10 +215,8 @@ def _downsample_slices(
 ) -> tuple[slice, slice]:
     """Slices taking every `step_size_pix` pixel, trimmed to an even count.
 
-    The sampled region runs from `step_size_pix` to `length - step_size_pix`
-    while the zoom back up stretches it over the whole image. That is the likely
-    cause of the offset upstream records as a TODO; sampling half a cell in
-    instead measured worse, so this keeps upstream's grid.
+    These do not cover the plane, so `_to_full_resolution` reads them to put
+    the maps back where they were taken from.
     """
     slices = []
     for length in (shape[0], shape[1]):
@@ -225,12 +227,44 @@ def _downsample_slices(
     return slices[0], slices[1]
 
 
+def _to_full_resolution(
+    smoothed: NDArray[np.float32],
+    sampled_at: tuple[slice, slice],
+    shape: tuple[int, ...],
+) -> NDArray[np.float32]:
+    """Put a map measured on the downsampled grid back onto the plane's own grid.
+
+    An affine transform rather than `ndimage.zoom`, which takes a scale alone
+    and so cannot know the sampled grid starts a step in. Linear rather than a
+    spline, which overshoots the step a blank leaves in the map.
+
+    Args:
+        smoothed (NDArray[np.float32]): A map on the downsampled grid
+        sampled_at (tuple[slice, slice]): The slices that took that grid off the plane
+        shape (tuple[int, ...]): Shape of the plane to put it back on
+
+    Returns:
+        NDArray[np.float32]: The map on the plane's grid
+    """
+    # affine_transform reads `input[matrix @ output_index + offset]`, so this is
+    # the inverse of `sample k of axis i came from pixel start_i + k * step_i`
+    steps = np.array([axis.step for axis in sampled_at], dtype=np.float64)
+    starts = np.array([axis.start for axis in sampled_at], dtype=np.float64)
+    return ndimage.affine_transform(
+        smoothed,
+        matrix=1.0 / steps,
+        offset=-starts / steps,
+        output_shape=shape,
+        order=1,
+        mode="nearest",
+    )
+
+
 def _bane_round(
-    filled: NDArray[np.float32],
-    valid: NDArray[np.float32],
+    image: NDArray[np.float32],
     nan_mask: NDArray[np.bool_],
-    background: NDArray[np.float32],
-    rms: NDArray[np.float32],
+    background: NDArray[np.float32] | np.float32,
+    rms: NDArray[np.float32] | np.float32,
     kernel: NDArray[np.float32],
     step_size_pix: int,
     clip_sigma: float,
@@ -241,62 +275,91 @@ def _bane_round(
 
     The refill carries the local background: zero-mean noise would drag the
     background down wherever a source was removed.
+
+    ``background`` and ``rms`` are either maps or, for the first round, the one
+    number each that describes the whole plane.
     """
     with np.errstate(invalid="ignore", divide="ignore"):
-        source_mask = (np.abs(filled - background) / rms > clip_sigma) & ~nan_mask
+        # Built in place: the plain expression holds the difference, its
+        # absolute value and the ratio as three separate full-size temporaries.
+        # A blank compares however its stand-in value happens to fall - a NaN
+        # never exceeds the threshold, a linmos zero may - so the mask is
+        # cleared over them below rather than the plane being zero-filled first
+        deviation = image - background
+        np.abs(deviation, out=deviation)
+        deviation /= rms
+        source_mask = deviation > clip_sigma
+    del deviation
+    source_mask[nan_mask] = False
+
+    n_source = int(source_mask.sum())
     logger.info(
-        f"BANE round {round_number}: refilling {source_mask.sum()} "
-        f"({source_mask.sum() / filled.size * 100:0.1f}%) source pixels with noise"
+        f"BANE round {round_number}: refilling {n_source} "
+        f"({n_source / image.size * 100:0.1f}%) source pixels with noise"
     )
 
-    clipped = filled.copy()
+    # Blanked pixels have to hold zero: bane_fft normalises by the smoothed
+    # validity mask and assumes they contribute nothing. Built from `image` each
+    # round rather than from a zero-filled copy kept across both, which would be
+    # a second full-resolution plane held for the whole routine
+    clipped = np.where(nan_mask, np.float32(0.0), image)
+    # Round one clips against one number for the whole plane, round two against
+    # the maps round one made
+    at_source: NDArray[np.float32] | np.float32
+    rms_at_source: NDArray[np.float32] | np.float32
+    if isinstance(background, np.ndarray) and isinstance(rms, np.ndarray):
+        at_source, rms_at_source = background[source_mask], rms[source_mask]
+    else:
+        at_source, rms_at_source = background, rms
     clipped[source_mask] = (
-        background[source_mask]
-        + rng.normal(loc=0, scale=1, size=source_mask.sum()) * rms[source_mask]
+        at_source + rng.normal(loc=0, scale=1, size=n_source) * rms_at_source
     )
-    # Blanked pixels must stay at zero: bane_fft normalises by the smoothed
-    # validity mask and assumes they contribute nothing
-    clipped[nan_mask] = 0.0
 
-    zoom: tuple[float, float] | None = None
-    round_valid = valid
+    sampled_at: tuple[slice, slice] | None = None
+    full_shape = clipped.shape
     if step_size_pix > 0:
-        y_slice, x_slice = _downsample_slices(clipped.shape, step_size_pix)
-        zoom = (
-            clipped.shape[0] / clipped[y_slice, x_slice].shape[0],
-            clipped.shape[1] / clipped[y_slice, x_slice].shape[1],
-        )
-        clipped, round_valid = clipped[y_slice, x_slice], valid[y_slice, x_slice]
+        # Taken as contiguous copies here rather than as views handed to
+        # `bane_fft`, so the full-size `clipped` can be dropped below before the
+        # maps are put back on the plane's grid to replace it
+        y_slice, x_slice = _downsample_slices(full_shape, step_size_pix)
+        downsampled = np.ascontiguousarray(clipped[y_slice, x_slice])
+        # Built already downsampled: `bane_fft` is the only thing that wants a
+        # float32 validity mask, and at full resolution that is another copy of
+        # the whole plane
+        round_valid = (~nan_mask[y_slice, x_slice]).astype(np.float32)
+        sampled_at = (y_slice, x_slice)
+    else:
+        downsampled = np.ascontiguousarray(clipped)
+        round_valid = (~nan_mask).astype(np.float32)
 
     # pad_reflect is njit-ed without bounds checking, so a kernel wider than the
     # image reads off the end and returns quietly wrong maps rather than raising
-    if any(pad >= length for pad, length in zip(kernel.shape, clipped.shape)):
+    if any(pad >= length for pad, length in zip(kernel.shape, downsampled.shape)):
         msg = (
-            f"A {kernel.shape} kernel does not fit the {clipped.shape} image it "
+            f"A {kernel.shape} kernel does not fit the {downsampled.shape} image it "
             "smooths. Lower step_size so less is downsampled away, or box_size "
             "for a smaller kernel."
         )
         raise ValueError(msg)
 
-    background, rms = bane_fft(
-        np.ascontiguousarray(clipped), kernel, np.ascontiguousarray(round_valid)
-    )
-    background = np.nan_to_num(background, nan=0.0)
-    rms = np.nan_to_num(rms, nan=0.0)
+    del clipped, source_mask
 
-    if zoom is not None:
-        background = ndimage.zoom(
-            background, zoom, order=3, grid_mode=True, mode="reflect"
+    smooth_background, smooth_rms = bane_fft(downsampled, kernel, round_valid)
+    # In place throughout: both come straight out of bane_fft, so nothing else
+    # holds a view of them
+    np.nan_to_num(smooth_background, nan=0.0, copy=False)
+    np.nan_to_num(smooth_rms, nan=0.0, copy=False)
+
+    if sampled_at is not None:
+        smooth_background = _to_full_resolution(
+            smooth_background, sampled_at, full_shape
         )
-        rms = ndimage.zoom(rms, zoom, order=3, grid_mode=True, mode="reflect")
-        # The cubic spline rings across the step the nan_to_num above puts at
-        # the footprint edge, and undershoots to a negative noise. A negative
-        # error squares to a small positive variance, so an inverse-variance
-        # weight downstream comes out orders of magnitude too large rather than
-        # obviously wrong
-        rms = np.clip(rms, 0.0, None)
+        smooth_rms = _to_full_resolution(smooth_rms, sampled_at, full_shape)
+        # A guard: linear interpolation cannot undershoot, but a spline can, and
+        # a negative error squares to a small positive variance downstream
+        np.clip(smooth_rms, 0.0, None, out=smooth_rms)
 
-    return background, rms
+    return smooth_background, smooth_rms
 
 
 def _needs_a_beam(fft_bane_options: FFTBANEOptions) -> bool:
@@ -324,6 +387,11 @@ def robust_bane(
     ``fft_bane_options.invalidate_zeros`` is unset, those of exactly zero. A
     plane that is blank throughout gets blank maps, there being nothing to
     measure.
+
+    Peaks at roughly five times the plane, the two maps and the working copies
+    of the plane the rounds need. A worker measuring a channel of its own has to
+    fit that, not just the maps it hands back - a 6000x6000 float32 plane is
+    137 MB and peaks near 600 MB. ``tests/test_bane.py`` holds the multiple.
 
     Args:
         image (NDArray[np.float32]): The image plane to measure
@@ -353,6 +421,11 @@ def robust_bane(
         kernel_func=kernel_func,
     )
 
+    # The rounds below smooth the plane itself rather than a zero-filled copy of
+    # it, and ``bane_fft`` is compiled for float32 alone. A plane read from a
+    # FITS file is float32 already, so this is a view rather than a copy
+    image = np.asarray(image, dtype=np.float32)
+
     nan_mask = ~np.isfinite(image)
     if fft_bane_options.invalidate_zeros:
         # linmos fills outside its primary beam cutoff with exact zeros rather
@@ -361,11 +434,9 @@ def robust_bane(
         # being blank it takes both to exactly zero, whereupon round one clips
         # every pixel as a source and refills it with zero-scaled noise. The
         # maps come back identically zero, which reads downstream as noiseless
-        nan_mask = nan_mask | (image == 0.0)
-    valid = (~nan_mask).astype(np.float32)
-    filled = np.where(nan_mask, 0.0, image).astype(np.float32)
-    finite = image[~nan_mask].ravel()
+        nan_mask |= image == 0.0
 
+    finite = image[~nan_mask].ravel()
     if finite.size == 0:
         # Nothing was measured, so there are no seeds to take a median and a
         # mad_std of. Both would come back NaN off an empty slice and propagate
@@ -377,26 +448,30 @@ def robust_bane(
         return blank, blank.copy()
 
     # The median matters: testing |image| rather than |image - background| makes
-    # every pixel a source as soon as the plane carries a DC offset
-    background = np.full_like(filled, float(np.median(finite)))
-    rms = np.full_like(filled, float(rms_estimator(finite)))
+    # every pixel a source as soon as the plane carries a DC offset. Scalars,
+    # and dropped before the rounds: `finite` and the copy `rms_estimator` makes
+    # of it are each most of a plane
+    clip_against: tuple[
+        NDArray[np.float32] | np.float32, NDArray[np.float32] | np.float32
+    ] = (np.float32(np.median(finite)), np.float32(rms_estimator(finite)))
+    del finite
 
     # A mosaic's noise rises with the primary beam, so one threshold clips real
     # noise at the edge while missing faint sources in the middle
     rng = np.random.default_rng(fft_bane_options.seed)
     for round_number in (1, 2):
         background, rms = _bane_round(
-            filled=filled,
-            valid=valid,
+            image=image,
             nan_mask=nan_mask,
-            background=background,
-            rms=rms,
+            background=clip_against[0],
+            rms=clip_against[1],
             kernel=kernel,
             step_size_pix=step_size_pix,
             clip_sigma=fft_bane_options.clip_sigma,
             rng=rng,
             round_number=round_number,
         )
+        clip_against = (background, rms)
 
     background[nan_mask] = np.nan
     rms[nan_mask] = np.nan
@@ -412,6 +487,9 @@ def bane_fits_image(
 
     Named ``_bkg.fits`` and ``_rms.fits`` beside the input, as the aegean BANE
     names them, so the two are interchangeable downstream.
+
+    Runs as one task per channel, so a worker's memory has to cover the peak
+    ``robust_bane`` reaches - see there for the multiple of the plane it takes.
 
     Args:
         image (Path): Single-plane FITS image to measure

--- a/flint/coadd/linmos.py
+++ b/flint/coadd/linmos.py
@@ -9,6 +9,7 @@ from typing import Literal, NamedTuple
 
 import numpy as np
 from astropy.io import fits
+from astropy.stats import mad_std
 from capn_crunch import BaseOptions, add_options_to_parser, create_options_from_parser
 
 from flint.exceptions import ShapeMismatchError
@@ -278,38 +279,35 @@ def _get_image_weight_plane(
     Args:
         image_data (np.ndarray): Data to consider
         mode (str, optional): Statistic computation mode. Defaults to "mad".
-        stride (int, optional): Include every n'th pixel when computing the weight. '1' includes all pixels. Defaults to 1.
+        stride (int, optional): Include every n'th pixel when computing the weight. '1' includes all pixels. Defaults to 4.
 
     Raises:
-        ValueError: Raised when modes unknown
+        ValueError: Raised when mode is unknown
 
     Returns:
-        float: The inverse variance weight computerd
+        float: The inverse variance weight computed
     """
 
     weight_modes = ("mad", "std")
-    assert mode in weight_modes, (
-        f"Invalid {mode=} specified. Available modes: {weight_modes}"
-    )
+    if mode not in weight_modes:
+        raise ValueError(f"Invalid {mode=} specified. Available modes: {weight_modes}")
 
-    # remove non-finite numbers that would ruin the statistic
-    image_data = image_data[np.isfinite(image_data)][::stride]
+    # Drop non-finite values that would ruin the statistic
+    image_data = image_data[::stride]
+    image_data = image_data[np.isfinite(image_data)]
 
-    if np.all(~np.isfinite(image_data)):
+    if image_data.size == 0:
         return 0.0
 
     if mode == "mad":
-        median = np.median(image_data)
-        mad = np.median(np.abs(image_data - median))
-        weight = 1.0 / mad**2
-    elif mode == "std":
-        std = np.std(image_data)
-        weight = 1.0 / std**2
-    else:
-        raise ValueError(f"Invalid {mode=} specified. Available modes: {weight_modes}")
+        rms = mad_std(image_data, ignore_nan=True)
+    else:  # mode == "std"
+        rms = np.nanstd(image_data)
 
-    float_weight = float(weight)
-    return float_weight if np.isfinite(float_weight) else 0.0
+    # Force RMS to 0 if close
+    rms = 0.0 if np.isclose(rms, 0.0) else rms
+    weight = float(1.0 / (rms**2) if rms > 0.0 else 0.0)
+    return weight if np.isfinite(weight) else 0.0
 
 
 def get_image_weight(

--- a/flint/coadd/linmos.py
+++ b/flint/coadd/linmos.py
@@ -72,6 +72,19 @@ class BoundingBox(BaseOptions):
     original_shape: tuple[int, int]
     """The original shape of the image. If constructed against a cube this is the shape of a single plane."""
 
+    def clip(self) -> BoundingBox | None:
+        """Clip to ``original_shape``, or None if the box falls entirely off it
+
+        Returns:
+            BoundingBox | None: The clipped box, or None if nothing remains
+        """
+        ny, nx = self.original_shape
+        xmin, xmax = max(0, self.xmin), min(ny, self.xmax)
+        ymin, ymax = max(0, self.ymin), min(nx, self.ymax)
+        if xmin >= xmax or ymin >= ymax:
+            return None
+        return self.with_options(xmin=xmin, xmax=xmax, ymin=ymin, ymax=ymax)
+
 
 class LinmosParsetSummary(NamedTuple):
     """Container for key components around a linmos parset file"""

--- a/flint/coadd/linmos.py
+++ b/flint/coadd/linmos.py
@@ -58,7 +58,7 @@ class LinmosOptions(BaseOptions):
     """Delete the images that were coaddede together. Defaults to False."""
 
 
-class BoundingBox(NamedTuple):
+class BoundingBox(BaseOptions):
     """Simple container to represent a bounding box"""
 
     xmin: int

--- a/flint/configuration.py
+++ b/flint/configuration.py
@@ -353,6 +353,23 @@ def get_options_from_strategy(
         logger.debug(f"Updating options with {update_options=}")
         options.update(update_options)
 
+    if polarisation is not None and mode == "wsclean":
+        # Hardcoded to keep parallel imaging of all Stokes/MSs safe and to
+        # avoid spurious spectral fitting / source lists on Q, U and V.
+        hardcoded_options: dict[str, Any] = {"no_update_model_required": True}
+        if polarisation == "linear":
+            hardcoded_options["fit_spectral_pol"] = None
+        if polarisation in ("linear", "circular"):
+            hardcoded_options["save_source_list"] = False
+
+        for key, value in hardcoded_options.items():
+            if key in options and options[key] != value:
+                logger.warning(
+                    f"Requested {key}={options[key]!r} for {polarisation=} wsclean "
+                    f"options is not supported. Hardcoding to {value!r}."
+                )
+        options.update(hardcoded_options)
+
     return options
 
 

--- a/flint/configuration.py
+++ b/flint/configuration.py
@@ -17,6 +17,7 @@ from jolly_roger.tractor import TukeyTractorOptions
 from flint.imager.wsclean import WSCleanOptions
 from flint.logging import logger
 from flint.masking import MaskingOptions
+from flint.misc.holo import ConcatHoloOptions
 from flint.naming import add_timestamp_to_path
 from flint.options import (
     ArchiveOptions,
@@ -52,6 +53,7 @@ MODE_OPTIONS_MAPPING = {
     "tukeytractor": TukeyTractorOptions,
     "rmsynth": RMSynthOptions,
     "rmclean": RMCleanOptions,
+    "concatholo": ConcatHoloOptions,
 }
 POLARISATION_MAPPING = {
     "total": "i",

--- a/flint/configuration.py
+++ b/flint/configuration.py
@@ -23,6 +23,7 @@ from flint.options import (
     FitsCubeOptions,
     RMCleanOptions,
     RMSynthOptions,
+    SpiceOptions,
 )
 from flint.peel.potato import PotatoPeelOptions
 from flint.selfcal.casa import GainCalOptions
@@ -52,6 +53,7 @@ MODE_OPTIONS_MAPPING = {
     "tukeytractor": TukeyTractorOptions,
     "rmsynth": RMSynthOptions,
     "rmclean": RMCleanOptions,
+    "spice": SpiceOptions,
 }
 POLARISATION_MAPPING = {
     "total": "i",

--- a/flint/configuration.py
+++ b/flint/configuration.py
@@ -21,6 +21,7 @@ from flint.misc.holo import ConcatHoloOptions
 from flint.naming import add_timestamp_to_path
 from flint.options import (
     ArchiveOptions,
+    FFTBANEOptions,
     FitsCubeOptions,
     RMCleanOptions,
     RMSynthOptions,
@@ -54,6 +55,8 @@ MODE_OPTIONS_MAPPING = {
     "tukeytractor": TukeyTractorOptions,
     "rmsynth": RMSynthOptions,
     "rmclean": RMCleanOptions,
+    # "bane" is the containerised aegean BANE; this is the FFT one in flint.bane
+    "fftbane": FFTBANEOptions,
     "concatholo": ConcatHoloOptions,
     "spice": SpiceOptions,
 }

--- a/flint/configuration.py
+++ b/flint/configuration.py
@@ -18,7 +18,12 @@ from flint.imager.wsclean import WSCleanOptions
 from flint.logging import logger
 from flint.masking import MaskingOptions
 from flint.naming import add_timestamp_to_path
-from flint.options import ArchiveOptions, FitsCubeOptions
+from flint.options import (
+    ArchiveOptions,
+    FitsCubeOptions,
+    RMCleanOptions,
+    RMSynthOptions,
+)
 from flint.peel.potato import PotatoPeelOptions
 from flint.selfcal.casa import GainCalOptions
 from flint.source_finding.aegean import AegeanOptions, BANEOptions
@@ -33,7 +38,7 @@ from flint.source_finding.aegean import AegeanOptions, BANEOptions
 # Known headers must **always** be present in the strategy file
 KNOWN_HEADERS = ("defaults", "version")
 # Known options are optional, but if present must be in the correct format
-KNOWN_OPERATIONS = ("selfcal", "stokesv", "subtractcube", "polarisation")
+KNOWN_OPERATIONS = ("selfcal", "stokesv", "subtractcube", "polarisation", "rmsynth")
 FORMAT_VERSION = 0.2
 MODE_OPTIONS_MAPPING = {
     "wsclean": WSCleanOptions,
@@ -45,6 +50,8 @@ MODE_OPTIONS_MAPPING = {
     "potatopeel": PotatoPeelOptions,
     "fitscube": FitsCubeOptions,
     "tukeytractor": TukeyTractorOptions,
+    "rmsynth": RMSynthOptions,
+    "rmclean": RMCleanOptions,
 }
 POLARISATION_MAPPING = {
     "total": "i",

--- a/flint/convol.py
+++ b/flint/convol.py
@@ -542,6 +542,84 @@ def convolve_images(
     return return_conv_image_paths
 
 
+def blank_images(
+    image_paths: Collection[Path], convol_suffix: str = "conv"
+) -> list[Path]:
+    """Write an all-NaN copy of each image, marked with a zero beam.
+
+    This stands in for a convolution that cannot be done: a channel whose every
+    image is beyond the beam cutoff has no common beam to convolve to, and
+    copying the images at their own resolutions would have whatever they are
+    co-added into claim a beam that describes none of them. The zero beam is the
+    marker ``usable_beam_mask`` and ``fitscube`` both read as 'no PSF here'.
+
+    Args:
+        image_paths (Collection[Path]): The images to blank
+        convol_suffix (str, optional): The suffix added to .fits, matching the convolved images these stand in for. Defaults to 'conv'.
+
+    Returns:
+        list[Path]: The blanked images
+    """
+    blank_image_paths: list[Path] = []
+
+    for image_path in image_paths:
+        blank_image_path = Path(
+            str(image_path).replace(".fits", f".{convol_suffix}.fits")
+        )
+        logger.info(f"Blanking {image_path} into {blank_image_path=}")
+
+        with fits.open(image_path) as open_fits:
+            header = open_fits[0].header.copy()
+            data = np.full_like(open_fits[0].data, np.nan, dtype=np.float32)
+
+        for key in ("BMAJ", "BMIN", "BPA"):
+            header[key] = 0.0
+
+        fits.writeto(blank_image_path, data=data, header=header, overwrite=True)
+        blank_image_paths.append(blank_image_path)
+
+    return blank_image_paths
+
+
+def convolve_images_or_blank(
+    image_paths: Collection[Path],
+    beam_shape: BeamShape,
+    cutoff: float | None = None,
+    convol_suffix: str = "conv",
+) -> list[Path]:
+    """Convolve images to ``beam_shape``, or blank them when it does not describe
+    a beam.
+
+    ``convolve_images`` copies its inputs through untouched when handed a
+    non-finite ``beam_shape``, which is what ``get_common_beam`` returns when
+    every input is beyond the cutoff. For a set that is about to be co-added and
+    cubed that copy is worse than nothing: the images keep their own differing
+    resolutions and the product claims the first of them. Blank instead.
+
+    Args:
+        image_paths (Collection[Path]): The images to convolve
+        beam_shape (BeamShape): The resolution to convolve to
+        cutoff (float | None, optional): Images whose major axis exceeds this, in arcsec, are blanked. Defaults to no cutoff.
+        convol_suffix (str, optional): The suffix added to .fits to indicate a smoothed image. Defaults to 'conv'.
+
+    Returns:
+        list[Path]: The convolved (or blanked) images
+    """
+    if np.isfinite(beam_shape.bmaj_arcsec):
+        return convolve_images(
+            image_paths=image_paths,
+            beam_shape=beam_shape,
+            cutoff=cutoff,
+            convol_suffix=convol_suffix,
+        )
+
+    logger.info(
+        f"No common beam over {len(image_paths)} images, likely all beyond "
+        f"{cutoff=}. Blanking them rather than copying them through."
+    )
+    return blank_images(image_paths=image_paths, convol_suffix=convol_suffix)
+
+
 def get_parser() -> ArgumentParser:
     parser = ArgumentParser(description=__doc__)
 

--- a/flint/convol.py
+++ b/flint/convol.py
@@ -16,8 +16,10 @@ import numpy as np
 from astropy.io import fits
 from astropy.wcs import FITSFixedWarning
 from racs_tools import beamcon_2D, beamcon_3D
+from racs_tools.convolve_uv import my_ceil, round_up
 from radio_beam import Beam, Beams
 from radio_beam.beam import NoBeamException
+from radio_beam.utils import BeamError
 
 from flint.logging import logger
 
@@ -91,84 +93,223 @@ def _beams_from_cubes(cube_paths: list[Path]) -> Beams:
     )
 
 
-def cubes_share_common_beam(cube_paths: Collection[Path]) -> bool:
-    """Whether a single restoring beam describes every channel of every cube.
-    Cubes with no beam information at all have no resolution to make common.
+def usable_beam_mask(beams: Beams, cutoff: float | None = None) -> np.ndarray:
+    """Which beams describe a real PSF that may be brought to a common resolution.
+
+    Blank channels carry a placeholder beam rather than a real one, and a
+    channel coarser than ``cutoff`` is to be blanked rather than convolved to.
+    Neither constrains a common beam, and neither may be handed to
+    ``radio_beam``, whose common-beam solver reduces a set with no usable beam
+    in it to an empty sequence and raises an opaque ``argmax`` error.
+
+    Args:
+        beams (Beams): The beams to inspect
+        cutoff (float | None, optional): Beams whose major axis exceeds this, in arcsec, are not usable. Defaults to no cutoff.
+
+    Returns:
+        np.ndarray: Boolean mask, True where the beam is usable
+    """
+    major = np.asarray(beams.major.to(u.arcsecond).value, dtype=float)
+    minor = np.asarray(beams.minor.to(u.arcsecond).value, dtype=float)
+    pa = np.asarray(beams.pa.to(u.degree).value, dtype=float)
+
+    # A blank channel is marked with an exactly-zero beam (wsclean's convention
+    # for a plane with no fitted PSF) or, in a BEAMS table, with the positive
+    # sentinel `fitscube` writes there because CASA rejects a NaN. `> 0` alone
+    # would let the latter through and have a cube already at one beam
+    # reconvolved for the sake of its blank channels.
+    blank_beam_arcsec = float(np.finfo(np.float32).tiny)
+
+    usable = (
+        (major > blank_beam_arcsec)
+        & (minor > blank_beam_arcsec)
+        & np.isfinite(major)
+        & np.isfinite(minor)
+        & np.isfinite(pa)
+    )
+    if cutoff is not None:
+        usable &= major <= cutoff
+
+    return usable
+
+
+def beam_from_header(header: fits.Header) -> Beam | None:
+    """The restoring beam recorded in a FITS header, or None when there is none"""
+    try:
+        return Beam.from_fits_header(header)
+    except (NoBeamException, KeyError):
+        return None
+
+
+def header_beam_is_usable(header: fits.Header, cutoff: float | None = None) -> bool:
+    """Whether the beam a FITS header records is a real PSF. See ``usable_beam_mask``"""
+    beam = beam_from_header(header=header)
+    if beam is None:
+        return False
+
+    return bool(usable_beam_mask(beams=Beams(beams=[beam]), cutoff=cutoff)[0])
+
+
+def _cube_beams(cube_paths: Collection[Path]) -> Beams | None:
+    """Every channel beam of every cube, or None when there is no beam to read"""
+    try:
+        return _beams_from_cubes(cube_paths=list(cube_paths))
+    except NoBeamException:
+        logger.info(f"No beam information found among {list(cube_paths)=}")
+        return None
+
+
+def cubes_share_common_beam(
+    cube_paths: Collection[Path], cutoff: float | None = None
+) -> bool:
+    """Whether a single restoring beam already describes every channel of every
+    cube. Placeholder beams are ignored: a blanked channel holds no signal and
+    so has no resolution to make common. Cubes with no beam information at all,
+    or with nothing but placeholders, likewise have nothing to bring together.
+
+    A channel whose beam is coarser than ``cutoff`` is one to blank, which only
+    a convolution pass will do, so such a cube does not share a common beam.
 
     Args:
         cube_paths (Collection[Path]): The FITS cubes to inspect
+        cutoff (float | None, optional): Channels coarser than this, in arcsec, are to be blanked rather than convolved to. Defaults to no cutoff.
 
     Returns:
         bool: Whether the cubes are already at a common resolution
     """
-    cube_paths = list(cube_paths)
-    try:
-        beams = _beams_from_cubes(cube_paths=cube_paths)
-    except NoBeamException:
-        logger.info(f"No beam information found among {cube_paths=}")
+    beams = _cube_beams(cube_paths=cube_paths)
+    if beams is None:
         return True
 
-    return all(beam == beams[0] for beam in beams)
+    usable = usable_beam_mask(beams=beams, cutoff=cutoff)
+    if not usable.any():
+        logger.info(f"No usable restoring beam among {list(cube_paths)=}")
+        return True
+
+    # A real beam that the cutoff excludes is a channel to blank, which is work
+    # only the convolution pass does
+    if cutoff is not None and (usable_beam_mask(beams=beams) & ~usable).any():
+        return False
+
+    usable_beams = beams[usable]
+    return all(beam == usable_beams[0] for beam in usable_beams)
 
 
-def common_beam_from_cubes(cube_paths: Collection[Path]) -> Beam:
-    """The smallest beam that encompasses every channel of every cube.
+def common_beam_from_cubes(
+    cube_paths: Collection[Path], cutoff: float | None = None
+) -> Beam | None:
+    """The smallest beam that encompasses every usable channel of every cube.
 
     Args:
         cube_paths (Collection[Path]): The FITS cubes to inspect
+        cutoff (float | None, optional): Channels coarser than this, in arcsec, are left out of the common beam rather than dragging every channel out to their resolution. Defaults to no cutoff.
 
     Returns:
-        Beam: The beam every channel of every cube fits inside
+        Beam | None: The beam every usable channel fits inside, or None when no channel of any cube carries a real restoring beam
     """
-    return _beams_from_cubes(cube_paths=list(cube_paths)).common_beam()
+    beams = _cube_beams(cube_paths=cube_paths)
+    if beams is None:
+        return None
 
+    usable = usable_beam_mask(beams=beams, cutoff=cutoff)
+    if not usable.any():
+        logger.warning(
+            f"No usable restoring beam among {list(cube_paths)=}, so no common beam"
+        )
+        return None
 
-def convolve_cubes_to_common_beam(
-    cube_paths: Collection[Path],
-    output_path: Path | None = None,
-    convol_suffix: str = "conv",
-    cutoff: float | None = None,
-) -> list[Path]:
-    """Convolve every channel of every cube to the one smallest beam that
-    encompasses them all. New cubes are written and the inputs are left as they
-    are.
+    logger.info(f"Deriving a common beam from {usable.sum()} of {len(usable)} beams")
+    usable_beams = beams[usable]
+    try:
+        common_beam = usable_beams.common_beam()
+    except BeamError:
+        logger.warning(
+            "Could not find a common beam with the default tolerance, trying again"
+        )
+        common_beam = usable_beams.common_beam(tolerance=1e-5)
 
-    Args:
-        cube_paths (Collection[Path]): The FITS cubes to bring to one resolution
-        output_path (Path | None, optional): Directory the convolved cubes are written into. Defaults to alongside each input cube.
-        convol_suffix (str, optional): The suffix added to .fits to indicate a smoothed cube. Defaults to 'conv'.
-        cutoff (float | None, optional): Channels whose BMAJ exceeds this, in arcsec, are blanked and left out of the common beam, rather than dragging every channel out to their resolution. Defaults to no cutoff.
-
-    Returns:
-        list[Path]: The convolved cubes, in the order of ``cube_paths``
-    """
-    logger.info(f"Convolving {len(cube_paths)} cubes to a common resolution")
-    if output_path is not None:
-        output_path.mkdir(parents=True, exist_ok=True)
-
-    _, _, convolved_cubes = beamcon_3D.smooth_fits_cube(
-        infiles_list=list(cube_paths),
-        # 'total' is the one beam across all channels and all cubes that
-        # RM-synthesis needs, as opposed to 'natural's beam per channel
-        mode="total",
-        conv_mode="robust",
-        suffix=convol_suffix,
-        outdir=output_path,
-        cutoff=cutoff,
+    # The minimum enclosing ellipse radio_beam solves for sits right against the
+    # beams it encloses, so a channel whose own beam it barely covers can fail to
+    # deconvolve. Rounding up gives every channel the headroom to reach it, which
+    # is what racs_tools does with the common beams it derives itself.
+    return Beam(
+        major=my_ceil(common_beam.major.to(u.arcsecond).value, precision=1)
+        * u.arcsecond,
+        minor=my_ceil(common_beam.minor.to(u.arcsecond).value, precision=1)
+        * u.arcsecond,
+        pa=round_up(common_beam.pa.to(u.degree).value, decimals=2) * u.degree,
     )
 
-    # 'total' mode carries the input header's CASAMBM flag into a cube that now
-    # has one beam and no BEAMS table for a reader to find
-    for convolved_cube in convolved_cubes:
-        with fits.open(convolved_cube, mode="update") as open_fits:
-            open_fits[0].header.pop("CASAMBM", None)
 
-    # smooth_fits_cube sorts its inputs, so pair each output back to its input
-    convolved_by_name = {cube.name: cube for cube in convolved_cubes}
-    return [
-        convolved_by_name[Path(cube.name).with_suffix(f".{convol_suffix}.fits").name]
-        for cube in cube_paths
-    ]
+def common_beam_shape_from_cubes(
+    cube_paths: Collection[Path], cutoff: float | None = None
+) -> BeamShape:
+    """The common beam of a set of cubes, for a caller that cannot do without
+    one. See ``common_beam_from_cubes``.
+
+    Args:
+        cube_paths (Collection[Path]): The FITS cubes to inspect
+        cutoff (float | None, optional): Channels coarser than this, in arcsec, are left out of the common beam. Defaults to no cutoff.
+
+    Raises:
+        ValueError: If no channel of any cube carries a real restoring beam
+
+    Returns:
+        BeamShape: The beam every usable channel fits inside
+    """
+    common_beam = common_beam_from_cubes(cube_paths=cube_paths, cutoff=cutoff)
+    if common_beam is None:
+        msg = f"No usable restoring beam among {list(cube_paths)=}"
+        raise ValueError(msg)
+
+    return BeamShape.from_radio_beam(radio_beam=common_beam)
+
+
+def convolve_plane_to_beam(
+    plane: Path,
+    beam_shape: BeamShape,
+    cutoff: float | None = None,
+    convol_suffix: str = "conv",
+) -> Path:
+    """Convolve a single channel plane to ``beam_shape``, writing a new image
+    alongside it and leaving the input in place.
+
+    A plane coarser than ``cutoff`` is blanked rather than convolved, and its
+    output is marked with a zero beam so that the cube it is combined into
+    records that the channel holds no PSF.
+
+    Args:
+        plane (Path): The channel image to convolve
+        beam_shape (BeamShape): The resolution to convolve to
+        cutoff (float | None, optional): Planes whose major axis exceeds this, in arcsec, are blanked. Defaults to no cutoff.
+        convol_suffix (str, optional): The suffix added to .fits to indicate a smoothed image. Defaults to 'conv'.
+
+    Returns:
+        Path: The convolved (or blanked) image
+    """
+    convolved_plane = convolve_images(
+        image_paths=[plane],
+        beam_shape=beam_shape,
+        cutoff=cutoff,
+        convol_suffix=convol_suffix,
+    )[0]
+
+    header = fits.getheader(plane)
+    beyond_cutoff = header_beam_is_usable(header=header) and not header_beam_is_usable(
+        header=header, cutoff=cutoff
+    )
+    if not beyond_cutoff:
+        return convolved_plane
+
+    # racs_tools blanks the data of a plane beyond the cutoff but still stamps
+    # the target beam onto it, which would have the cube claim a PSF for a
+    # channel that holds none
+    logger.info(f"{plane=} is beyond {cutoff=}, marking {convolved_plane=} as blank")
+    with fits.open(convolved_plane, mode="update") as open_fits:
+        for key in ("BMAJ", "BMIN", "BPA"):
+            open_fits[0].header[key] = 0.0
+
+    return convolved_plane
 
 
 def get_cube_common_beam(
@@ -371,7 +512,7 @@ def convolve_images(
             str(image_path).replace(".fits", f".{convol_suffix}.fits")
         )
         header = fits.getheader(image_path)
-        if header["BMAJ"] == 0.0:
+        if not header_beam_is_usable(header=header):
             logger.info(f"Copying {image_path} to {convol_output_path=} for empty beam")
             copyfile(image_path, convol_output_path)
         else:

--- a/flint/convol.py
+++ b/flint/convol.py
@@ -17,6 +17,7 @@ from astropy.io import fits
 from astropy.wcs import FITSFixedWarning
 from racs_tools import beamcon_2D, beamcon_3D
 from radio_beam import Beam, Beams
+from radio_beam.beam import NoBeamException
 
 from flint.logging import logger
 
@@ -78,6 +79,96 @@ def check_if_cube_fits(fits_file: Path) -> bool:
         return False
 
     return len(squeeze_data.shape) == 3
+
+
+def _beams_from_cubes(cube_paths: list[Path]) -> Beams:
+    """Every channel beam of every cube, as one Beams"""
+    cube_data_list = beamcon_3D.make_data(
+        files=cube_paths, outdir=[cube_path.parent for cube_path in cube_paths]
+    )
+    return Beams(
+        beams=[beam for cube_data in cube_data_list for beam in cube_data.beams]
+    )
+
+
+def cubes_share_common_beam(cube_paths: Collection[Path]) -> bool:
+    """Whether a single restoring beam describes every channel of every cube.
+    Cubes with no beam information at all have no resolution to make common.
+
+    Args:
+        cube_paths (Collection[Path]): The FITS cubes to inspect
+
+    Returns:
+        bool: Whether the cubes are already at a common resolution
+    """
+    cube_paths = list(cube_paths)
+    try:
+        beams = _beams_from_cubes(cube_paths=cube_paths)
+    except NoBeamException:
+        logger.info(f"No beam information found among {cube_paths=}")
+        return True
+
+    return all(beam == beams[0] for beam in beams)
+
+
+def common_beam_from_cubes(cube_paths: Collection[Path]) -> Beam:
+    """The smallest beam that encompasses every channel of every cube.
+
+    Args:
+        cube_paths (Collection[Path]): The FITS cubes to inspect
+
+    Returns:
+        Beam: The beam every channel of every cube fits inside
+    """
+    return _beams_from_cubes(cube_paths=list(cube_paths)).common_beam()
+
+
+def convolve_cubes_to_common_beam(
+    cube_paths: Collection[Path],
+    output_path: Path | None = None,
+    convol_suffix: str = "conv",
+    cutoff: float | None = None,
+) -> list[Path]:
+    """Convolve every channel of every cube to the one smallest beam that
+    encompasses them all. New cubes are written and the inputs are left as they
+    are.
+
+    Args:
+        cube_paths (Collection[Path]): The FITS cubes to bring to one resolution
+        output_path (Path | None, optional): Directory the convolved cubes are written into. Defaults to alongside each input cube.
+        convol_suffix (str, optional): The suffix added to .fits to indicate a smoothed cube. Defaults to 'conv'.
+        cutoff (float | None, optional): Channels whose BMAJ exceeds this, in arcsec, are blanked and left out of the common beam, rather than dragging every channel out to their resolution. Defaults to no cutoff.
+
+    Returns:
+        list[Path]: The convolved cubes, in the order of ``cube_paths``
+    """
+    logger.info(f"Convolving {len(cube_paths)} cubes to a common resolution")
+    if output_path is not None:
+        output_path.mkdir(parents=True, exist_ok=True)
+
+    _, _, convolved_cubes = beamcon_3D.smooth_fits_cube(
+        infiles_list=list(cube_paths),
+        # 'total' is the one beam across all channels and all cubes that
+        # RM-synthesis needs, as opposed to 'natural's beam per channel
+        mode="total",
+        conv_mode="robust",
+        suffix=convol_suffix,
+        outdir=output_path,
+        cutoff=cutoff,
+    )
+
+    # 'total' mode carries the input header's CASAMBM flag into a cube that now
+    # has one beam and no BEAMS table for a reader to find
+    for convolved_cube in convolved_cubes:
+        with fits.open(convolved_cube, mode="update") as open_fits:
+            open_fits[0].header.pop("CASAMBM", None)
+
+    # smooth_fits_cube sorts its inputs, so pair each output back to its input
+    convolved_by_name = {cube.name: cube for cube in convolved_cubes}
+    return [
+        convolved_by_name[Path(cube.name).with_suffix(f".{convol_suffix}.fits").name]
+        for cube in cube_paths
+    ]
 
 
 def get_cube_common_beam(

--- a/flint/convol.py
+++ b/flint/convol.py
@@ -9,7 +9,7 @@ from argparse import ArgumentParser
 from collections.abc import Collection
 from pathlib import Path
 from shutil import copyfile
-from typing import Literal, NamedTuple
+from typing import Any, Literal, NamedTuple
 
 import astropy.units as u
 import numpy as np
@@ -133,7 +133,7 @@ def usable_beam_mask(beams: Beams, cutoff: float | None = None) -> np.ndarray:
     return usable
 
 
-def beam_from_header(header: fits.Header) -> Beam | None:
+def beam_from_header(header: fits.Header | dict[str, Any]) -> Beam | None:
     """The restoring beam recorded in a FITS header, or None when there is none"""
     try:
         return Beam.from_fits_header(header)
@@ -141,7 +141,9 @@ def beam_from_header(header: fits.Header) -> Beam | None:
         return None
 
 
-def header_beam_is_usable(header: fits.Header, cutoff: float | None = None) -> bool:
+def header_beam_is_usable(
+    header: fits.Header | dict[str, Any], cutoff: float | None = None
+) -> bool:
     """Whether the beam a FITS header records is a real PSF. See ``usable_beam_mask``"""
     beam = beam_from_header(header=header)
     if beam is None:

--- a/flint/data/tests/test_config_pol.yaml
+++ b/flint/data/tests/test_config_pol.yaml
@@ -108,3 +108,10 @@ polarisation:
       squared_channel_joining: true
   circular:
     wsclean: {}
+
+rmsynth:
+  rmsynth:
+    phi_max_radm2: 1000.0
+  rmclean:
+    auto_mask: 7
+    auto_threshold: 1

--- a/flint/data/tests/test_config_pol.yaml
+++ b/flint/data/tests/test_config_pol.yaml
@@ -107,6 +107,7 @@ polarisation:
   total:
     wsclean:
       squared_channel_joining: false
+      flint_save_mfs_products: true
   linear:
     wsclean:
       join_polarizations: true

--- a/flint/data/tests/test_config_pol.yaml
+++ b/flint/data/tests/test_config_pol.yaml
@@ -118,6 +118,10 @@ polarisation:
 rmsynth:
   rmsynth:
     phi_max_radm2: 1000.0
+    # 'auto', 'per_pixel', or a lambda^2 in m^2
+    lam_sq_0_m2: auto
   rmclean:
     auto_mask: 7
     auto_threshold: 1
+    # Any of: dirty, clean, model
+    peak_products: []

--- a/flint/data/tests/test_config_pol.yaml
+++ b/flint/data/tests/test_config_pol.yaml
@@ -123,5 +123,3 @@ rmsynth:
   rmclean:
     auto_mask: 7
     auto_threshold: 1
-    # Any of: dirty, clean, model
-    peak_products: []

--- a/flint/imager/channel_division.py
+++ b/flint/imager/channel_division.py
@@ -24,7 +24,7 @@ a partition gives a candidate; the least padded, most uniform one is returned.
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 from astropy import units as u
@@ -311,3 +311,24 @@ def channel_division_for_beams(
         channels_out=channels_out,
         size_tolerance=size_tolerance,
     )
+
+
+def apply_cube_division(
+    update_wsclean_options: dict[Any, Any], cube_division: ChannelDivision
+) -> dict[Any, Any]:
+    """Replace the strategy channel division with a solved one. A division set
+    explicitly in the strategy wins, so a known good grid can be pinned."""
+    if update_wsclean_options.get("channel_division_frequencies") is not None:
+        logger.info(
+            "Strategy specifies channel_division_frequencies, not using the solved division"
+        )
+        return update_wsclean_options
+
+    logger.info(
+        f"Imaging with the solved channel division, {cube_division.channels_out=}"
+    )
+    return {
+        **update_wsclean_options,
+        "channels_out": cube_division.channels_out,
+        "channel_division_frequencies": cube_division.channel_division_frequencies,
+    }

--- a/flint/imager/wsclean.py
+++ b/flint/imager/wsclean.py
@@ -209,6 +209,8 @@ class WSCleanOptions(BaseOptions):
     # Options below here are not added to wsclean command
     flint_no_log_wsclean_output: bool = False
     """If True do not log the wsclean output"""
+    flint_name_suffix: str | None = None
+    """An additional trailing token appended to the constructed wsclean ``-name``, e.g. to disambiguate outputs from different pipelines imaging the same measurement set"""
 
 
 class WSCleanResult(BaseOptions):
@@ -878,6 +880,7 @@ def create_wsclean_name_argument(
         pol=pol,
         channel_range=channel_range,
         scan_range=scan_range,
+        name_suffix=wsclean_options_dict.get("flint_name_suffix"),
     )
 
     # Now resolve the directory part

--- a/flint/imager/wsclean.py
+++ b/flint/imager/wsclean.py
@@ -482,13 +482,14 @@ def transpose_and_sort_channel_images(
     return [list(channel_group) for channel_group in zip(*sorted_beams)]
 
 
-def split_cube_into_planes(cube: Path) -> list[Path]:
+def split_cube_into_planes(cube: Path, output_path: Path | None = None) -> list[Path]:
     """Extract each channel of a FITS cube into its own image, named following the
     flint processed name format so that the planes may be regrouped across beams
     by ``transpose_and_sort_channel_images``.
 
     Args:
         cube (Path): The FITS cube to split apart
+        output_path (Path | None, optional): Directory the planes are written into. Only the flint name fields are retained, so cubes that share them (e.g. an image cube and its weights) need separate directories. Defaults to alongside ``cube``.
 
     Returns:
         list[Path]: The per-channel images extracted from ``cube``
@@ -513,6 +514,9 @@ def split_cube_into_planes(cube: Path) -> list[Path]:
         msg = f"Expected a flint named cube. Got {cube=}"
         raise NamingException(msg)
 
+    if output_path is not None:
+        output_path.mkdir(parents=True, exist_ok=True)
+
     with fits.open(cube, memmap=True, lazy_load_hdus=True) as open_fits:
         header = open_fits[0].header
     channels = int(header[f"NAXIS{find_target_axis(header=header).axis}"])
@@ -525,7 +529,7 @@ def split_cube_into_planes(cube: Path) -> list[Path]:
             processed_name_components=components._replace(
                 channel_range=(channel, channel)
             ),
-            parent_path=cube.parent,
+            parent_path=cube.parent if output_path is None else output_path,
         )
         return Path(f"{plane_base}.fits")
 

--- a/flint/imager/wsclean.py
+++ b/flint/imager/wsclean.py
@@ -22,7 +22,7 @@ from collections.abc import Collection
 from glob import glob
 from numbers import Number
 from pathlib import Path
-from typing import Any, Literal, NamedTuple
+from typing import Any, NamedTuple
 
 import numpy as np
 from astropy.io import fits
@@ -299,6 +299,7 @@ def combine_images_to_cube(
         bounding_box=fitscube_options.bounding_box
         if bounding_box is None
         else bounding_box,
+        create_blanks=fitscube_options.create_blanks,
     )
     rotate_cube(output_cube_name, inplace=fitscube_options.inplace)
 
@@ -1218,10 +1219,7 @@ def rotate_cube(output_cube_path: str | Path, inplace: bool = True) -> Path:
 
 def combine_image_set_to_cube(
     image_set: ImageSet,
-    remove_original_images: bool = False,
-    inplace: bool = True,
-    compress: bool = False,
-    compress_method: Literal["gzip", "pgzip"] = "pgzip",
+    fitscube_options: FitsCubeOptions,
 ) -> ImageSet:
     """Combine wsclean subband channel images into a cube. Each collection attribute
     of the input `image_set` will be inspected. The MFS images will be ignored.
@@ -1230,11 +1228,7 @@ def combine_image_set_to_cube(
 
     Args:
         image_set (ImageSet): Collection of wsclean image productds
-        remove_original_images (bool, optional): If True, images that went into the cube are removed. Defaults to False.
-        inplace (bool, optional): If True, modify the file in-place. If False, write to a temporary file and
-        then replace the original. Default True
-        compress (bool, optional): Gzip-compress each cube once written. Defaults to False.
-        compress_method (Literal["gzip", "pgzip"], optional): Compression backend used when `compress` is set. Defaults to "pgzip".
+        fitscube_options (FitsCubeOptions): Options to control the cube creation, forwarded to ``combine_images_to_cube`` for each mode
 
     Returns:
         ImageSet: Updated iamgeset describing the new outputs
@@ -1262,34 +1256,16 @@ def combine_image_set_to_cube(
             logger.info(f"Not enough subband images for {mode=}, not creating a cube")
             continue
 
-        output_cube_name = create_image_cube_name(
-            image_prefix=Path(image_set.prefix), mode=mode
+        output_cube_name = combine_images_to_cube(
+            images=subband_images,
+            prefix=str(image_set.prefix),
+            mode=mode,
+            fitscube_options=fitscube_options,
         )
 
-        logger.info(f"Combining {len(subband_images)} images. {subband_images=}")
-        freqs = combine_fits(
-            file_list=subband_images, out_cube=output_cube_name, create_blanks=True
-        )
-
-        rotate_cube(output_cube_name, inplace=inplace)
-
-        # Write out the hdu to preserve the beam table constructed in fitscube
-        logger.info(f"Writing {output_cube_name=}")
-
-        output_freqs_name = Path(output_cube_name).with_suffix(".freqs_Hz.txt")
-        np.savetxt(output_freqs_name, freqs.to("Hz").value)
-
-        if compress:
-            output_cube_name = compress_cube(
-                Path(output_cube_name), method=compress_method
-            )
-
-        image_set_dict[mode] = [Path(output_cube_name)] + [
+        image_set_dict[mode] = [output_cube_name] + [
             image for image in image_set_dict[mode] if image not in subband_images
         ]
-
-        if remove_original_images:
-            remove_files_folders(*subband_images)
 
     return ImageSet(**image_set_dict)
 
@@ -1464,10 +1440,7 @@ def run_wsclean_imager(
             fitscube_options = FitsCubeOptions()
         image_set = combine_image_set_to_cube(
             image_set=image_set,
-            remove_original_images=fitscube_options.remove_original_images,
-            inplace=fitscube_options.inplace,
-            compress=fitscube_options.compress,
-            compress_method=fitscube_options.compress_method,
+            fitscube_options=fitscube_options,
         )
 
     image_set = rename_wsclean_prefix_in_image_set(input_image_set=image_set)

--- a/flint/imager/wsclean.py
+++ b/flint/imager/wsclean.py
@@ -575,15 +575,12 @@ def get_wsclean_output_source_list_path(
 
 
 def _rename_wsclean_title(name_str: str) -> str:
-    """Construct and apply a regular expression that aims to identify
-    the wsclean appended properties string within a file and replace
-    the `-` separator with a `.`.
+    """Identify the wsclean-appended properties suffix at the end of a file
+    name and rewrite it with `.` separators instead of `-`.
 
-    Rather than blindly swapping every `-` for `.` across the matched
-    span, the wsclean-appended fields (polarisation, sub-band/MFS index,
-    multiscale term, image type) are captured by name and the replacement
-    is rebuilt from those fields directly. This avoids relying on the
-    matched span containing only `-` characters that are safe to swap.
+    The suffix's fields (polarisation, sub-band/MFS index, multiscale term,
+    image type) are captured by name and the dot-separated replacement is
+    built directly from those fields.
 
     Args:
         name_str (str): The name that will be extracted and modified
@@ -606,12 +603,15 @@ def _rename_wsclean_title(name_str: str) -> str:
     # sure that the ch0000-0001 field is not captured. For example:
     # SB57516.RACS_0929-81.beam35.round4.i.ch0287-0288-image.fits
     # would be inadvertently picked up and replaced. The [0-9]{4}
-    # we are testing for are the channel indicator when --channel-out is used
+    # we are testing for are the channel indicator when --channel-out is used.
+    # The trailing look ahead anchors the image type to the end of the name
+    # (before an optional .fits) so that a project field matching a reserved
+    # word, e.g. .project-image., is not picked up instead.
     search_re = (
         r"(?:-(?P<pol>i|q|u|v|xx|xy|yx|yy))?"
         r"(?:-(?P<mfs>MFS)|-(?P<chidx>(?<!ch[0-9]{4}-)[0-9]{4}))?"
         r"(?:-(?P<term>t[0-9]{5}))?"
-        r"-(?P<image_type>image|dirty|model|residual|psf)"
+        r"-(?P<image_type>image|dirty|model|residual|psf)(?=\.fits$|$)"
     )
     match_re = re.compile(search_re)
 
@@ -621,9 +621,8 @@ def _rename_wsclean_title(name_str: str) -> str:
     if result is None:
         return name_str
 
-    # Map each wsclean-named component onto its flint-processed name field
-    # (pol, channel index, image type) and rebuild the dot-separated form
-    # from those fields, rather than replacing every `-` in the matched span.
+    # Build the dot-separated suffix from the named fields (pol, channel
+    # index, image type) rather than the raw matched text.
     groups = result.groupdict()
     fields = (
         groups["pol"],

--- a/flint/imager/wsclean.py
+++ b/flint/imager/wsclean.py
@@ -295,6 +295,7 @@ def combine_images_to_cube(
     freqs = combine_fits(
         file_list=images,
         out_cube=output_cube_name,
+        max_workers=fitscube_options.max_workers,
         invalidate_zeros=fitscube_options.invalidate_zeros,
         bounding_box=fitscube_options.bounding_box
         if bounding_box is None

--- a/flint/imager/wsclean.py
+++ b/flint/imager/wsclean.py
@@ -578,9 +578,13 @@ def _rename_wsclean_title(name_str: str) -> str:
     """Identify the wsclean-appended properties suffix at the end of a file
     name and rewrite it with `.` separators instead of `-`.
 
-    The suffix's fields (polarisation, sub-band/MFS index, multiscale term,
+    The suffix's fields (polarisation, sub-band/MFS index, timestep,
     image type) are captured by name and the dot-separated replacement is
-    built directly from those fields.
+    built directly from those fields. The sub-band and timestep indices are
+    reformatted as flint's canonical ``ch<lo>-<hi>``/``scan<lo>-<hi>`` ranges
+    (exclusive upper bound) rather than the bare wsclean index, so that
+    ``ProcessedNameComponents.channel_range``/``scan_range`` parse them
+    consistently with every other flint-named path.
 
     Args:
         name_str (str): The name that will be extracted and modified
@@ -610,7 +614,7 @@ def _rename_wsclean_title(name_str: str) -> str:
     search_re = (
         r"(?:-(?P<pol>i|q|u|v|xx|xy|yx|yy))?"
         r"(?:-(?P<mfs>MFS)|-(?P<chidx>(?<!ch[0-9]{4}-)[0-9]{4}))?"
-        r"(?:-(?P<term>t[0-9]{5}))?"
+        r"(?:-(?P<time>t[0-9]{5}))?"
         r"-(?P<image_type>image|dirty|model|residual|psf)(?=\.fits$|$)"
     )
     match_re = re.compile(search_re)
@@ -622,12 +626,26 @@ def _rename_wsclean_title(name_str: str) -> str:
         return name_str
 
     # Build the dot-separated suffix from the named fields (pol, channel
-    # index, image type) rather than the raw matched text.
+    # index, timestep, image type) rather than the raw matched text. The
+    # channel/timestep index is reformatted into flint's ch<lo>-<hi>/
+    # scan<lo>-<hi> range convention (exclusive upper bound) so it parses
+    # back out as a proper ProcessedNameComponents.channel_range/scan_range
+    # instead of the ambiguous bare wsclean index.
     groups = result.groupdict()
+    chan_field = (
+        f"ch{int(groups['chidx']):04d}-{int(groups['chidx']) + 1:04d}"
+        if groups["chidx"]
+        else groups["mfs"]
+    )
+    time_field = (
+        f"scan{int(groups['time'][1:]):04d}-{int(groups['time'][1:]) + 1:04d}"
+        if groups["time"]
+        else None
+    )
     fields = (
         groups["pol"],
-        groups["mfs"] or groups["chidx"],
-        groups["term"],
+        chan_field,
+        time_field,
         groups["image_type"],
     )
     new_suffix = "." + ".".join(field for field in fields if field)

--- a/flint/imager/wsclean.py
+++ b/flint/imager/wsclean.py
@@ -211,6 +211,8 @@ class WSCleanOptions(BaseOptions):
     """If True do not log the wsclean output"""
     flint_name_suffix: str | None = None
     """An additional trailing token appended to the constructed wsclean ``-name``, e.g. to disambiguate outputs from different pipelines imaging the same measurement set"""
+    flint_save_mfs_products: bool = False
+    """Save the MFS image, model and residual products (co-added and leakage-corrected the same way as the science image), rather than just the image"""
 
 
 class WSCleanResult(BaseOptions):
@@ -1330,6 +1332,7 @@ def run_wsclean_imager(
     container: Path,
     make_cube_from_subbands: bool = True,
     fitscube_options: FitsCubeOptions | None = None,
+    extra_output_types: tuple[str, ...] | None = None,
 ) -> ImageSet:
     """Run a provided wsclean command. Optionally will clean up files,
     including the dirty beams, psfs and other assorted things.
@@ -1346,6 +1349,7 @@ def run_wsclean_imager(
         move_hold_directories (Optional[Tuple[Path,Optional[Path]]], optional): The `move_directory` and `hold_directory` passed to the temporary context manager. If None no `hold_then_move_into` manager is used. Defaults to None.
         make_cube_from_subbands (bool, optional): Form a single FITS cube from the set of sub-band images wsclean produces. Defaults to False.
         image_prefix_str (Optional[str], optional): The name used to search for wsclean outputs. If None, it is guessed from the name and location of the MS. Defaults to None.
+        extra_output_types (tuple[str, ...] | None, optional): Additional output types (beyond ``image``/``residual``) to search for and attach to the returned ``ImageSet``, e.g. ``("model",)``. Defaults to None.
 
     Returns:
         ImageSet: The executed wsclean output products.
@@ -1424,7 +1428,7 @@ def run_wsclean_imager(
         subbands=wsclean_result.options.channels_out,
         pols=pols,
         verify_exists=True,
-        output_types=("image", "residual"),
+        output_types=("image", "residual", *(extra_output_types or ())),
         check_exists_when_adding=True,
     )
 
@@ -1457,6 +1461,7 @@ def wsclean_imager(
     update_wsclean_options: dict[str, Any] | None = None,
     update_fitscube_options: dict[str, Any] | None = None,
     make_cube_from_subbands: bool = True,
+    extra_output_types: tuple[str, ...] | None = None,
 ) -> WSCleanResult:
     """Create and run a wsclean imager command against a measurement set.
 
@@ -1505,6 +1510,7 @@ def wsclean_imager(
         container=wsclean_container,
         fitscube_options=fitscube_options,
         make_cube_from_subbands=make_cube_from_subbands,
+        extra_output_types=extra_output_types,
     )
 
     return wsclean_result.with_options(image_set=image_set)

--- a/flint/imager/wsclean.py
+++ b/flint/imager/wsclean.py
@@ -880,7 +880,7 @@ def create_wsclean_name_argument(
         pol=pol,
         channel_range=channel_range,
         scan_range=scan_range,
-        name_suffix=wsclean_options_dict.get("flint_name_suffix"),
+        project=wsclean_options_dict.get("flint_name_suffix"),
     )
 
     # Now resolve the directory part

--- a/flint/imager/wsclean.py
+++ b/flint/imager/wsclean.py
@@ -579,8 +579,11 @@ def _rename_wsclean_title(name_str: str) -> str:
     the wsclean appended properties string within a file and replace
     the `-` separator with a `.`.
 
-    A simple replace of all `-` with `.` may not be ideal if the
-    character has been used on purpose.
+    Rather than blindly swapping every `-` for `.` across the matched
+    span, the wsclean-appended fields (polarisation, sub-band/MFS index,
+    multiscale term, image type) are captured by name and the replacement
+    is rebuilt from those fields directly. This avoids relying on the
+    matched span containing only `-` characters that are safe to swap.
 
     Args:
         name_str (str): The name that will be extracted and modified
@@ -592,9 +595,9 @@ def _rename_wsclean_title(name_str: str) -> str:
     # The following should replace the .qu with .q or .u whilst removing the -Q and -U
     logger.info(f"Renaming {name_str=} for qu components if necessary")
     name_str = re.sub(
-        r"(\.qu)-([^-]+)-?([QU])?(\-(psf|image|dirty|model|residual)\.fits)",
+        r"(\.qu)-(?P<chan>[^-]+)-?(?P<qu_pol>[QU])?(?P<tail>-(?:psf|image|dirty|model|residual)\.fits)",
         lambda m: (
-            f".{m.group(3).lower() if m.group(3) else 'q'}-{m.group(2)}{m.group(4)}"
+            f".{m['qu_pol'].lower() if m['qu_pol'] else 'q'}-{m['chan']}{m['tail']}"
         ),
         name_str,
     )
@@ -604,7 +607,12 @@ def _rename_wsclean_title(name_str: str) -> str:
     # SB57516.RACS_0929-81.beam35.round4.i.ch0287-0288-image.fits
     # would be inadvertently picked up and replaced. The [0-9]{4}
     # we are testing for are the channel indicator when --channel-out is used
-    search_re = r"(-(i|q|u|v|xx|xy|yx|yy))?(-(MFS|(?<!ch[0-9]{4}-)[0-9]{4}))?(-t[0-9]{5})?-(image|dirty|model|residual|psf)"
+    search_re = (
+        r"(?:-(?P<pol>i|q|u|v|xx|xy|yx|yy))?"
+        r"(?:-(?P<mfs>MFS)|-(?P<chidx>(?<!ch[0-9]{4}-)[0-9]{4}))?"
+        r"(?:-(?P<term>t[0-9]{5}))?"
+        r"-(?P<image_type>image|dirty|model|residual|psf)"
+    )
     match_re = re.compile(search_re)
 
     logger.info(f"Searching {name_str=} for wsclean added filename components")
@@ -613,7 +621,19 @@ def _rename_wsclean_title(name_str: str) -> str:
     if result is None:
         return name_str
 
-    name = name_str.replace(result[0], result[0].replace("-", "."))
+    # Map each wsclean-named component onto its flint-processed name field
+    # (pol, channel index, image type) and rebuild the dot-separated form
+    # from those fields, rather than replacing every `-` in the matched span.
+    groups = result.groupdict()
+    fields = (
+        groups["pol"],
+        groups["mfs"] or groups["chidx"],
+        groups["term"],
+        groups["image_type"],
+    )
+    new_suffix = "." + ".".join(field for field in fields if field)
+
+    name = name_str.replace(result[0], new_suffix)
 
     return name
 

--- a/flint/imager/wsclean.py
+++ b/flint/imager/wsclean.py
@@ -356,6 +356,16 @@ def merge_image_sets(
 
     logger.info(f"Merged image set: {image_set_dict=}")
 
+    source_lists = image_set_dict.get("source_list", None)
+    if (
+        source_lists is not None
+        and isinstance(source_lists, list)
+        and len(source_lists) > 1
+    ):
+        msg = f"Multiple source lists found in merged image set: {source_lists}. Only the first will be used."
+        logger.warning(msg)
+        image_set_dict["source_list"] = source_lists[0]
+
     return ImageSet(**image_set_dict)
 
 

--- a/flint/imager/wsclean.py
+++ b/flint/imager/wsclean.py
@@ -1089,22 +1089,15 @@ def create_wsclean_cmd(
 
 
 def rotate_cube(output_cube_path: str | Path, inplace: bool = True) -> Path:
-    """
-    Rotate the FITS cube axes to a shape of (chan, pol, dec, ra)
-    which is what yandasoft linmos tasks expect.
+    """Rotate the FITS cube axes to a shape of (chan, pol, dec, ra)
+    # which is what yandasoft linmos tasks expect.
 
-    Parameters
-    ----------
-    output_cube_path : str | Path
-        Path to the FITS cube to rotate.
-    inplace : bool, optional
-        If True, modify the file in-place. If False, write to a temporary file and
-        then replace the original. Default True
+    Args:
+        output_cube_path (str | Path): Path to the FITS cube to rotate.
+        inplace (bool, optional): If True, modify the file in-place. If False, write to a temporary file and then replace the original. Defaults to True.
 
-    Returns
-    -------
-    Path
-        Path to the rotated FITS cube.
+    Returns:
+        Path: Path to the rotated FITS cube.
     """
     output_path = Path(output_cube_path)
     logger.info(f"Rotating FITS axes of {output_path.name}")

--- a/flint/imager/wsclean.py
+++ b/flint/imager/wsclean.py
@@ -594,7 +594,7 @@ def _rename_wsclean_title(name_str: str) -> str:
     # SB57516.RACS_0929-81.beam35.round4.i.ch0287-0288-image.fits
     # would be inadvertently picked up and replaced. The [0-9]{4}
     # we are testing for are the channel indicator when --channel-out is used
-    search_re = r"(-(i|q|u|v|xx|xy|yx|yy))?(-(MFS|(<!ch[0-9]{4}-[0-9]{4})[0-9]{4}))?(-t[0-9]{5})?-(image|dirty|model|residual|psf)"
+    search_re = r"(-(i|q|u|v|xx|xy|yx|yy))?(-(MFS|(?<!ch[0-9]{4}-)[0-9]{4}))?(-t[0-9]{5})?-(image|dirty|model|residual|psf)"
     match_re = re.compile(search_re)
 
     logger.info(f"Searching {name_str=} for wsclean added filename components")

--- a/flint/imager/wsclean.py
+++ b/flint/imager/wsclean.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import re
 import socket
+import time
 from argparse import ArgumentParser
 from collections.abc import Collection
 from glob import glob
@@ -34,8 +35,13 @@ from capn_crunch import (
 )
 from fitscube.bounding_box import BoundingBox
 from fitscube.combine_fits import combine_fits, compress_cube
-from fitscube.exceptions import TargetAxisMissingException
-from fitscube.extract import ExtractOptions, extract_plane_from_cube, find_target_axis
+from fitscube.exceptions import ShapeMismatchException, TargetAxisMissingException
+from fitscube.extract import (
+    ExtractPlanesOptions,
+    count_cube_planes,
+    extract_planes_from_cube,
+    find_target_axis,
+)
 
 from flint.exceptions import (
     AttemptRerunException,
@@ -243,27 +249,6 @@ def image_set_from_result(wsclean_result: WSCleanResult) -> ImageSet | None:
     return wsclean_result.image_set
 
 
-def assert_common_pixel_grid(images: Collection[Path]) -> None:
-    """Ensure a set of images all share the same spatial pixel grid.
-
-    ``fitscube`` writes each plane into the cube at a fixed byte offset, so
-    planes of differing shape are silently interleaved rather than rejected.
-
-    Args:
-        images (Collection[Path]): The images that will be stacked into a cube
-
-    Raises:
-        ShapeMismatchError: If the images do not share a common NAXIS1/NAXIS2
-    """
-    shapes = {
-        (header["NAXIS1"], header["NAXIS2"])
-        for header in (fits.getheader(image) for image in images)
-    }
-    if len(shapes) > 1:
-        msg = f"Images to be cubed have differing pixel grids: {shapes=}"
-        raise ShapeMismatchError(msg)
-
-
 def combine_images_to_cube(
     images: list[Path],
     prefix: str,
@@ -291,25 +276,33 @@ def combine_images_to_cube(
     logger.info("Combining subband images into fits cubes")
     logger.info(f"Running on {socket.gethostname()=}")
 
-    assert_common_pixel_grid(images=images)
-
     output_cube_name = create_image_cube_name(image_prefix=Path(prefix), mode=mode)
 
-    logger.info(f"Combining {len(images)} images. {images=}")
-    freqs = combine_fits(
-        file_list=images,
-        out_cube=output_cube_name,
-        max_workers=fitscube_options.max_workers,
-        invalidate_zeros=fitscube_options.invalidate_zeros,
-        bounding_box=fitscube_options.bounding_box
-        if bounding_box is None
-        else bounding_box,
-        create_blanks=fitscube_options.create_blanks,
+    logger.info(f"Combining {len(images)} images into {output_cube_name}")
+    logger.debug(f"{images=}")
+    start = time.perf_counter()
+    # fitscube checks the pixel grids itself, in parallel, before it writes
+    # anything, so there is no need to walk every header again first
+    try:
+        freqs = combine_fits(
+            file_list=images,
+            out_cube=output_cube_name,
+            max_workers=fitscube_options.max_workers,
+            invalidate_zeros=fitscube_options.invalidate_zeros,
+            bounding_box=fitscube_options.bounding_box
+            if bounding_box is None
+            else bounding_box,
+            create_blanks=fitscube_options.create_blanks,
+        )
+    except ShapeMismatchException as e:
+        msg = f"Images to be cubed have differing pixel grids: {e}"
+        raise ShapeMismatchError(msg) from e
+    logger.info(
+        f"Combined {len(images)} images into {output_cube_name.name} in "
+        f"{time.perf_counter() - start:.0f}s"
     )
-    rotate_cube(output_cube_name, inplace=fitscube_options.inplace)
 
-    # Write out the hdu to preserve the beam table constructed in fitscube
-    logger.info(f"Writing {output_cube_name=}")
+    rotate_cube(output_cube_name, inplace=fitscube_options.inplace)
 
     output_freqs_name = output_cube_name.with_suffix(".freqs_Hz.txt")
     np.savetxt(output_freqs_name, freqs.to("Hz").value)
@@ -318,8 +311,12 @@ def combine_images_to_cube(
         remove_files_folders(*images)
 
     if fitscube_options.compress:
+        start = time.perf_counter()
         output_cube_name = compress_cube(
             output_cube_name, method=fitscube_options.compress_method
+        )
+        logger.info(
+            f"Compressed to {output_cube_name.name} in {time.perf_counter() - start:.0f}s"
         )
 
     return output_cube_name
@@ -484,7 +481,9 @@ def transpose_and_sort_channel_images(
     return [list(channel_group) for channel_group in zip(*sorted_beams)]
 
 
-def split_cube_into_planes(cube: Path, output_path: Path | None = None) -> list[Path]:
+def split_cube_into_planes(
+    cube: Path, output_path: Path | None = None, num_workers: int = 4
+) -> list[Path]:
     """Extract each channel of a FITS cube into its own image, named following the
     flint processed name format so that the planes may be regrouped across beams
     by ``transpose_and_sort_channel_images``.
@@ -492,21 +491,22 @@ def split_cube_into_planes(cube: Path, output_path: Path | None = None) -> list[
     Args:
         cube (Path): The FITS cube to split apart
         output_path (Path | None, optional): Directory the planes are written into. Only the flint name fields are retained, so cubes that share them (e.g. an image cube and its weights) need separate directories. Defaults to alongside ``cube``.
+        num_workers (int, optional): Planes written at once. Defaults to 4.
 
     Returns:
         list[Path]: The per-channel images extracted from ``cube``
 
     Raises:
-        NotSupportedError: If ``cube`` is gzip-compressed. Splitting reopens
-            the cube once per channel, and astropy cannot memmap a gzip file,
-            so each reopen decompresses the entire cube into memory. Set
-            ``FitsCubeOptions.compress=False`` for cubes that get split.
+        NotSupportedError: If ``cube`` is gzip-compressed, as astropy cannot
+            memmap a compressed FITS file and would decompress the whole cube
+            into memory. Set ``FitsCubeOptions.compress=False`` for cubes that
+            get split.
     """
     if cube.suffix == ".gz":
         msg = (
             f"{cube=} is gzip-compressed and cannot be split into planes: "
-            "astropy cannot memmap a compressed FITS file, so each of the "
-            "per-channel reads would decompress the whole cube into memory. "
+            "astropy cannot memmap a compressed FITS file, so the per-channel "
+            "reads would decompress the whole cube into memory. "
             "Disable FitsCubeOptions.compress for cubes that will be split."
         )
         raise NotSupportedError(msg)
@@ -519,11 +519,6 @@ def split_cube_into_planes(cube: Path, output_path: Path | None = None) -> list[
     if output_path is not None:
         output_path.mkdir(parents=True, exist_ok=True)
 
-    with fits.open(cube, memmap=True, lazy_load_hdus=True) as open_fits:
-        header = open_fits[0].header
-    channels = int(header[f"NAXIS{find_target_axis(header=header).axis}"])
-    logger.info(f"Splitting {cube} into {channels} planes")
-
     def _plane_path(channel: int) -> Path:
         # Only the flint name fields are retained, so a single cube per beam
         # should be split at a time to avoid clobbering planes
@@ -535,15 +530,17 @@ def split_cube_into_planes(cube: Path, output_path: Path | None = None) -> list[
         )
         return Path(f"{plane_base}.fits")
 
-    return [
-        extract_plane_from_cube(
-            fits_cube=cube,
-            extract_options=ExtractOptions(
-                channel_index=channel, output_path=_plane_path(channel), overwrite=True
-            ),
-        )
-        for channel in range(channels)
-    ]
+    channels = count_cube_planes(header=fits.getheader(cube))
+    logger.info(f"Splitting {cube} into {channels} planes")
+
+    return extract_planes_from_cube(
+        cube,
+        ExtractPlanesOptions(
+            output_paths=[_plane_path(channel) for channel in range(channels)],
+            overwrite=True,
+            max_workers=num_workers,
+        ),
+    )
 
 
 def get_wsclean_output_source_list_path(

--- a/flint/imager/wsclean.py
+++ b/flint/imager/wsclean.py
@@ -17,6 +17,7 @@ with a ``.``.
 from __future__ import annotations
 
 import re
+import socket
 from argparse import ArgumentParser
 from collections.abc import Collection
 from glob import glob
@@ -288,6 +289,7 @@ def combine_images_to_cube(
         Path: The path to the created FITS cube
     """
     logger.info("Combining subband images into fits cubes")
+    logger.info(f"Running on {socket.gethostname()=}")
 
     assert_common_pixel_grid(images=images)
 

--- a/flint/misc/holo.py
+++ b/flint/misc/holo.py
@@ -23,10 +23,13 @@ from flint.logging import logger
 class ConcatHoloOptions(BaseOptions):
     """Options to use to concatenate holography cubes today"""
 
-    output_path: Path
+    output_path: Path | None = None
     """Output holography cube to make"""
-    holo_cubes: tuple[Path, ...]
-    """The path to the holography IQUV cubes to concatenate together"""
+    holo_cubes: tuple[Path, ...] = ()
+    """The path to the holography IQUV cubes to concatenate together. No sensible
+    default exists (it always names specific input cubes); an empty tuple is a
+    placeholder that must be overridden before calling ``concatenate_holography``,
+    which raises if it is left unset"""
     max_workers: int = 8
     """The maximum number of sub-processes that may be spawned"""
 
@@ -531,6 +534,12 @@ def concatenate_holography(concat_holo_options: ConcatHoloOptions) -> Path:
     Returns:
         Path: Path to the output cube formed
     """
+
+    if concat_holo_options.output_path is None or not concat_holo_options.holo_cubes:
+        raise ValueError(
+            "concat_holo_options.output_path and holo_cubes are placeholder "
+            f"defaults and must be set, got {concat_holo_options=}"
+        )
 
     logger.info("Attempting to concatenate holography cubes")
     logger.info(f"Running on host {gethostname()}")

--- a/flint/ms.py
+++ b/flint/ms.py
@@ -15,7 +15,7 @@ from contextlib import contextmanager
 from curses.ascii import controlnames
 from os import PathLike
 from pathlib import Path
-from typing import cast
+from typing import TypeAlias, cast
 
 import astropy.units as u
 import numpy as np
@@ -1015,6 +1015,10 @@ def rename_ms_and_columns_for_selfcal(
     )
 
     return ms.with_options(path=target, column=data)
+
+
+MSsByBeam: TypeAlias = tuple[tuple[MS, ...], ...]
+"""Per-beam groups of MS (e.g. one group per beam, each containing the MS/s that make up that beam)"""
 
 
 def find_mss(

--- a/flint/naming.py
+++ b/flint/naming.py
@@ -275,7 +275,7 @@ def create_imaging_name_prefix(
     pol: str | None = None,
     channel_range: tuple[int, int] | None = None,
     scan_range: tuple[int, int] | None = None,
-    name_suffix: str | None = None,
+    project: str | None = None,
 ) -> str:
     """Given a measurement set and a polarisation, create the naming prefix to be used
     by some imager
@@ -285,21 +285,31 @@ def create_imaging_name_prefix(
         pol (Optional[str], optional): Whether a polarsation is being considered. Defaults to None.
         channel_range (Optional[Tuple[int,int]], optional): The channel range that is going to be imaged. Defaults to none.
         scan_range (Optional[Tuple[int,int]], optional): The scan range that is going to be imaged. Defaults to none.
-        name_suffix (Optional[str], optional): An additional trailing token appended to the name, e.g. to disambiguate which pipeline produced the image. Defaults to None.
+        project (Optional[str], optional): The project name to include in the naming. Defaults to None.
 
     Returns:
         str: The constructed string name
     """
 
-    names = [ms_path.stem]
+    name = ms_path.stem
+    processed_name_components = processed_ms_format(in_name=name)
+    if project is not None:
+        assert processed_name_components is not None, (
+            f"Processed name format failed for {name=}"
+        )
+        processed_name_components = processed_name_components._replace(project=project)
+        name = create_path_from_processed_name_components(
+            processed_name_components=processed_name_components
+        ).name
+
+    names = [name]
+
     if pol is not None:
         names.append(f"{pol.lower()}")
     if channel_range is not None:
         names.append(f"ch{channel_range[0]:04}-{channel_range[1]:04}")
     if scan_range is not None:
         names.append(f"scan{scan_range[0]:04}-{scan_range[1]:04}")
-    if name_suffix is not None:
-        names.append(name_suffix)
 
     return ".".join(names)
 

--- a/flint/naming.py
+++ b/flint/naming.py
@@ -545,6 +545,8 @@ class ProcessedNameComponents(NamedTuple):
     """The sbid of the observation"""
     field: str
     """The name of the field extracted"""
+    project: str | None = None
+    """A specialised project name that might be encoded in the file name. This is not always present. """
     beam: str | None = None
     """The beam of the observation processed"""
     spw: str | None = None
@@ -581,6 +583,7 @@ def processed_ms_format(
     regex = re.compile(
         r"^SB(?P<sbid>[0-9]+)"
         r"\.(?P<field>[^.]+)"
+        r"((\.project-(?P<project>[a-zA-Z0-9]+))?)"
         r"((\.beam(?P<beam>[0-9]+))?)"
         r"((\.spw(?P<spw>[0-9]+))?)"
         r"((\.round(?P<round>[0-9]+))?)"
@@ -606,6 +609,7 @@ def processed_ms_format(
     return ProcessedNameComponents(
         sbid=groups["sbid"],
         field=groups["field"],
+        project=groups["project"],
         beam=groups["beam"],
         spw=groups["spw"],
         round=groups["round"],
@@ -635,6 +639,8 @@ def create_path_from_processed_name_components(
         components.append(f"SB{processed_name_components.sbid}")
     if processed_name_components.field is not None:
         components.append(processed_name_components.field)
+    if processed_name_components.project is not None:
+        components.append(f"project-{processed_name_components.project}")
     if processed_name_components.beam is not None:
         components.append(f"beam{int(processed_name_components.beam):02d}")
     if processed_name_components.spw is not None:

--- a/flint/naming.py
+++ b/flint/naming.py
@@ -586,6 +586,7 @@ def processed_ms_format(
         r"((\.round(?P<round>[0-9]+))?)"
         r"((\.(?P<pol>(i|q|u|v|xx|yy|xy|yx)+))?)"
         r"((\.ch(?P<chl>([0-9]+))-(?P<chh>([0-9]+)))?)"
+        r"((\.(?P<chidx>[0-9]{4}))?)"
         r"((\.scan(?P<scanl>([0-9]+))-(?P<scanh>([0-9]+)))?)"
     )
     results = regex.match(in_name)
@@ -598,7 +599,15 @@ def processed_ms_format(
 
     logger.debug(f"Matched groups are: {groups}")
 
-    channel_range = (int(groups["chl"]), int(groups["chh"])) if groups["chl"] else None
+    # chidx catches wsclean's own bare per-channel index (e.g. ``.0000``), used
+    # when channels are imaged individually without being grouped into a flint
+    # ch<lo>-<hi> range (see _rename_wsclean_title)
+    if groups["chl"]:
+        channel_range = (int(groups["chl"]), int(groups["chh"]))
+    elif groups["chidx"]:
+        channel_range = (int(groups["chidx"]), int(groups["chidx"]))
+    else:
+        channel_range = None
     scan_range = (
         (int(groups["scanl"]), int(groups["scanh"])) if groups["scanl"] else None
     )

--- a/flint/naming.py
+++ b/flint/naming.py
@@ -275,6 +275,7 @@ def create_imaging_name_prefix(
     pol: str | None = None,
     channel_range: tuple[int, int] | None = None,
     scan_range: tuple[int, int] | None = None,
+    name_suffix: str | None = None,
 ) -> str:
     """Given a measurement set and a polarisation, create the naming prefix to be used
     by some imager
@@ -284,6 +285,7 @@ def create_imaging_name_prefix(
         pol (Optional[str], optional): Whether a polarsation is being considered. Defaults to None.
         channel_range (Optional[Tuple[int,int]], optional): The channel range that is going to be imaged. Defaults to none.
         scan_range (Optional[Tuple[int,int]], optional): The scan range that is going to be imaged. Defaults to none.
+        name_suffix (Optional[str], optional): An additional trailing token appended to the name, e.g. to disambiguate which pipeline produced the image. Defaults to None.
 
     Returns:
         str: The constructed string name
@@ -296,6 +298,8 @@ def create_imaging_name_prefix(
         names.append(f"ch{channel_range[0]:04}-{channel_range[1]:04}")
     if scan_range is not None:
         names.append(f"scan{scan_range[0]:04}-{scan_range[1]:04}")
+    if name_suffix is not None:
+        names.append(name_suffix)
 
     return ".".join(names)
 

--- a/flint/options.py
+++ b/flint/options.py
@@ -17,6 +17,7 @@ import yaml
 from astropy.coordinates import EarthLocation, SkyCoord
 from astropy.time import Time
 from capn_crunch import BaseOptions
+from pydantic import create_model
 
 from flint.exceptions import MSError
 from flint.logging import logger
@@ -313,12 +314,36 @@ class RACSAllOptions(BaseOptions):
 def racs_all_options_to_pol_field_options(
     racs_all_options: RACSAllOptions,
 ) -> PolFieldOptions:
-    """Build a ``PolFieldOptions`` from the fields of ``RACSAllOptions`` that share
-    a name and meaning between the two (containers, beam/pb cutoffs, etc). Fields
-    that only exist on ``PolFieldOptions`` are left at their default."""
+    """Build a default ``PolFieldOptions`` from the fields of ``RACSAllOptions`` that
+    share a name and meaning between the two (containers, beam/pb cutoffs, etc).
+    Fields that only exist on ``PolFieldOptions`` are left at their default. Used
+    when a caller does not supply its own ``PolFieldOptions`` (e.g. calling the
+    racs-all flow directly rather than through its CLI, where every
+    ``PolFieldOptions`` field is exposed)."""
     shared_fields = set(RACSAllOptions.model_fields) & set(PolFieldOptions.model_fields)
     return PolFieldOptions(
         **{name: getattr(racs_all_options, name) for name in shared_fields}
+    )
+
+
+def pol_field_options_cli_class(
+    racs_all_options_class: type[RACSAllOptions] = RACSAllOptions,
+) -> type[PolFieldOptions]:
+    """Build a ``PolFieldOptions`` subclass containing only the fields not already
+    present on ``RACSAllOptions``, so it can be added to the same CLI parser without
+    duplicate flags for the fields the two share. Every current and future
+    ``PolFieldOptions`` field is exposed on the CLI this way, either through this
+    class or through ``RACSAllOptions`` itself for the shared ones."""
+    overlap = set(racs_all_options_class.model_fields) & set(
+        PolFieldOptions.model_fields
+    )
+    unique_fields = {
+        name: (field.annotation, field)
+        for name, field in PolFieldOptions.model_fields.items()
+        if name not in overlap
+    }
+    return create_model(
+        "PolFieldOptionsCLI", __base__=PolFieldOptions.__base__, **unique_fields
     )
 
 

--- a/flint/options.py
+++ b/flint/options.py
@@ -10,7 +10,7 @@ hold stateful properties throughout the flint codebase.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Protocol
+from typing import Literal, Protocol
 
 import numpy as np
 import yaml
@@ -236,6 +236,65 @@ class PolFieldOptions(BaseOptions):
     """Path to a FLINT imaging yaml file that contains settings to use throughout imaging"""
     sbid_copy_path: Path | None = None
     """Path that final processed products will be copied into. If None no copying of file products is performed. See ArchiveOptions. """
+    run_rmsynth: bool = False
+    """Run RM-synthesis (and optionally RM-CLEAN) on the Stokes Q/U cubes once created. Requires 'linear' to have been imaged."""
+    rmsynth_cube_products: list[Literal["dirty", "clean", "model"]] = []
+    """Which Faraday dispersion function (FDF) cubes to write as FITS. 'dirty' is the raw FDF (no RM-CLEAN needed). 'clean'/'model' are RM-CLEAN's cleaned/clean-component FDF (RM-CLEAN is run if either is requested). Empty by default, as these cubes are large."""
+    rmsynth_moment_products: list[Literal["dirty", "clean", "model"]] = ["clean"]
+    """Which FDF(s) to compute Faraday moment maps (mom0=polarised intensity, mom1=mean Faraday depth, mom2=Faraday depth dispersion) from. 'clean' is the usual choice; 'dirty' moments are noise-biased; 'model' moments describe just the clean components."""
+
+
+class RMSynthOptions(BaseOptions):
+    """Options controlling ``rm_lite.tools_3d.rmsynth.rmsynth_3d_from_fits``.
+
+    Defined here rather than in ``flint.rmsynth`` so that strategy validation
+    (``flint.configuration``) does not need to import ``rm_lite``, an optional
+    dependency.
+    """
+
+    phi_max_radm2: float | None = None
+    """Maximum Faraday depth to synthesise, in rad/m^2"""
+    d_phi_radm2: float | None = None
+    """Faraday depth resolution, in rad/m^2"""
+    n_samples: float | None = 10.0
+    """Number of samples across the RMSF"""
+    weight_type: Literal["variance", "natural", "uniform", "uniform_lsq", "briggs"] = (
+        "variance"
+    )
+    """Per-channel weighting scheme used during RM-synthesis"""
+    robust: float | None = None
+    """Briggs robust parameter, required if weight_type is 'briggs'"""
+    nufft_nthreads: int = 1
+    """finufft OpenMP threads per dask chunk"""
+    target_chunk_mb: float = 256
+    """Target per-chunk memory footprint, in MB, when reading the Q/U cubes"""
+    fit_order: int = 2
+    """Stokes I fractional-polarisation fit order; negative iterates orders and picks the best by AIC"""
+    fit_function: Literal["log", "linear"] = "log"
+    """Stokes I fit function: 'log' is a power law, 'linear' is a polynomial"""
+    stokes_i_snr_cut: float | None = 5.0
+    """Below this frequency-averaged Stokes I SNR a pixel falls back to a flat model. None fits every pixel"""
+    estimate_stokes_i_noise: bool = False
+    """Derive a per-channel Stokes I error from the Stokes I cube when fitting the fractional-polarisation model"""
+
+
+class RMCleanOptions(BaseOptions):
+    """Options controlling ``rm_lite.tools_3d.rmclean.run_rmclean_from_synth``.
+    See ``RMSynthOptions`` for why this lives here rather than ``flint.rmsynth``.
+    """
+
+    auto_mask: float = 7
+    """Masking threshold in SNR, scaled by the theoretical FDF noise"""
+    auto_threshold: float = 1
+    """Cleaning threshold in SNR, scaled by the theoretical FDF noise"""
+    max_iter: int = 100_000
+    """Maximum CLEAN iterations"""
+    gain: float = 0.1
+    """CLEAN loop gain"""
+    moment_threshold_snr: float = 5.0
+    """SNR cut (times the theoretical FDF noise) applied before computing Faraday moment maps"""
+    multiscale: bool = False
+    """Use multiscale RM-CLEAN, which can recover Faraday-thick structure"""
 
 
 class RACSAllOptions(BaseOptions):

--- a/flint/options.py
+++ b/flint/options.py
@@ -17,7 +17,7 @@ import yaml
 from astropy.coordinates import EarthLocation, SkyCoord
 from astropy.time import Time
 from capn_crunch import BaseOptions
-from pydantic import create_model, model_validator
+from pydantic import create_model
 
 from flint.exceptions import MSError
 from flint.logging import logger
@@ -277,6 +277,7 @@ class RMSynthOptions(BaseOptions):
     """Median filter size (pixels) used by mom0 debiasing"""
     per_pixel_rmsf: bool = False
     """ Compute the RMSF for each pixel in the cube """
+
 
 class RMCleanOptions(BaseOptions):
     """Options controlling ``rm_lite.tools_3d.rmclean.run_rmclean_from_synth``.

--- a/flint/options.py
+++ b/flint/options.py
@@ -9,15 +9,16 @@ hold stateful properties throughout the flint codebase.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from pathlib import Path
-from typing import Literal, Protocol
+from typing import Annotated, Literal, Protocol, Self, TypeAlias
 
 import numpy as np
 import yaml
 from astropy.coordinates import EarthLocation, SkyCoord
 from astropy.time import Time
 from capn_crunch import BaseOptions
-from pydantic import create_model
+from pydantic import Field, create_model
 
 from flint.exceptions import MSError
 from flint.logging import logger
@@ -229,12 +230,84 @@ class PolFieldOptions(BaseOptions):
     """Specify the final beamsize of linmos field images in (arcsec, arcsec, deg)"""
     pb_cutoff: float = 0.1
     """Primary beam attenuation cutoff to use during linmos"""
+    bane_noise: bool = False
+    """Measure a background and RMS cube off the co-added planes with BANE. Parameters come from the strategy's ``fftbane`` mode. Independent of ``RMSynthFieldOptions.bane_noise``"""
     imaging_strategy: Path | None = None
     """Path to a FLINT imaging yaml file that contains settings to use throughout imaging"""
     pol_cube_channel_width: float | None = None
     """Desired width, in Hz, of each plane of the polarisation cubes. The wsclean channel division is solved for this target so the cubes have a single linear frequency axis, overriding the strategy ``channels_out``. Deliberately separate from ``RACSAllOptions.cube_channel_width``, as the continuum and polarisation cubes need not share a channelisation. See ``flint.imager.channel_division``"""
     sbid_copy_path: Path | None = None
     """Path that final processed products will be copied into. If None no copying of file products is performed. See ArchiveOptions. """
+
+
+class FFTBANEOptions(BaseOptions):
+    """Options for ``flint.bane.robust_bane``. Lives here, not in ``flint.bane``,
+    so strategy validation does not pull in numba"""
+
+    step_size: int | None = None
+    """Downsampling factor in pixels. None uses 3 beams; a negative value sets the beams per step"""
+    box_size: int | None = None
+    """Convolution kernel size in pixels. None uses 10 beams; a negative value sets the beams per box"""
+    clip_sigma: float = 5.0
+    """Pixels above this SNR are replaced by noise before the background is fitted"""
+    seed: int = 1234
+    """Seeds the noise clipped pixels are filled with, so a rerun reproduces the maps"""
+
+
+class _CubesForRMSynth(BaseOptions):
+    """The Stokes RM-synthesis reads: Q and U, and I for the fractional
+    correction. No V, which has no part in a Faraday spectrum.
+
+    Never annotate with this: the types below exist to be told apart.
+    """
+
+    q_path: Path
+    """Stokes Q"""
+    u_path: Path
+    """Stokes U"""
+    i_path: Path | None = None
+    """Stokes I, optional: rm-synthesis runs without it"""
+
+    @classmethod
+    def from_mapping(cls, cubes: Mapping[str, Path]) -> Self:
+        """From a per-Stokes dict, dropping anything but q/u/i"""
+        missing = {"q", "u"} - cubes.keys()
+        if missing:
+            msg = f"Need a cube for every one of q and u, missing {sorted(missing)}."
+            raise ValueError(msg)
+        return cls(q_path=cubes["q"], u_path=cubes["u"], i_path=cubes.get("i"))
+
+    @property
+    def paths(self) -> list[Path]:
+        """Every path set"""
+        return [
+            path for path in (self.q_path, self.u_path, self.i_path) if path is not None
+        ]
+
+
+class CubesForRMSynth(_CubesForRMSynth):
+    """The Stokes image cubes"""
+
+
+class WeightCubesForRMSynth(_CubesForRMSynth):
+    """Inverse variance, 1/sigma**2, as linmos writes it"""
+
+    kind: Literal["weight"] = "weight"
+    """Union discriminator"""
+
+
+class NoiseCubesForRMSynth(_CubesForRMSynth):
+    """Noise, sigma, as BANE measures it"""
+
+    kind: Literal["noise"] = "noise"
+    """Union discriminator"""
+
+
+ErrorCubesForRMSynth: TypeAlias = Annotated[
+    WeightCubesForRMSynth | NoiseCubesForRMSynth, Field(discriminator="kind")
+]
+"""A weight or a noise, never both. Confusing them inverts the noise by 1/sigma**2,
+so the tag keeps them apart across the serialisation prefect does to task inputs."""
 
 
 class RMSynthOptions(BaseOptions):
@@ -296,10 +369,6 @@ class RMCleanOptions(BaseOptions):
     """Maximum CLEAN iterations"""
     gain: float = 0.1
     """CLEAN loop gain"""
-    moment_threshold_snr: float = 5.0
-    """SNR cut (times the theoretical FDF noise) applied before computing Faraday moment maps, the dirty ones included"""
-    peak_threshold_snr: float = 0.0
-    """SNR cut (times the theoretical FDF noise) below which FDF peak statistics are blanked. Zero applies no cut: unlike mom0, a peak is a single sample with no noise floor to integrate, and peak_pi_error is written beside it to judge significance downstream"""
 
 
 class SpiceOptions(BaseOptions):
@@ -349,18 +418,12 @@ class RMSynthFieldOptions(BaseOptions):
     algorithm parameters, which are drawn from ``imaging_strategy`` rather
     than exposed here."""
 
-    stokes_q_cube: Path | None = None
-    """Path to the Stokes Q FITS cube. Computed by the racs-all flow, so required only when running this pipeline standalone"""
-    stokes_u_cube: Path | None = None
-    """Path to the Stokes U FITS cube. Computed by the racs-all flow, so required only when running this pipeline standalone"""
-    stokes_i_cube: Path | None = None
-    """Path to a Stokes I FITS cube, used to fit a per-pixel fractional-polarisation correction. Defaults to None."""
-    stokes_q_weight_cube: Path | None = None
-    """Path to Stokes Q weights cube produced by LINMOS"""
-    stokes_u_weight_cube: Path | None = None
-    """Path to Stokes U weights cube produced by LINMOS"""
-    stokes_i_weight_cube: Path | None = None
-    """Path to Stokes I weights cube produced by LINMOS"""
+    stokes_cubes: CubesForRMSynth | None = None
+    """The Stokes cubes. Set by the racs-all flow"""
+    error_cubes: ErrorCubesForRMSynth | None = None
+    """Weight or noise cubes, never both. None lets rm-lite estimate from Q/U itself"""
+    bane_noise: bool = False
+    """Measure BANE cubes off the common-resolution cubes and take the FDF noise from the RMS. Parameters come from the strategy's ``fftbane`` mode. Supersedes ``error_cubes``, which describe the unconvolved inputs"""
     imaging_strategy: Path | None = None
     """Path to a FLINT imaging yaml file that contains the RMSynthOptions/RMCleanOptions settings to use"""
     beam_cutoff: float | None = None
@@ -369,6 +432,10 @@ class RMSynthFieldOptions(BaseOptions):
     """Which Faraday dispersion function (FDF) cubes to write as FITS. Nothing by default, as these cubes can be large."""
     moment_products: list[Literal["dirty", "clean", "model"]] = ["clean"]
     """Which FDF(s) to compute Faraday moment maps from."""
+    moment_threshold_snr: float = 5.0
+    """SNR cut (times the theoretical FDF noise) applied before the moment maps are computed, the dirty ones included"""
+    peak_threshold_snr: float = 0.0
+    """SNR cut (times the theoretical FDF noise) below which peak statistics are blanked. Zero applies no cut: a peak is a single sample with no noise floor to integrate, and peak_pi_error is written beside it"""
     peak_products: list[Literal["dirty", "clean", "model"]] = []
     """Which FDF(s) to measure peak statistics from: peak polarised intensity (raw and debiased), Faraday depth, polarisation angle and intrinsic angle, each with its error. Nine (ny, nx) maps per FDF, so empty by default -- at 16032^2 that is ~9 GB per entry"""
     output_path: Path | None = None
@@ -386,7 +453,7 @@ class SpiceFieldOptions(BaseOptions):
     cubes: list[Path] = []
     """Stokes image cubes to trim and compress. Computed by the racs-all flow, so required only when running this pipeline standalone"""
     weight_cubes: list[Path] = []
-    """LINMOS weight cubes to trim and compress alongside ``cubes``, spiced with the same boxes so they stay on a matching grid. Computed by the racs-all flow"""
+    """Ancillary cubes to trim and compress alongside ``cubes``, spiced with the same boxes so they stay on a matching grid: the LINMOS weight cubes, and the BANE background/RMS cubes when the polarisation stage made them. Computed by the racs-all flow"""
     reference_image: Path | None = None
     """A 2D MFS image whose WCS/shape sources the source-finding boxes. Required only when catalogue is not set (built-in aegean source finding)"""
     catalogue: Path | None = None

--- a/flint/options.py
+++ b/flint/options.py
@@ -20,8 +20,9 @@ from astropy.time import Time
 from capn_crunch import BaseOptions
 from pydantic import Field, create_model
 
-from flint.exceptions import MSError
+from flint.exceptions import MSError, NamingException
 from flint.logging import logger
+from flint.naming import split_images
 
 
 class BandpassOptions(BaseOptions):
@@ -276,6 +277,32 @@ class _CubesForRMSynth(BaseOptions):
             msg = f"Need a cube for every one of q and u, missing {sorted(missing)}."
             raise ValueError(msg)
         return cls(q_path=cubes["q"], u_path=cubes["u"], i_path=cubes.get("i"))
+
+    @classmethod
+    def from_paths(cls, paths: list[Path]) -> Self:
+        """From a flat list of cubes, taking the Stokes of each from its filename.
+
+        For the CLI, which has only a list of paths to hand. Prefer
+        ``from_mapping`` wherever the Stokes of each cube is already known.
+
+        Raises:
+            ValueError: A path carries no recognisable Stokes, or two cubes claim the same one
+        """
+        try:
+            split = split_images(images=paths, by="pol")
+        except (NamingException, ValueError) as err:
+            msg = (
+                f"Could not read the Stokes of every cube in {paths}. Names must "
+                "follow the flint or CASDA scheme, as the polarisation stage writes them."
+            )
+            raise ValueError(msg) from err
+
+        duplicated = {pol: found for pol, found in split.items() if len(found) > 1}
+        if duplicated:
+            msg = f"More than one cube for a Stokes, so which to use is ambiguous: {duplicated}"
+            raise ValueError(msg)
+
+        return cls.from_mapping({pol: found[0] for pol, found in split.items()})
 
     @property
     def paths(self) -> list[Path]:
@@ -554,6 +581,30 @@ def pol_field_options_cli_class(
     }
     return create_model(
         "PolFieldOptionsCLI", __base__=PolFieldOptions.__base__, **unique_fields
+    )
+
+
+def exclude_fields_cli_class(
+    options_class: type[BaseOptions], exclude_fields: set[str]
+) -> type[BaseOptions]:
+    """Build a sibling of ``options_class`` exposing only the fields not in
+    ``exclude_fields``, so it can be added to a parser that already exposes
+    those fields via another options class, or sets them up by hand, without a
+    duplicate-flag error.
+
+    The result derives from ``options_class.__base__``, so it is a sibling rather
+    than a subclass. Generalises ``pol_field_options_cli_class`` to an arbitrary,
+    accumulated set of already-registered field names.
+    """
+    unique_fields = {
+        name: (field.annotation, field)
+        for name, field in options_class.model_fields.items()
+        if name not in exclude_fields
+    }
+    return create_model(
+        f"{options_class.__name__}CLI",
+        __base__=options_class.__base__,
+        **unique_fields,
     )
 
 

--- a/flint/options.py
+++ b/flint/options.py
@@ -276,7 +276,9 @@ class RMSynthOptions(BaseOptions):
     debias_filter_size: int = 5
     """Median filter size (pixels) used by mom0 debiasing"""
     per_pixel_rmsf: bool = False
-    """ Compute the RMSF for each pixel in the cube """
+    """Compute the RMSF for each pixel rather than one shared by the cube. Roughly doubles the FDF's size. rm-lite turns this on itself when the weights make pixels disagree, as the linmos weight cubes do"""
+    estimate_stokes_i_noise: bool = True
+    """Derive the per-channel Stokes I error from the Stokes I cube when no Stokes I weight cube is given. A weight cube takes precedence"""
 
 
 class RMCleanOptions(BaseOptions):

--- a/flint/options.py
+++ b/flint/options.py
@@ -17,7 +17,7 @@ import yaml
 from astropy.coordinates import EarthLocation, SkyCoord
 from astropy.time import Time
 from capn_crunch import BaseOptions
-from pydantic import create_model
+from pydantic import create_model, model_validator
 
 from flint.exceptions import MSError
 from flint.logging import logger
@@ -231,22 +231,10 @@ class PolFieldOptions(BaseOptions):
     """Primary beam attenuation cutoff to use during linmos"""
     imaging_strategy: Path | None = None
     """Path to a FLINT imaging yaml file that contains settings to use throughout imaging"""
+    pol_cube_channel_width: float | None = None
+    """Desired width, in Hz, of each plane of the polarisation cubes. The wsclean channel division is solved for this target so the cubes have a single linear frequency axis, overriding the strategy ``channels_out``. Deliberately separate from ``RACSAllOptions.cube_channel_width``, as the continuum and polarisation cubes need not share a channelisation. See ``flint.imager.channel_division``"""
     sbid_copy_path: Path | None = None
     """Path that final processed products will be copied into. If None no copying of file products is performed. See ArchiveOptions. """
-    run_rmsynth: bool = False
-    """Run RM-synthesis (and optionally RM-CLEAN) on the Stokes Q/U cubes once created. Requires 'linear' to have been imaged."""
-    rmsynth_cube_products: list[Literal["dirty", "clean", "model"]] = []
-    """Which Faraday dispersion function (FDF) cubes to write as FITS. 'dirty' is the raw FDF (no RM-CLEAN needed). 'clean'/'model' are RM-CLEAN's cleaned/clean-component FDF (RM-CLEAN is run if either is requested). Empty by default, as these cubes are large."""
-    rmsynth_moment_products: list[Literal["dirty", "clean", "model"]] = ["clean"]
-    """Which FDF(s) to compute Faraday moment maps (mom0=polarised intensity, mom1=mean Faraday depth, mom2=Faraday depth dispersion) from. 'clean' is the usual choice; 'dirty' moments are noise-biased; 'model' moments describe just the clean components."""
-    run_spice: bool = False
-    """Trim the Stokes cubes down to small boxes around catalogued sources (SPICE-style), for archiving and/or as RM-synthesis's input. See flint.spice"""
-    aegean_container: Path | None = None
-    """Path to the singularity aegean container. Required by run_spice when spice_catalogue is not set (built-in source finding)"""
-    spice_catalogue: Path | None = None
-    """A source catalogue (RA/Dec at minimum) for run_spice. If None the pipeline source finds its own Stokes I mosaic instead. See SpiceOptions for how to describe this catalogue's columns"""
-    rmsynth_on_spiced_cubes: bool = False
-    """When both run_spice and run_rmsynth are set, whether rm-synth reads the spiced cubes rather than the full (unspiced) ones. Ignored otherwise."""
 
 
 class RMSynthOptions(BaseOptions):
@@ -271,6 +259,29 @@ class RMSynthOptions(BaseOptions):
     """Briggs robust parameter, required if weight_type is 'briggs'"""
     nufft_nthreads: int = 1
     """finufft OpenMP threads per dask chunk"""
+
+    @model_validator(mode="after")
+    def _snr_cut_needs_a_noise_estimate(self) -> RMSynthOptions:
+        """Reject a Stokes I SNR cut that has nothing to measure against.
+
+        rm-lite scores a pixel whose Stokes I error is all-zero as infinite SNR,
+        so without an estimate the cut passes every pixel: each gets a full
+        ``curve_fit``, and a power law fitted to noise can pass close enough to
+        zero that dividing Q/U by it gives an infinite FDF. That is a broken
+        configuration rather than a slow one, so it is refused here instead of
+        being warned about once the run is already underway.
+        """
+        if self.stokes_i_snr_cut is not None and not self.estimate_stokes_i_noise:
+            msg = (
+                f"stokes_i_snr_cut={self.stokes_i_snr_cut} requires "
+                "estimate_stokes_i_noise=True. Without a Stokes I noise estimate "
+                "rm-lite scores every pixel as infinite SNR, so the cut passes all "
+                "of them. Set estimate_stokes_i_noise=True, or stokes_i_snr_cut=None "
+                "to fit every pixel deliberately."
+            )
+            raise ValueError(msg)
+        return self
+
     target_chunk_mb: float = 256
     """Target per-chunk memory footprint, in MB, when reading the Q/U cubes"""
     fit_order: int = 2
@@ -287,9 +298,7 @@ class RMSynthOptions(BaseOptions):
     """Also compute a debiased (via rm_lite's debias_fdf) mom0/mom1/mom2 set per requested FDF"""
     debias_filter_size: int = 5
     """Median filter size (pixels) used by mom0 debiasing"""
-    write_fdfs_to_zarr: bool = False
-    """Write requested FDF cubes (rmsynth_cube_products) as a chunked zarr store instead of FITS. Recommended for large cubes"""
-    estimate_stokes_i_noise: bool = False
+    estimate_stokes_i_noise: bool = True
     """Derive a per-channel Stokes I error from the Stokes I cube when fitting the fractional-polarisation model"""
 
 
@@ -307,38 +316,37 @@ class RMCleanOptions(BaseOptions):
     gain: float = 0.1
     """CLEAN loop gain"""
     moment_threshold_snr: float = 5.0
-    """SNR cut (times the theoretical FDF noise) applied before computing Faraday moment maps"""
-    multiscale: bool = False
-    """Use multiscale RM-CLEAN, which can recover Faraday-thick structure"""
+    """SNR cut (times the theoretical FDF noise) applied before computing Faraday moment maps, the dirty ones included"""
 
 
 class SpiceOptions(BaseOptions):
-    """Options controlling the SPICE-style cube trimming (see ``flint.spice``):
-    mask everything outside small boxes around catalogued sources, crop to
+    """Options controlling the SPICE-style cube trimming (see ``flint.spice``)
+
+    Mask everything outside small boxes around catalogued sources, crop to
     their union, and compress. Column names/units for a user-supplied
-    ``PolFieldOptions.spice_catalogue`` are never guessed -- see the
-    ``catalogue_*`` fields below."""
+    ``SpiceFieldOptions.catalogue`` are specified via the ``catalogue_*`` fields
+    """
 
     n_beamwidths: float = 3.0
     """Padding added to each side of an island's bounding box, in units of the restoring beam major axis"""
     catalogue_island_col: str | None = None
-    """Column grouping components into islands in a user-supplied spice_catalogue. None treats each row as its own island"""
+    """Column grouping components into islands in a user-supplied catalogue. None treats each row as its own island"""
     catalogue_ra_col: str | None = None
-    """RA column in a user-supplied spice_catalogue. Required whenever spice_catalogue is set -- never guessed"""
+    """RA column in a user-supplied catalogue. Required whenever a catalogue is supplied"""
     catalogue_dec_col: str | None = None
-    """Dec column in a user-supplied spice_catalogue. Required whenever spice_catalogue is set"""
+    """Dec column in a user-supplied catalogue. Required whenever a catalogue is supplied"""
     catalogue_radec_unit: str = "deg"
     """Astropy unit string for catalogue_ra_col/catalogue_dec_col"""
     catalogue_maj_col: str | None = None
-    """Major-axis column in a user-supplied spice_catalogue. None disables ellipse sizing (point-source + beamwidth padding only)"""
+    """Major-axis column in a user-supplied catalogue. None disables ellipse sizing (point-source + beamwidth padding only)"""
     catalogue_min_col: str | None = None
-    """Minor-axis column in a user-supplied spice_catalogue"""
+    """Minor-axis column in a user-supplied catalogue"""
     catalogue_pa_col: str | None = None
-    """Position-angle column in a user-supplied spice_catalogue"""
+    """Position-angle column in a user-supplied catalogue"""
     catalogue_shape_unit: str = "arcsec"
     """Astropy unit string for catalogue_maj_col/catalogue_min_col. catalogue_pa_col is always degrees"""
     catalogue_sizes_deconvolved: bool | None = None
-    """Whether catalogue_maj_col/catalogue_min_col are PSF-deconvolved rather than as-observed. Required whenever catalogue_maj_col is set -- the built-in Aegean catalogue is exempt (its a/b/pa are already as-observed)"""
+    """Whether catalogue_maj_col/catalogue_min_col are PSF-deconvolved rather than as-observed. Required whenever catalogue_maj_col is set"""
     catalogue_psf_maj_col: str | None = None
     """Per-source PSF major-axis column, used to re-convolve when catalogue_sizes_deconvolved is True. Unset falls back to the pipeline's common restoring beam"""
     catalogue_psf_min_col: str | None = None
@@ -349,6 +357,53 @@ class SpiceOptions(BaseOptions):
     """Compression backend for the mandatory gzip of every spiced cube."""
     compress_max_workers: int | None = None
     """Thread count handed to the compression backend"""
+
+
+class RMSynthFieldOptions(BaseOptions):
+    """Options for running RM-synthesis (and optionally RM-CLEAN) as its own
+    standalone pipeline, given already-imaged Stokes Q/U cubes. See
+    ``RMSynthOptions``/``RMCleanOptions`` for the RM-synthesis/RM-CLEAN
+    algorithm parameters, which are drawn from ``imaging_strategy`` rather
+    than exposed here."""
+
+    stokes_q_cube: Path | None = None
+    """Path to the Stokes Q FITS cube. Computed by the racs-all flow, so required only when running this pipeline standalone"""
+    stokes_u_cube: Path | None = None
+    """Path to the Stokes U FITS cube. Computed by the racs-all flow, so required only when running this pipeline standalone"""
+    stokes_i_cube: Path | None = None
+    """Path to a Stokes I FITS cube, used to fit a per-pixel fractional-polarisation correction. Defaults to None."""
+    imaging_strategy: Path | None = None
+    """Path to a FLINT imaging yaml file that contains the RMSynthOptions/RMCleanOptions settings to use"""
+    cube_products: list[Literal["dirty", "clean", "model"]] = []
+    """Which Faraday dispersion function (FDF) cubes to write as FITS. Nothing by default, as these cubes can be large."""
+    moment_products: list[Literal["dirty", "clean", "model"]] = ["clean"]
+    """Which FDF(s) to compute Faraday moment maps from."""
+    output_path: Path | None = None
+    """Directory the FDF cube and moment products are written into. Defaults to alongside the input Stokes cubes"""
+    sbid_copy_path: Path | None = None
+    """Path that final processed products will be copied into. If None no copying of file products is performed. See ArchiveOptions. """
+
+
+class SpiceFieldOptions(BaseOptions):
+    """Options for running SPICE-style cube compression as its own standalone
+    pipeline, given already-imaged Stokes cubes. See ``SpiceOptions`` for the
+    trimming/compression algorithm parameters, which are drawn from
+    ``imaging_strategy`` rather than exposed here."""
+
+    cubes: list[Path] = []
+    """Stokes cubes to trim and compress. Computed by the racs-all flow, so required only when running this pipeline standalone"""
+    reference_image: Path | None = None
+    """A 2D MFS image whose WCS/shape sources the source-finding boxes. Required only when catalogue is not set (built-in aegean source finding)"""
+    catalogue: Path | None = None
+    """A source catalogue (RA/Dec at minimum). If None the pipeline source finds its own sources from reference_image instead. See SpiceOptions for how to describe this catalogue's columns"""
+    aegean_container: Path | None = None
+    """Path to the singularity aegean container. Required when catalogue is not set (built-in source finding)"""
+    imaging_strategy: Path | None = None
+    """Path to a FLINT imaging yaml file that contains the SpiceOptions settings to use"""
+    output_path: Path | None = None
+    """Directory the spiced cubes are written into, replacing the originals. Defaults to leaving each cube in place"""
+    sbid_copy_path: Path | None = None
+    """Path that final processed products will be copied into. If None no copying of file products is performed. See ArchiveOptions. """
 
 
 class RACSAllOptions(BaseOptions):
@@ -417,25 +472,6 @@ class RACSAllOptions(BaseOptions):
     """Desired width, in Hz, of each plane of the final cube. The wsclean channel division is solved for this target so the cube has a single linear frequency axis, overriding the strategy ``channels_out`` in the final round. See ``flint.imager.channel_division``"""
     holofile: Path | None = None
     """The oath to a concatenated holography FITS file that contains low-, mid- and high-band cubes"""
-    run_polarisation: bool = False
-    """Whether to run the polarisation imaging pipeline on the final round of calibrated measurement sets"""
-    pol_cube_channel_width: float | None = None
-    """Desired width, in Hz, of each plane of the polarisation cubes. Solved for independently of ``cube_channel_width``, as the polarisation strategy may use a different channelisation. See ``flint.imager.channel_division``"""
-
-
-def racs_all_options_to_pol_field_options(
-    racs_all_options: RACSAllOptions,
-) -> PolFieldOptions:
-    """Build a default ``PolFieldOptions`` from the fields of ``RACSAllOptions`` that
-    share a name and meaning between the two (containers, beam/pb cutoffs, etc).
-    Fields that only exist on ``PolFieldOptions`` are left at their default. Used
-    when a caller does not supply its own ``PolFieldOptions`` (e.g. calling the
-    racs-all flow directly rather than through its CLI, where every
-    ``PolFieldOptions`` field is exposed)."""
-    shared_fields = set(RACSAllOptions.model_fields) & set(PolFieldOptions.model_fields)
-    return PolFieldOptions(
-        **{name: getattr(racs_all_options, name) for name in shared_fields}
-    )
 
 
 def pol_field_options_cli_class(
@@ -457,6 +493,34 @@ def pol_field_options_cli_class(
     return create_model(
         "PolFieldOptionsCLI", __base__=PolFieldOptions.__base__, **unique_fields
     )
+
+
+class RACSAllPipelineOptions(BaseOptions):
+    """Options controlling the ``racs-all`` flow-of-flows.
+
+    Execution order: imaging -> polarisation -> rm-synth/clean -> spice-compression
+
+    with each stage individually skippable.
+    """
+
+    output_path: Path | None = None
+    """Root directory the rm-synth and spice stages write their products under, in per-stage subdirectories. Defaults to the continuum stage's science path"""
+    skip_imaging: bool = False
+    """Skip the continuum imaging/self-calibration stage"""
+    skip_polarisation: bool = False
+    """Skip the polarisation imaging stage"""
+    skip_rmsynth: bool = False
+    """Skip the RM-synthesis/RM-CLEAN stage"""
+    skip_spice: bool = False
+    """Skip the SPICE compression stage"""
+    imaging_cluster_config: Path | None = None
+    """Specify a new cluster configuration file for the imaging stage, different to the preferred one. If None, drawn from the preferred cluster config"""
+    polarisation_cluster_config: Path | None = None
+    """Specify a new cluster configuration file for the polarisation stage, different to the preferred one. If None, drawn from the preferred cluster config"""
+    rmsynth_cluster_config: Path | None = None
+    """Specify a new cluster configuration file for the rm-synth/clean stage, different to the preferred one. If None, drawn from the preferred cluster config"""
+    spice_cluster_config: Path | None = None
+    """Specify a new cluster configuration file for the spice-compression stage, different to the preferred one. If None, drawn from the preferred cluster config"""
 
 
 def dump_field_options_to_yaml(

--- a/flint/options.py
+++ b/flint/options.py
@@ -298,6 +298,8 @@ class RMCleanOptions(BaseOptions):
     """CLEAN loop gain"""
     moment_threshold_snr: float = 5.0
     """SNR cut (times the theoretical FDF noise) applied before computing Faraday moment maps, the dirty ones included"""
+    peak_threshold_snr: float = 0.0
+    """SNR cut (times the theoretical FDF noise) below which FDF peak statistics are blanked. Zero applies no cut: unlike mom0, a peak is a single sample with no noise floor to integrate, and peak_pi_error is written beside it to judge significance downstream"""
 
 
 class SpiceOptions(BaseOptions):

--- a/flint/options.py
+++ b/flint/options.py
@@ -275,6 +275,8 @@ class RMSynthOptions(BaseOptions):
     """Also compute a debiased (via rm_lite's debias_fdf) mom0/mom1/mom2 set per requested FDF"""
     debias_filter_size: int = 5
     """Median filter size (pixels) used by mom0 debiasing"""
+    lam_sq_0_m2: float | Literal["auto", "per_pixel"] = "auto"
+    """Reference lambda^2 the FDF is derotated to. 'auto' picks one value for the whole cube; 'per_pixel' gives each pixel its own, which also forces per_pixel_rmsf since the RMSF then differs pixel to pixel. A float pins it explicitly"""
     per_pixel_rmsf: bool = False
     """Compute the RMSF for each pixel rather than one shared by the cube. Roughly doubles the FDF's size. rm-lite turns this on itself when the weights make pixels disagree, as the linmos weight cubes do"""
     estimate_stokes_i_noise: bool = True
@@ -296,6 +298,8 @@ class RMCleanOptions(BaseOptions):
     """CLEAN loop gain"""
     moment_threshold_snr: float = 5.0
     """SNR cut (times the theoretical FDF noise) applied before computing Faraday moment maps, the dirty ones included"""
+    peak_products: list[Literal["dirty", "clean", "model"]] = []
+    """Which FDF(s) to measure peak statistics from: peak polarised intensity (raw and debiased), Faraday depth, polarisation angle and intrinsic angle, each with its error. Nine (ny, nx) maps per FDF, so empty by default -- at 16032^2 that is ~9 GB per entry"""
 
 
 class SpiceOptions(BaseOptions):

--- a/flint/options.py
+++ b/flint/options.py
@@ -279,9 +279,11 @@ class RMSynthOptions(BaseOptions):
     n_error_samples: int = 1000
     """Monte-Carlo resamples used by compute_model_error"""
     debias_moments: bool = False
-    """Debias the mom0 (polarised intensity) moment map via rm_lite's debias_fdf, instead of a hard amplitude threshold. Requires lam_sq_0_m2 from the synthesis, so overrides any SNR threshold"""
+    """Also compute a debiased (via rm_lite's debias_fdf) mom0/mom1/mom2 set per requested FDF"""
     debias_filter_size: int = 5
     """Median filter size (pixels) used by mom0 debiasing"""
+    write_fdfs_to_zarr: bool = False
+    """Write requested FDF cubes (rmsynth_cube_products) as a chunked zarr store instead of FITS. Recommended for large cubes"""
     estimate_stokes_i_noise: bool = False
     """Derive a per-channel Stokes I error from the Stokes I cube when fitting the fractional-polarisation model"""
 

--- a/flint/options.py
+++ b/flint/options.py
@@ -239,6 +239,14 @@ class PolFieldOptions(BaseOptions):
     """Which Faraday dispersion function (FDF) cubes to write as FITS. 'dirty' is the raw FDF (no RM-CLEAN needed). 'clean'/'model' are RM-CLEAN's cleaned/clean-component FDF (RM-CLEAN is run if either is requested). Empty by default, as these cubes are large."""
     rmsynth_moment_products: list[Literal["dirty", "clean", "model"]] = ["clean"]
     """Which FDF(s) to compute Faraday moment maps (mom0=polarised intensity, mom1=mean Faraday depth, mom2=Faraday depth dispersion) from. 'clean' is the usual choice; 'dirty' moments are noise-biased; 'model' moments describe just the clean components."""
+    run_spice: bool = False
+    """Trim the Stokes cubes down to small boxes around catalogued sources (SPICE-style), for archiving and/or as RM-synthesis's input. See flint.spice"""
+    aegean_container: Path | None = None
+    """Path to the singularity aegean container. Required by run_spice when spice_catalogue is not set (built-in source finding)"""
+    spice_catalogue: Path | None = None
+    """A source catalogue (RA/Dec at minimum) for run_spice. If None the pipeline source finds its own Stokes I mosaic instead. See SpiceOptions for how to describe this catalogue's columns"""
+    rmsynth_on_spiced_cubes: bool = False
+    """When both run_spice and run_rmsynth are set, whether rm-synth reads the spiced cubes rather than the full (unspiced) ones. Ignored otherwise."""
 
 
 class RMSynthOptions(BaseOptions):
@@ -302,6 +310,45 @@ class RMCleanOptions(BaseOptions):
     """SNR cut (times the theoretical FDF noise) applied before computing Faraday moment maps"""
     multiscale: bool = False
     """Use multiscale RM-CLEAN, which can recover Faraday-thick structure"""
+
+
+class SpiceOptions(BaseOptions):
+    """Options controlling the SPICE-style cube trimming (see ``flint.spice``):
+    mask everything outside small boxes around catalogued sources, crop to
+    their union, and compress. Column names/units for a user-supplied
+    ``PolFieldOptions.spice_catalogue`` are never guessed -- see the
+    ``catalogue_*`` fields below."""
+
+    n_beamwidths: float = 3.0
+    """Padding added to each side of an island's bounding box, in units of the restoring beam major axis"""
+    catalogue_island_col: str | None = None
+    """Column grouping components into islands in a user-supplied spice_catalogue. None treats each row as its own island"""
+    catalogue_ra_col: str | None = None
+    """RA column in a user-supplied spice_catalogue. Required whenever spice_catalogue is set -- never guessed"""
+    catalogue_dec_col: str | None = None
+    """Dec column in a user-supplied spice_catalogue. Required whenever spice_catalogue is set"""
+    catalogue_radec_unit: str = "deg"
+    """Astropy unit string for catalogue_ra_col/catalogue_dec_col"""
+    catalogue_maj_col: str | None = None
+    """Major-axis column in a user-supplied spice_catalogue. None disables ellipse sizing (point-source + beamwidth padding only)"""
+    catalogue_min_col: str | None = None
+    """Minor-axis column in a user-supplied spice_catalogue"""
+    catalogue_pa_col: str | None = None
+    """Position-angle column in a user-supplied spice_catalogue"""
+    catalogue_shape_unit: str = "arcsec"
+    """Astropy unit string for catalogue_maj_col/catalogue_min_col. catalogue_pa_col is always degrees"""
+    catalogue_sizes_deconvolved: bool | None = None
+    """Whether catalogue_maj_col/catalogue_min_col are PSF-deconvolved rather than as-observed. Required whenever catalogue_maj_col is set -- the built-in Aegean catalogue is exempt (its a/b/pa are already as-observed)"""
+    catalogue_psf_maj_col: str | None = None
+    """Per-source PSF major-axis column, used to re-convolve when catalogue_sizes_deconvolved is True. Unset falls back to the pipeline's common restoring beam"""
+    catalogue_psf_min_col: str | None = None
+    """Column name for the per-source PSF minor axis, paired with catalogue_psf_maj_col"""
+    catalogue_psf_pa_col: str | None = None
+    """Column name for the per-source PSF position angle, paired with catalogue_psf_maj_col"""
+    compress_method: Literal["gzip", "pgzip"] = "pgzip"
+    """Compression backend for the mandatory gzip of every spiced cube."""
+    compress_max_workers: int | None = None
+    """Thread count handed to the compression backend"""
 
 
 class RACSAllOptions(BaseOptions):

--- a/flint/options.py
+++ b/flint/options.py
@@ -298,8 +298,6 @@ class RMCleanOptions(BaseOptions):
     """CLEAN loop gain"""
     moment_threshold_snr: float = 5.0
     """SNR cut (times the theoretical FDF noise) applied before computing Faraday moment maps, the dirty ones included"""
-    peak_products: list[Literal["dirty", "clean", "model"]] = []
-    """Which FDF(s) to measure peak statistics from: peak polarised intensity (raw and debiased), Faraday depth, polarisation angle and intrinsic angle, each with its error. Nine (ny, nx) maps per FDF, so empty by default -- at 16032^2 that is ~9 GB per entry"""
 
 
 class SpiceOptions(BaseOptions):
@@ -369,6 +367,8 @@ class RMSynthFieldOptions(BaseOptions):
     """Which Faraday dispersion function (FDF) cubes to write as FITS. Nothing by default, as these cubes can be large."""
     moment_products: list[Literal["dirty", "clean", "model"]] = ["clean"]
     """Which FDF(s) to compute Faraday moment maps from."""
+    peak_products: list[Literal["dirty", "clean", "model"]] = []
+    """Which FDF(s) to measure peak statistics from: peak polarised intensity (raw and debiased), Faraday depth, polarisation angle and intrinsic angle, each with its error. Nine (ny, nx) maps per FDF, so empty by default -- at 16032^2 that is ~9 GB per entry"""
     output_path: Path | None = None
     """Directory the FDF cube and moment products are written into. Defaults to alongside the input Stokes cubes"""
     sbid_copy_path: Path | None = None

--- a/flint/options.py
+++ b/flint/options.py
@@ -304,6 +304,22 @@ class RACSAllOptions(BaseOptions):
     """Desired width, in Hz, of each plane of the final cube. The wsclean channel division is solved for this target so the cube has a single linear frequency axis, overriding the strategy ``channels_out`` in the final round. See ``flint.imager.channel_division``"""
     holofile: Path | None = None
     """The oath to a concatenated holography FITS file that contains low-, mid- and high-band cubes"""
+    run_polarisation: bool = False
+    """Whether to run the polarisation imaging pipeline on the final round of calibrated measurement sets"""
+    pol_cube_channel_width: float | None = None
+    """Desired width, in Hz, of each plane of the polarisation cubes. Solved for independently of ``cube_channel_width``, as the polarisation strategy may use a different channelisation. See ``flint.imager.channel_division``"""
+
+
+def racs_all_options_to_pol_field_options(
+    racs_all_options: RACSAllOptions,
+) -> PolFieldOptions:
+    """Build a ``PolFieldOptions`` from the fields of ``RACSAllOptions`` that share
+    a name and meaning between the two (containers, beam/pb cutoffs, etc). Fields
+    that only exist on ``PolFieldOptions`` are left at their default."""
+    shared_fields = set(RACSAllOptions.model_fields) & set(PolFieldOptions.model_fields)
+    return PolFieldOptions(
+        **{name: getattr(racs_all_options, name) for name in shared_fields}
+    )
 
 
 def dump_field_options_to_yaml(

--- a/flint/options.py
+++ b/flint/options.py
@@ -363,6 +363,8 @@ class RMSynthFieldOptions(BaseOptions):
     """Path to Stokes I weights cube produced by LINMOS"""
     imaging_strategy: Path | None = None
     """Path to a FLINT imaging yaml file that contains the RMSynthOptions/RMCleanOptions settings to use"""
+    beam_cutoff: float | None = None
+    """Cutoff in arcseconds to use when bringing the input cubes to a common beam. Channels coarser than this are blanked instead of dragging every channel out to their resolution. Defaults to no cutoff"""
     cube_products: list[Literal["dirty", "clean", "model"]] = []
     """Which Faraday dispersion function (FDF) cubes to write as FITS. Nothing by default, as these cubes can be large."""
     moment_products: list[Literal["dirty", "clean", "model"]] = ["clean"]

--- a/flint/options.py
+++ b/flint/options.py
@@ -259,29 +259,6 @@ class RMSynthOptions(BaseOptions):
     """Briggs robust parameter, required if weight_type is 'briggs'"""
     nufft_nthreads: int = 1
     """finufft OpenMP threads per dask chunk"""
-
-    @model_validator(mode="after")
-    def _snr_cut_needs_a_noise_estimate(self) -> RMSynthOptions:
-        """Reject a Stokes I SNR cut that has nothing to measure against.
-
-        rm-lite scores a pixel whose Stokes I error is all-zero as infinite SNR,
-        so without an estimate the cut passes every pixel: each gets a full
-        ``curve_fit``, and a power law fitted to noise can pass close enough to
-        zero that dividing Q/U by it gives an infinite FDF. That is a broken
-        configuration rather than a slow one, so it is refused here instead of
-        being warned about once the run is already underway.
-        """
-        if self.stokes_i_snr_cut is not None and not self.estimate_stokes_i_noise:
-            msg = (
-                f"stokes_i_snr_cut={self.stokes_i_snr_cut} requires "
-                "estimate_stokes_i_noise=True. Without a Stokes I noise estimate "
-                "rm-lite scores every pixel as infinite SNR, so the cut passes all "
-                "of them. Set estimate_stokes_i_noise=True, or stokes_i_snr_cut=None "
-                "to fit every pixel deliberately."
-            )
-            raise ValueError(msg)
-        return self
-
     target_chunk_mb: float = 256
     """Target per-chunk memory footprint, in MB, when reading the Q/U cubes"""
     fit_order: int = 2
@@ -298,9 +275,8 @@ class RMSynthOptions(BaseOptions):
     """Also compute a debiased (via rm_lite's debias_fdf) mom0/mom1/mom2 set per requested FDF"""
     debias_filter_size: int = 5
     """Median filter size (pixels) used by mom0 debiasing"""
-    estimate_stokes_i_noise: bool = True
-    """Derive a per-channel Stokes I error from the Stokes I cube when fitting the fractional-polarisation model"""
-
+    per_pixel_rmsf: bool = False
+    """ Compute the RMSF for each pixel in the cube """
 
 class RMCleanOptions(BaseOptions):
     """Options controlling ``rm_lite.tools_3d.rmclean.run_rmclean_from_synth``.
@@ -372,6 +348,12 @@ class RMSynthFieldOptions(BaseOptions):
     """Path to the Stokes U FITS cube. Computed by the racs-all flow, so required only when running this pipeline standalone"""
     stokes_i_cube: Path | None = None
     """Path to a Stokes I FITS cube, used to fit a per-pixel fractional-polarisation correction. Defaults to None."""
+    stokes_q_weight_cube: Path | None = None
+    """Path to Stokes Q weights cube produced by LINMOS"""
+    stokes_u_weight_cube: Path | None = None
+    """Path to Stokes U weights cube produced by LINMOS"""
+    stokes_i_weight_cube: Path | None = None
+    """Path to Stokes I weights cube produced by LINMOS"""
     imaging_strategy: Path | None = None
     """Path to a FLINT imaging yaml file that contains the RMSynthOptions/RMCleanOptions settings to use"""
     cube_products: list[Literal["dirty", "clean", "model"]] = []

--- a/flint/options.py
+++ b/flint/options.py
@@ -274,6 +274,14 @@ class RMSynthOptions(BaseOptions):
     """Stokes I fit function: 'log' is a power law, 'linear' is a polynomial"""
     stokes_i_snr_cut: float | None = 5.0
     """Below this frequency-averaged Stokes I SNR a pixel falls back to a flat model. None fits every pixel"""
+    compute_model_error: bool = False
+    """Monte-Carlo the Stokes I fit's per-pixel model error via n_error_samples resamples. Only used if a Stokes I cube is given"""
+    n_error_samples: int = 1000
+    """Monte-Carlo resamples used by compute_model_error"""
+    debias_moments: bool = False
+    """Debias the mom0 (polarised intensity) moment map via rm_lite's debias_fdf, instead of a hard amplitude threshold. Requires lam_sq_0_m2 from the synthesis, so overrides any SNR threshold"""
+    debias_filter_size: int = 5
+    """Median filter size (pixels) used by mom0 debiasing"""
     estimate_stokes_i_noise: bool = False
     """Derive a per-channel Stokes I error from the Stokes I cube when fitting the fractional-polarisation model"""
 

--- a/flint/options.py
+++ b/flint/options.py
@@ -428,6 +428,8 @@ class FitsCubeOptions(BaseOptions):
     """Remove the images that go into forming the fitscube"""
     inplace: bool = True
     """If True, modify the file in-place. If False, write to a temporary file and then replace the original. Default True"""
+    create_blanks: bool = True
+    """Have fitscube re-grid the input frequencies onto a tolerant regular grid before writing."""
 
 
 class MSSummary(BaseOptions):

--- a/flint/options.py
+++ b/flint/options.py
@@ -380,7 +380,9 @@ class SpiceFieldOptions(BaseOptions):
     ``imaging_strategy`` rather than exposed here."""
 
     cubes: list[Path] = []
-    """Stokes cubes to trim and compress. Computed by the racs-all flow, so required only when running this pipeline standalone"""
+    """Stokes image cubes to trim and compress. Computed by the racs-all flow, so required only when running this pipeline standalone"""
+    weight_cubes: list[Path] = []
+    """LINMOS weight cubes to trim and compress alongside ``cubes``, spiced with the same boxes so they stay on a matching grid. Computed by the racs-all flow"""
     reference_image: Path | None = None
     """A 2D MFS image whose WCS/shape sources the source-finding boxes. Required only when catalogue is not set (built-in aegean source finding)"""
     catalogue: Path | None = None

--- a/flint/options.py
+++ b/flint/options.py
@@ -253,6 +253,8 @@ class FFTBANEOptions(BaseOptions):
     """Pixels above this SNR are replaced by noise before the background is fitted"""
     seed: int = 1234
     """Seeds the noise clipped pixels are filled with, so a rerun reproduces the maps"""
+    invalidate_zeros: bool = True
+    """Treat pixels of exactly 0.0 as blank, as ``FitsCubeOptions.invalidate_zeros`` does. linmos fills outside its primary beam cutoff with zeros, not nans"""
 
 
 class _CubesForRMSynth(BaseOptions):

--- a/flint/options.py
+++ b/flint/options.py
@@ -374,13 +374,13 @@ class RMSynthOptions(BaseOptions):
     n_error_samples: int = 1000
     """Monte-Carlo resamples used by compute_model_error"""
     debias_moments: bool = False
-    """Also compute a debiased (via rm_lite's debias_fdf) mom0/mom1/mom2 set per requested FDF"""
+    """Also compute a debiased (via rm_lite's debias_fdf) moment set per requested FDF, written with a '.debiased' suffix."""
     debias_filter_size: int = 5
     """Median filter size (pixels) used by mom0 debiasing"""
     lam_sq_0_m2: float | Literal["auto", "per_pixel"] = "auto"
-    """Reference lambda^2 the FDF is derotated to. 'auto' picks one value for the whole cube; 'per_pixel' gives each pixel its own, which also forces per_pixel_rmsf since the RMSF then differs pixel to pixel. A float pins it explicitly"""
+    """Reference lambda^2 the FDF is derotated to. 'auto' picks one value for the whole cube; 'per_pixel' gives each pixel its own, which also forces per_pixel_rmsf"""
     per_pixel_rmsf: bool = False
-    """Compute the RMSF for each pixel rather than one shared by the cube. Roughly doubles the FDF's size. rm-lite turns this on itself when the weights make pixels disagree, as the linmos weight cubes do"""
+    """Compute the RMSF for each pixel"""
     estimate_stokes_i_noise: bool = True
     """Derive the per-channel Stokes I error from the Stokes I cube when no Stokes I weight cube is given. A weight cube takes precedence"""
 
@@ -460,13 +460,11 @@ class RMSynthFieldOptions(BaseOptions):
     cube_products: list[Literal["dirty", "clean", "model"]] = []
     """Which Faraday dispersion function (FDF) cubes to write as FITS. Nothing by default, as these cubes can be large."""
     moment_products: list[Literal["dirty", "clean", "model"]] = ["clean"]
-    """Which FDF(s) to compute Faraday moment maps from."""
+    """Which FDF(s) to compute Faraday moment maps from: 'dirty', 'clean', 'model'"""
     moment_threshold_snr: float = 5.0
     """SNR cut (times the theoretical FDF noise) applied before the moment maps are computed, the dirty ones included"""
-    peak_threshold_snr: float = 0.0
-    """SNR cut (times the theoretical FDF noise) below which peak statistics are blanked. Zero applies no cut: a peak is a single sample with no noise floor to integrate, and peak_pi_error is written beside it"""
     peak_products: list[Literal["dirty", "clean", "model"]] = []
-    """Which FDF(s) to measure peak statistics from: peak polarised intensity (raw and debiased), Faraday depth, polarisation angle and intrinsic angle, each with its error. Nine (ny, nx) maps per FDF, so empty by default -- at 16032^2 that is ~9 GB per entry"""
+    """Which FDF(s) to measure peak statistics from: 'dirty', 'clean', 'model'"""
     output_path: Path | None = None
     """Directory the FDF cube and moment products are written into. Defaults to alongside the input Stokes cubes"""
     sbid_copy_path: Path | None = None

--- a/flint/options.py
+++ b/flint/options.py
@@ -363,6 +363,8 @@ class RMSynthOptions(BaseOptions):
     """finufft OpenMP threads per dask chunk"""
     target_chunk_mb: float = 256
     """Target per-chunk memory footprint, in MB, when reading the Q/U cubes"""
+    convert_to_zarr: bool = False
+    """Convert each FITS cube to a zarr store beside it before reading"""
     fit_order: int = 2
     """Stokes I fractional-polarisation fit order; negative iterates orders and picks the best by AIC"""
     fit_function: Literal["log", "linear"] = "log"

--- a/flint/prefect/common/imaging.py
+++ b/flint/prefect/common/imaging.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from collections.abc import Collection, Sequence
 from pathlib import Path
-from typing import Any, ParamSpec, TypeVar
+from typing import Any, NamedTuple, ParamSpec, TypeVar
 
 import numpy as np
 import pandas as pd
@@ -17,6 +17,7 @@ from prefect import Task, unmapped
 from prefect.artifacts import create_table_artifact
 from prefect.futures import PrefectFuture
 
+from flint.bane import FFTBANEOptions, bane_fits_image
 from flint.calibrate.aocalibrate import (
     ApplySolutions,
     CalibrateCommand,
@@ -111,6 +112,7 @@ task_create_name_from_common_fields = task(create_name_from_common_fields)
 task_remove_files_folders = task(remove_files_folders)
 task_get_common_bounding_box = task(get_common_bounding_box)
 task_split_cube_into_planes = task(split_cube_into_planes)
+task_bane_fits_image = task(bane_fits_image)
 
 # Tasks below are extracting componented from earlier stages, or are
 # otherwise doing something important
@@ -986,6 +988,24 @@ def task_convolve_linmos_to_fixed_shape(
     return linmos_result.with_options(image_fits=output_image_path)
 
 
+class LinmosCubes(NamedTuple):
+    """The cubes ``linmos_channel_groups_to_cubes`` builds from one Stokes"""
+
+    image: PrefectFuture[Path]
+    """The co-added image cube"""
+    weight: PrefectFuture[Path]
+    """The linmos weight cube"""
+    bkg: PrefectFuture[Path] | None = None
+    """Background cube, None unless BANE was asked for"""
+    rms: PrefectFuture[Path] | None = None
+    """RMS noise cube, None unless BANE was asked for"""
+
+    @property
+    def futures(self) -> list[PrefectFuture[Path]]:
+        """Every cube actually being made, for callers that only need to wait"""
+        return [future for future in self if future is not None]
+
+
 def linmos_channel_groups_to_cubes(
     channel_groups: Collection[Collection[Path]],
     container: Path,
@@ -995,7 +1015,8 @@ def linmos_channel_groups_to_cubes(
     field_summary: FieldSummary | None = None,
     suffix_str: str | None = None,
     holofile: Path | None = None,
-) -> list[PrefectFuture[Path]]:
+    fft_bane_options: FFTBANEOptions | None = None,
+) -> LinmosCubes:
     """Co-add beam images one channel at a time, in parallel, then stack the
     resulting mosaics back into image and weight cubes.
 
@@ -1013,9 +1034,10 @@ def linmos_channel_groups_to_cubes(
         field_summary (FieldSummary | None, optional): Description of the field, used to get the ``pol_axis``. Defaults to None.
         suffix_str (str | None, optional): Additional suffix added to the linmos and cube names. Defaults to None.
         holofile (Path | None, optional): Holography file overriding the one in ``linmos_options``. Defaults to None.
+        fft_bane_options (FFTBANEOptions | None, optional): When given, each co-added channel also gets a BANE background and RMS map, stacked into their own cubes. Defaults to None, i.e. no BANE.
 
     Returns:
-        list[PrefectFuture[Path]]: The image and weight cubes being created
+        LinmosCubes: The cubes being created
     """
     stokesi_groups = (
         list(stokesi_channel_groups) if stokesi_channel_groups is not None else None
@@ -1027,6 +1049,8 @@ def linmos_channel_groups_to_cubes(
 
     image_planes: list[PrefectFuture[Path]] = []
     weight_planes: list[PrefectFuture[Path]] = []
+    bkg_planes: list[PrefectFuture[Path]] = []
+    rms_planes: list[PrefectFuture[Path]] = []
     for channel_idx, beam_images in enumerate(channel_groups):
         linmos_result = task_linmos_images.submit(
             image_list=list(beam_images),
@@ -1048,6 +1072,15 @@ def linmos_channel_groups_to_cubes(
         image_planes.append(image_plane)
         weight_planes.append(weight_plane)
 
+        if fft_bane_options is not None:
+            # One task per channel, so every plane's background and noise is
+            # measured across the cluster while the other channels co-add
+            bane_maps = task_bane_fits_image.submit(
+                image=image_plane, fft_bane_options=fft_bane_options
+            )
+            bkg_planes.append(task_getattr.submit(bane_maps, "bkg_image"))
+            rms_planes.append(task_getattr.submit(bane_maps, "rms_image"))
+
     bounding_box: bool | PrefectFuture[BoundingBox] = False
     if fitscube_options.bounding_box:
         # Passing the future in is what forms the barrier - every channel has to
@@ -1062,16 +1095,28 @@ def linmos_channel_groups_to_cubes(
     cube_prefix = task_create_name_from_common_fields.submit(
         in_paths=image_planes, additional_suffixes=suffix_str
     )
-    return [
-        task_combine_images_to_cube.submit(
+    cubes = {
+        mode: task_combine_images_to_cube.submit(
             images=planes,
             prefix=cube_prefix,
             mode=mode,
             fitscube_options=fitscube_options,
             bounding_box=bounding_box,
         )
-        for planes, mode in ((image_planes, "image"), (weight_planes, "weight"))
-    ]
+        for planes, mode in (
+            (image_planes, "image"),
+            (weight_planes, "weight"),
+            (bkg_planes, "bkg"),
+            (rms_planes, "rms"),
+        )
+        if planes
+    }
+    return LinmosCubes(
+        image=cubes["image"],
+        weight=cubes["weight"],
+        bkg=cubes.get("bkg"),
+        rms=cubes.get("rms"),
+    )
 
 
 def create_convolve_linmos_cubes(
@@ -1123,7 +1168,7 @@ def create_convolve_linmos_cubes(
         fitscube_options=fitscube_options,
         suffix_str=linmos_suffix_str,
         holofile=holofile,
-    )
+    ).futures
 
     # Remove the convolved planes once every cube has been formed
     task_remove_files_folders.submit(

--- a/flint/prefect/common/imaging.py
+++ b/flint/prefect/common/imaging.py
@@ -6,7 +6,7 @@ imaging flows.
 
 from __future__ import annotations
 
-from collections.abc import Collection
+from collections.abc import Callable, Collection
 from pathlib import Path
 from typing import Any, ParamSpec, TypeVar
 
@@ -118,6 +118,14 @@ FlagMS = TypeVar("FlagMS", MS, ApplySolutions)
 @task
 def task_get_channel_images_from_paths(paths: list[Path]) -> list[Path]:
     return [path for path in paths if "MFS" not in path.name]
+
+
+@task
+def task_get_mfs_image_from_paths(paths: list[Path]) -> Path:
+    """Inverse of ``task_get_channel_images_from_paths`` -- the single MFS image"""
+    mfs_paths = [path for path in paths if "MFS" in path.name]
+    assert len(mfs_paths) == 1, f"Expected a single MFS image, got {mfs_paths=}"
+    return mfs_paths[0]
 
 
 @task
@@ -986,6 +994,8 @@ def linmos_channel_groups_to_cubes(
     field_summary: FieldSummary | None = None,
     suffix_str: str | None = None,
     holofile: Path | None = None,
+    plane_post_process: Callable[[PrefectFuture[Path]], PrefectFuture[Path]]
+    | None = None,
 ) -> list[PrefectFuture[Path]]:
     """Co-add beam images one channel at a time, in parallel, then stack the
     resulting mosaics back into image and weight cubes.
@@ -1004,6 +1014,7 @@ def linmos_channel_groups_to_cubes(
         field_summary (FieldSummary | None, optional): Description of the field, used to get the ``pol_axis``. Defaults to None.
         suffix_str (str | None, optional): Additional suffix added to the linmos and cube names. Defaults to None.
         holofile (Path | None, optional): Holography file overriding the one in ``linmos_options``. Defaults to None.
+        plane_post_process (Callable[[PrefectFuture[Path]], PrefectFuture[Path]] | None, optional): Applied to each per-channel image/weight plane future right after it's co-added, before cubing (e.g. spice's mask/crop). Defaults to None.
 
     Returns:
         list[PrefectFuture[Path]]: The image and weight cubes being created
@@ -1034,8 +1045,13 @@ def linmos_channel_groups_to_cubes(
             field_summary=field_summary,
             holofile=holofile,
         )
-        image_planes.append(task_getattr.submit(linmos_result, "image_fits"))
-        weight_planes.append(task_getattr.submit(linmos_result, "weight_fits"))
+        image_plane = task_getattr.submit(linmos_result, "image_fits")
+        weight_plane = task_getattr.submit(linmos_result, "weight_fits")
+        if plane_post_process is not None:
+            image_plane = plane_post_process(image_plane)
+            weight_plane = plane_post_process(weight_plane)
+        image_planes.append(image_plane)
+        weight_planes.append(weight_plane)
 
     bounding_box: bool | PrefectFuture[BoundingBox] = False
     if fitscube_options.bounding_box:

--- a/flint/prefect/common/imaging.py
+++ b/flint/prefect/common/imaging.py
@@ -6,7 +6,7 @@ imaging flows.
 
 from __future__ import annotations
 
-from collections.abc import Callable, Collection
+from collections.abc import Collection
 from pathlib import Path
 from typing import Any, ParamSpec, TypeVar
 
@@ -122,7 +122,10 @@ def task_get_channel_images_from_paths(paths: list[Path]) -> list[Path]:
 
 @task
 def task_get_mfs_image_from_paths(paths: list[Path]) -> Path:
-    """Inverse of ``task_get_channel_images_from_paths`` -- the single MFS image"""
+    """Get the single MFS image from a list of paths.
+
+    Inverse of ``task_get_channel_images_from_paths``
+    """
     mfs_paths = [path for path in paths if "MFS" in path.name]
     assert len(mfs_paths) == 1, f"Expected a single MFS image, got {mfs_paths=}"
     return mfs_paths[0]
@@ -361,6 +364,7 @@ def task_wsclean_imager(
     channel_range: tuple[int, int] | None = None,
     scan_range: tuple[int, int] | None = None,
     make_cube_from_subbands: bool = True,
+    extra_output_types: tuple[str, ...] | None = None,
 ) -> WSCleanResult:
     """Run the wsclean imager against an input measurement set
 
@@ -374,6 +378,7 @@ def task_wsclean_imager(
         fits_mask (Optional[FITSMaskNames], optional): A path to a clean guard mask. Defaults to None.
         channel_range (Optional[Tuple[int,int]], optional): Add to the wsclean options the specific channel range to be imaged. Defaults to None.
         scan_range (Optional[Tuple[int,int]], optional): Add to the wsclean options the specific scan range to be imaged. Defaults to None.
+        extra_output_types (tuple[str, ...] | None, optional): Additional output types (beyond ``image``/``residual``) to search for and attach to the returned ``ImageSet``. Defaults to None.
 
     Returns:
         WSCleanResult: A resulting wsclean command and resulting meta-data
@@ -405,6 +410,7 @@ def task_wsclean_imager(
         update_wsclean_options=update_wsclean_options,
         make_cube_from_subbands=make_cube_from_subbands,
         update_fitscube_options=update_fitscube_options,
+        extra_output_types=extra_output_types,
     )
 
 
@@ -994,8 +1000,6 @@ def linmos_channel_groups_to_cubes(
     field_summary: FieldSummary | None = None,
     suffix_str: str | None = None,
     holofile: Path | None = None,
-    plane_post_process: Callable[[PrefectFuture[Path]], PrefectFuture[Path]]
-    | None = None,
 ) -> list[PrefectFuture[Path]]:
     """Co-add beam images one channel at a time, in parallel, then stack the
     resulting mosaics back into image and weight cubes.
@@ -1014,7 +1018,6 @@ def linmos_channel_groups_to_cubes(
         field_summary (FieldSummary | None, optional): Description of the field, used to get the ``pol_axis``. Defaults to None.
         suffix_str (str | None, optional): Additional suffix added to the linmos and cube names. Defaults to None.
         holofile (Path | None, optional): Holography file overriding the one in ``linmos_options``. Defaults to None.
-        plane_post_process (Callable[[PrefectFuture[Path]], PrefectFuture[Path]] | None, optional): Applied to each per-channel image/weight plane future right after it's co-added, before cubing (e.g. spice's mask/crop). Defaults to None.
 
     Returns:
         list[PrefectFuture[Path]]: The image and weight cubes being created
@@ -1047,9 +1050,6 @@ def linmos_channel_groups_to_cubes(
         )
         image_plane = task_getattr.submit(linmos_result, "image_fits")
         weight_plane = task_getattr.submit(linmos_result, "weight_fits")
-        if plane_post_process is not None:
-            image_plane = plane_post_process(image_plane)
-            weight_plane = plane_post_process(weight_plane)
         image_planes.append(image_plane)
         weight_planes.append(weight_plane)
 

--- a/flint/prefect/common/imaging.py
+++ b/flint/prefect/common/imaging.py
@@ -108,6 +108,7 @@ task_transpose_and_sort_channel_images = task(transpose_and_sort_channel_images)
 task_create_name_from_common_fields = task(create_name_from_common_fields)
 task_remove_files_folders = task(remove_files_folders)
 task_get_common_bounding_box = task(get_common_bounding_box)
+task_split_cube_into_planes = task(split_cube_into_planes)
 
 # Tasks below are extracting componented from earlier stages, or are
 # otherwise doing something important
@@ -129,14 +130,6 @@ def task_get_mfs_image_from_paths(paths: list[Path]) -> Path:
     mfs_paths = [path for path in paths if "MFS" in path.name]
     assert len(mfs_paths) == 1, f"Expected a single MFS image, got {mfs_paths=}"
     return mfs_paths[0]
-
-
-@task
-def task_split_cube_into_planes(cubes: Collection[Path]) -> list[Path]:
-    """Split the single cube of a beam into its per-channel planes"""
-    cube_list = list(cubes)
-    assert len(cube_list) == 1, f"Expected a single cube per beam, got {cube_list=}"
-    return split_cube_into_planes(cube=cube_list[0])
 
 
 @task

--- a/flint/prefect/common/imaging.py
+++ b/flint/prefect/common/imaging.py
@@ -6,7 +6,7 @@ imaging flows.
 
 from __future__ import annotations
 
-from collections.abc import Collection
+from collections.abc import Collection, Sequence
 from pathlib import Path
 from typing import Any, ParamSpec, TypeVar
 
@@ -31,6 +31,7 @@ from flint.coadd.linmos import (
 from flint.convol import (
     BeamShape,
     convolve_images,
+    convolve_images_or_blank,
     get_common_beam,
 )
 from flint.flagging import flag_ms_aoflagger
@@ -99,6 +100,7 @@ task_select_solution_for_ms: Task[P, R] = task(select_aosolution_for_ms)
 task_create_apply_solutions_cmd: Task[P, R] = task(create_apply_solutions_cmd)
 task_rename_column_in_ms: Task[P, R] = task(rename_column_in_ms)
 task_convolve_images = task(convolve_images)
+task_convolve_images_or_blank = task(convolve_images_or_blank)
 task_split_and_get_image_set = task(split_and_get_image_set)
 task_image_set_from_result = task(image_set_from_result)
 task_combine_images_to_cube = task(combine_images_to_cube)
@@ -1129,6 +1131,138 @@ def create_convolve_linmos_cubes(
         wait_for=cube_results,
     )
     return cube_results
+
+
+def convolve_channel_groups_to_natural_resolution(
+    stokes_channel_groups: dict[str, list[list[Path]]],
+    cutoff: float | None = None,
+    fixed_beam_shape: Sequence[float] | None = None,
+) -> dict[str, list[list[Path]]]:
+    """Convolve per-channel beam images to one common beam per channel, which is
+    the 'natural' resolution mode of racs_tools: resolution follows frequency
+    rather than every channel being dragged out to the coarsest in the band.
+    Contrast the 'total' mode of ``convolve_cubes_to_common_resolution``, which
+    RM-synthesis needs of its own inputs.
+
+    The beam of a channel is solved over every beam image of every Stokes at that
+    channel, so channel N of I, Q and U share one resolution and a per-channel
+    polarisation product is meaningful. Solving per Stokes would leave them at
+    differing resolutions in the same channel.
+
+    Args:
+        stokes_channel_groups (dict[str, list[list[Path]]]): For each Stokes, the beam images of each channel
+        cutoff (float | None, optional): Images whose major axis exceeds this, in arcsec, are blanked rather than convolved to. Defaults to no cutoff.
+        fixed_beam_shape (Sequence[float] | None, optional): Convolve every channel to this (arcsec, arcsec, deg) rather than a solved beam. Defaults to solving each channel.
+
+    Returns:
+        dict[str, list[list[Path]]]: The convolved beam images of each channel, for each Stokes
+    """
+    # Channel N has to be the same frequency in every Stokes, or a beam shared
+    # across them describes nothing. Differing channelisations already misalign
+    # the Stokes I images that linmos leakage-corrects Q/U against, so this is
+    # surfaced here rather than left to produce a quietly wrong mosaic.
+    channels_per_stokes = {
+        stokes: len(groups) for stokes, groups in stokes_channel_groups.items()
+    }
+    channel_counts = set(channels_per_stokes.values())
+    assert len(channel_counts) == 1, (
+        f"Stokes contribute differing channel counts: {channels_per_stokes}. "
+        "Every polarisation has to be imaged onto the same channel grid."
+    )
+    channels = channel_counts.pop()
+    logger.info(
+        f"Solving a natural common beam for each of {channels} channels over "
+        f"{list(stokes_channel_groups.keys())}"
+    )
+
+    # Left as futures and indexed per channel, so a channel's Stokes start
+    # convolving as soon as its own beam is solved rather than waiting on the
+    # slowest channel in the band
+    beam_shapes = task_get_common_beam_from_images.map(
+        image_paths=[
+            [
+                image
+                for channel_groups in stokes_channel_groups.values()
+                for image in channel_groups[channel]
+            ]
+            for channel in range(channels)
+        ],  # type: ignore
+        cutoff=unmapped(cutoff),  # type: ignore
+        fixed_beam_shape=unmapped(fixed_beam_shape),  # type: ignore
+    )
+
+    convolved_groups = {
+        stokes: [
+            task_convolve_images_or_blank.submit(
+                image_paths=channel_groups[channel],
+                beam_shape=beam_shapes[channel],
+                cutoff=cutoff,
+            )
+            for channel in range(channels)
+        ]
+        for stokes, channel_groups in stokes_channel_groups.items()
+    }
+
+    return {
+        stokes: [future.result() for future in futures]
+        for stokes, futures in convolved_groups.items()
+    }
+
+
+def convolve_mfs_beam_images_to_common_resolution(
+    mfs_beam_images: dict[str, dict[str, list[Path]]],
+    cutoff: float | None = None,
+    fixed_beam_shape: Sequence[float] | None = None,
+) -> dict[str, dict[str, list[Path]]]:
+    """Convolve the per-beam MFS products to a single common beam.
+
+    An MFS image has no frequency axis, so there is nothing for a natural,
+    per-channel beam to vary over: one beam is solved over the MFS images of
+    every beam and every Stokes. The beam is taken from the ``image`` products
+    alone and applied to the model and residual products too, which is what a
+    beam solved over ``ImageSet.image`` has always done here.
+
+    Args:
+        mfs_beam_images (dict[str, dict[str, list[Path]]]): For each Stokes, the per-beam MFS image of each product type
+        cutoff (float | None, optional): Images whose major axis exceeds this, in arcsec, are blanked rather than convolved to. Defaults to no cutoff.
+        fixed_beam_shape (Sequence[float] | None, optional): Convolve to this (arcsec, arcsec, deg) rather than a solved beam. Defaults to solving it.
+
+    Returns:
+        dict[str, dict[str, list[Path]]]: The convolved MFS products, keyed as the input
+    """
+    mfs_science_images = [
+        image
+        for product_type_images in mfs_beam_images.values()
+        for image in product_type_images.get("image", [])
+    ]
+    if not mfs_science_images:
+        logger.info("No MFS science images to solve a common beam over")
+        return mfs_beam_images
+
+    beam_shape: BeamShape = task_get_common_beam_from_images.submit(
+        image_paths=mfs_science_images,
+        cutoff=cutoff,
+        fixed_beam_shape=fixed_beam_shape,
+    ).result()
+    logger.info(f"Convolving the MFS products to {beam_shape=}")
+
+    convolved = {
+        stokes: {
+            product_type: task_convolve_images_or_blank.submit(
+                image_paths=images, beam_shape=beam_shape, cutoff=cutoff
+            )
+            for product_type, images in product_type_images.items()
+        }
+        for stokes, product_type_images in mfs_beam_images.items()
+    }
+
+    return {
+        stokes: {
+            product_type: future.result()
+            for product_type, future in product_type_futures.items()
+        }
+        for stokes, product_type_futures in convolved.items()
+    }
 
 
 @task

--- a/flint/prefect/common/rmsynth.py
+++ b/flint/prefect/common/rmsynth.py
@@ -8,14 +8,25 @@ that actually import this module.
 from __future__ import annotations
 
 from pathlib import Path
+from typing import NamedTuple
 
 from prefect import unmapped
+from prefect.futures import PrefectFuture
 
+from flint.bane import BANEMaps
 from flint.convol import BeamShape, convolve_plane_to_beam
 from flint.logging import logger
-from flint.options import FitsCubeOptions, RMCleanOptions, RMSynthOptions
+from flint.options import (
+    CubesForRMSynth,
+    ErrorCubesForRMSynth,
+    FFTBANEOptions,
+    FitsCubeOptions,
+    RMCleanOptions,
+    RMSynthOptions,
+)
 from flint.prefect.caching import task
 from flint.prefect.common.imaging import (
+    task_bane_fits_image,
     task_combine_images_to_cube,
     task_remove_files_folders,
     task_split_cube_into_planes,
@@ -32,13 +43,38 @@ from flint.rmsynth import (
 task_convolve_plane_to_beam = task(convolve_plane_to_beam)
 
 
+class CommonResolutionCubes(NamedTuple):
+    """The cubes ``convolve_cubes_to_common_resolution`` writes, keyed by Stokes"""
+
+    cubes: dict[str, Path]
+    """The cube to use per Stokes: convolved, or the input unchanged"""
+    convolved: bool = False
+    """False when the inputs already shared a resolution and nothing new was written"""
+    bkg_cubes: dict[str, Path] = {}
+    """BANE background cube per Stokes. Empty unless BANE was asked for"""
+    rms_cubes: dict[str, Path] = {}
+    """BANE RMS cube per Stokes. Empty unless BANE was asked for"""
+
+    @property
+    def all_cubes(self) -> list[Path]:
+        """Every cube written"""
+        if not self.convolved:
+            return []
+        return [
+            *self.cubes.values(),
+            *self.bkg_cubes.values(),
+            *self.rms_cubes.values(),
+        ]
+
+
 def convolve_cubes_to_common_resolution(
     cubes: dict[str, Path],
     beam_shape: BeamShape,
     output_path: Path | None = None,
     beam_cutoff: float | None = None,
     convol_suffix: str = "conv",
-) -> dict[str, Path]:
+    fft_bane_options: FFTBANEOptions | None = None,
+) -> CommonResolutionCubes:
     """Bring a set of FITS cubes to the one resolution described by
     ``beam_shape``, writing new cubes and leaving the inputs as they are. This is
     the 'total' resolution mode of racs_tools: one beam for every channel of
@@ -56,9 +92,10 @@ def convolve_cubes_to_common_resolution(
         output_path (Path | None, optional): Directory the new cubes are written into. Defaults to alongside each input cube.
         beam_cutoff (float | None, optional): Channels coarser than this, in arcsec, are blanked rather than convolved to. Defaults to no cutoff.
         convol_suffix (str, optional): The marker added to the name of a smoothed plane, and of the cube they are stacked into. Defaults to 'conv'.
+        fft_bane_options (FFTBANEOptions | None, optional): When given, each convolved plane also gets a BANE background and RMS map, stacked into their own cubes. Measured after the convolution, so they describe the resolution rm-synthesis actually builds the FDF at. Defaults to None.
 
     Returns:
-        dict[str, Path]: The convolved cube for each key of ``cubes``
+        CommonResolutionCubes: The convolved cube for each key of ``cubes``, and the BANE cubes when asked for
     """
     fitscube_options = FitsCubeOptions(
         # The weight cubes are not convolved, so the convolved image cubes have
@@ -106,21 +143,54 @@ def convolve_cubes_to_common_resolution(
         convol_suffix=unmapped(convol_suffix),
     ).result()
 
-    cube_futures = {}
+    # Measured on the convolved planes, which is the resolution the FDF is
+    # built at. Resolved before the cubes are assembled, since `fitscube_options`
+    # removes each plane once cubed.
+    bane_maps: list[BANEMaps] = []
+    if fft_bane_options is not None:
+        bane_maps = task_bane_fits_image.map(
+            image=convolved_planes,
+            fft_bane_options=unmapped(fft_bane_options),
+        ).result()
+
+    cube_futures: dict[str, dict[str, PrefectFuture[Path]]] = {
+        mode: {} for mode in (convol_suffix, "bkg", "rms")
+    }
     plane_idx = 0
     for key, planes in planes_per_cube.items():
-        cube_futures[key] = task_combine_images_to_cube.submit(
-            images=convolved_planes[plane_idx : plane_idx + len(planes)],
-            prefix=str(cube_parent[key] / cubes[key].stem),
+        plane_slice = slice(plane_idx, plane_idx + len(planes))
+        prefix = str(cube_parent[key] / cubes[key].stem)
+        cube_futures[convol_suffix][key] = task_combine_images_to_cube.submit(
+            images=convolved_planes[plane_slice],
+            prefix=prefix,
             mode=convol_suffix,
             fitscube_options=fitscube_options,
         )
+        for mode, attribute in (("bkg", "bkg_image"), ("rms", "rms_image")):
+            if bane_maps:
+                cube_futures[mode][key] = task_combine_images_to_cube.submit(
+                    images=[
+                        getattr(maps, attribute) for maps in bane_maps[plane_slice]
+                    ],
+                    prefix=prefix,
+                    mode=f"{convol_suffix}.{mode}",
+                    fitscube_options=fitscube_options,
+                )
         plane_idx += len(planes)
     assert plane_idx == len(convolved_planes), (
         f"Have {len(convolved_planes)} convolved planes across {plane_idx} channels"
     )
 
-    convolved_cubes = {key: future.result() for key, future in cube_futures.items()}
+    resolved = {
+        mode: {key: future.result() for key, future in futures.items()}
+        for mode, futures in cube_futures.items()
+    }
+    convolved_cubes = CommonResolutionCubes(
+        cubes=resolved[convol_suffix],
+        convolved=True,
+        bkg_cubes=resolved["bkg"],
+        rms_cubes=resolved["rms"],
+    )
 
     # The convolved planes are removed as each cube is assembled, leaving the
     # planes they were made from behind
@@ -131,13 +201,9 @@ def convolve_cubes_to_common_resolution(
 
 @task
 def task_rmsynth(
-    stokes_q_cube: Path,
-    stokes_u_cube: Path,
+    stokes_cubes: CubesForRMSynth,
     rmsynth_options: RMSynthOptions,
-    stokes_i_cube: Path | None = None,
-    stokes_q_weight_cube: Path | None = None,
-    stokes_u_weight_cube: Path | None = None,
-    stokes_i_weight_cube: Path | None = None,
+    error_cubes: ErrorCubesForRMSynth | None = None,
 ) -> RMSynth3DResults:
     from prefect_dask import get_dask_client
 
@@ -146,13 +212,9 @@ def task_rmsynth(
     # client they would read whole cubes on this one worker.
     with get_dask_client():
         return run_rmsynth_3d(
-            stokes_q_cube=stokes_q_cube,
-            stokes_u_cube=stokes_u_cube,
-            stokes_q_weight_cube=stokes_q_weight_cube,
-            stokes_u_weight_cube=stokes_u_weight_cube,
+            stokes_cubes=stokes_cubes,
             rmsynth_options=rmsynth_options,
-            stokes_i_cube=stokes_i_cube,
-            stokes_i_weight_cube=stokes_i_weight_cube,
+            error_cubes=error_cubes,
         )
 
 
@@ -180,6 +242,8 @@ def task_write_rm_products(
     moment_products: list[FDFLabel],
     peak_products: list[FDFLabel],
     output_prefix: Path,
+    moment_threshold_snr: float = 5.0,
+    peak_threshold_snr: float = 0.0,
 ) -> list[Path]:
     """Batch-compute and write the requested RM-synthesis/RM-CLEAN products"""
     from prefect_dask import get_dask_client
@@ -196,5 +260,7 @@ def task_write_rm_products(
             moment_products=moment_products,
             peak_products=peak_products,
             output_prefix=output_prefix,
+            moment_threshold_snr=moment_threshold_snr,
+            peak_threshold_snr=peak_threshold_snr,
             dask_client=client,
         )

--- a/flint/prefect/common/rmsynth.py
+++ b/flint/prefect/common/rmsynth.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from flint.convol import convolve_cubes_to_common_beam
 from flint.logging import logger
 from flint.options import RMCleanOptions, RMSynthOptions
 from flint.prefect.caching import task
@@ -20,6 +21,8 @@ from flint.rmsynth import (
     run_rmsynth_3d,
     write_rm_products,
 )
+
+task_convolve_cubes_to_common_beam = task(convolve_cubes_to_common_beam)
 
 
 @task

--- a/flint/prefect/common/rmsynth.py
+++ b/flint/prefect/common/rmsynth.py
@@ -1,0 +1,14 @@
+"""Prefect task wrapper for RM-synthesis (``flint.rmsynth``).
+
+Kept separate from ``flint.prefect.common.imaging`` (which every flow already
+imports) so that the ``rm-lite`` optional dependency is only required by flows
+that actually import this module.
+"""
+
+from __future__ import annotations
+
+from prefect import task
+
+from flint.rmsynth import rmsynth_and_write_products
+
+task_rmsynth_and_write_products = task(rmsynth_and_write_products)

--- a/flint/prefect/common/rmsynth.py
+++ b/flint/prefect/common/rmsynth.py
@@ -40,7 +40,10 @@ def convolve_cubes_to_common_resolution(
     convol_suffix: str = "conv",
 ) -> dict[str, Path]:
     """Bring a set of FITS cubes to the one resolution described by
-    ``beam_shape``, writing new cubes and leaving the inputs as they are.
+    ``beam_shape``, writing new cubes and leaving the inputs as they are. This is
+    the 'total' resolution mode of racs_tools: one beam for every channel of
+    every cube. The polarisation stage instead leaves its cubes at a 'natural'
+    resolution, one beam per channel, which is what they are archived at.
 
     Each cube is split into its per-channel planes, every plane of every cube is
     convolved as its own task, and the planes are then stacked back into a cube.

--- a/flint/prefect/common/rmsynth.py
+++ b/flint/prefect/common/rmsynth.py
@@ -7,8 +7,43 @@ that actually import this module.
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from prefect import task
 
-from flint.rmsynth import rmsynth_and_write_products
+from flint.logging import logger
+from flint.options import RMCleanOptions, RMSynthOptions
+from flint.rmsynth import FDFLabel, rmsynth_and_write_products
 
-task_rmsynth_and_write_products = task(rmsynth_and_write_products)
+
+@task
+def task_rmsynth_and_write_products(
+    stokes_q_cube: Path,
+    stokes_u_cube: Path,
+    rmsynth_options: RMSynthOptions,
+    rmclean_options: RMCleanOptions,
+    cube_products: list[FDFLabel],
+    moment_products: list[FDFLabel],
+    output_prefix: Path,
+    stokes_i_cube: Path | None = None,
+) -> list[Path]:
+    """Run RM-synthesis, computing across the Dask cluster backing the flow's
+    ``DaskTaskRunner`` rather than just this task's own worker -- mirrors how
+    ``task_crystalball_to_ms`` hands its distributed Client to crystalball
+    (``flint/prefect/common/predict.py``).
+    """
+    from prefect_dask import get_dask_client
+
+    with get_dask_client(set_as_default=False) as client:
+        logger.info("Obtained the Client supporting the DaskTaskRunner.")
+        return rmsynth_and_write_products(
+            stokes_q_cube=stokes_q_cube,
+            stokes_u_cube=stokes_u_cube,
+            rmsynth_options=rmsynth_options,
+            rmclean_options=rmclean_options,
+            cube_products=cube_products,
+            moment_products=moment_products,
+            output_prefix=output_prefix,
+            stokes_i_cube=stokes_i_cube,
+            dask_client=client,
+        )

--- a/flint/prefect/common/rmsynth.py
+++ b/flint/prefect/common/rmsynth.py
@@ -74,8 +74,8 @@ def task_write_rm_products(
     rmclean_options: RMCleanOptions,
     cube_products: list[FDFLabel],
     moment_products: list[FDFLabel],
+    peak_products: list[FDFLabel],
     output_prefix: Path,
-    peak_products: list[FDFLabel] | None = None,
 ) -> list[Path]:
     """Batch-compute and write the requested RM-synthesis/RM-CLEAN products"""
     from prefect_dask import get_dask_client
@@ -90,7 +90,7 @@ def task_write_rm_products(
             rmclean_options=rmclean_options,
             cube_products=cube_products,
             moment_products=moment_products,
+            peak_products=peak_products,
             output_prefix=output_prefix,
             dask_client=client,
-            peak_products=peak_products,
         )

--- a/flint/prefect/common/rmsynth.py
+++ b/flint/prefect/common/rmsynth.py
@@ -1,4 +1,4 @@
-"""Prefect task wrapper for RM-synthesis (``flint.rmsynth``).
+"""Prefect task wrappers for RM-synthesis (``flint.rmsynth``).
 
 Kept separate from ``flint.prefect.common.imaging`` (which every flow already
 imports) so that the ``rm-lite`` optional dependency is only required by flows
@@ -9,41 +9,79 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from prefect import task
-
 from flint.logging import logger
 from flint.options import RMCleanOptions, RMSynthOptions
-from flint.rmsynth import FDFLabel, rmsynth_and_write_products
+from flint.prefect.caching import task
+from flint.rmsynth import (
+    FDFLabel,
+    RMClean3DResults,
+    RMSynth3DResults,
+    run_rmclean_3d,
+    run_rmsynth_3d,
+    write_rm_products,
+)
+
+
+# task_rmsynth = task(run_rmsynth_3d)
+@task
+def task_rmsynth(
+    stokes_q_cube: Path,
+    stokes_u_cube: Path,
+    rmsynth_options: RMSynthOptions,
+    stokes_i_cube: Path | None = None,
+) -> RMSynth3DResults:
+    from prefect_dask import get_dask_client
+
+    # Set as the default scheduler, not just borrowed: rm-lite's per-channel
+    # noise estimates are eager `dask.compute` calls, so without a default
+    # client they would read whole cubes on this one worker.
+    with get_dask_client():
+        return run_rmsynth_3d(
+            stokes_q_cube=stokes_q_cube,
+            stokes_u_cube=stokes_u_cube,
+            rmsynth_options=rmsynth_options,
+            stokes_i_cube=stokes_i_cube,
+        )
+
+
+# task_rmclean = task(run_rmclean_3d)
+@task
+def task_rmclean(
+    rm_synth_results: RMSynth3DResults, rmclean_options: RMCleanOptions
+) -> RMClean3DResults:
+    from prefect_dask import get_dask_client
+
+    with get_dask_client():
+        return run_rmclean_3d(
+            rm_synth_results=rm_synth_results,
+            rmclean_options=rmclean_options,
+        )
 
 
 @task
-def task_rmsynth_and_write_products(
+def task_write_rm_products(
+    synth_results: RMSynth3DResults,
+    clean_results: RMClean3DResults | None,
     stokes_q_cube: Path,
-    stokes_u_cube: Path,
     rmsynth_options: RMSynthOptions,
     rmclean_options: RMCleanOptions,
     cube_products: list[FDFLabel],
     moment_products: list[FDFLabel],
     output_prefix: Path,
-    stokes_i_cube: Path | None = None,
 ) -> list[Path]:
-    """Run RM-synthesis, computing across the Dask cluster backing the flow's
-    ``DaskTaskRunner`` rather than just this task's own worker -- mirrors how
-    ``task_crystalball_to_ms`` hands its distributed Client to crystalball
-    (``flint/prefect/common/predict.py``).
-    """
+    """Batch-compute and write the requested RM-synthesis/RM-CLEAN products"""
     from prefect_dask import get_dask_client
 
     with get_dask_client(set_as_default=False) as client:
         logger.info("Obtained the Client supporting the DaskTaskRunner.")
-        return rmsynth_and_write_products(
+        return write_rm_products(
+            synth_results=synth_results,
+            clean_results=clean_results,
             stokes_q_cube=stokes_q_cube,
-            stokes_u_cube=stokes_u_cube,
             rmsynth_options=rmsynth_options,
             rmclean_options=rmclean_options,
             cube_products=cube_products,
             moment_products=moment_products,
             output_prefix=output_prefix,
-            stokes_i_cube=stokes_i_cube,
             dask_client=client,
         )

--- a/flint/prefect/common/rmsynth.py
+++ b/flint/prefect/common/rmsynth.py
@@ -72,6 +72,7 @@ def task_write_rm_products(
     cube_products: list[FDFLabel],
     moment_products: list[FDFLabel],
     output_prefix: Path,
+    peak_products: list[FDFLabel] | None = None,
 ) -> list[Path]:
     """Batch-compute and write the requested RM-synthesis/RM-CLEAN products"""
     from prefect_dask import get_dask_client
@@ -88,4 +89,5 @@ def task_write_rm_products(
             moment_products=moment_products,
             output_prefix=output_prefix,
             dask_client=client,
+            peak_products=peak_products,
         )

--- a/flint/prefect/common/rmsynth.py
+++ b/flint/prefect/common/rmsynth.py
@@ -9,10 +9,17 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from flint.convol import convolve_cubes_to_common_beam
+from prefect import unmapped
+
+from flint.convol import BeamShape, convolve_plane_to_beam
 from flint.logging import logger
-from flint.options import RMCleanOptions, RMSynthOptions
+from flint.options import FitsCubeOptions, RMCleanOptions, RMSynthOptions
 from flint.prefect.caching import task
+from flint.prefect.common.imaging import (
+    task_combine_images_to_cube,
+    task_remove_files_folders,
+    task_split_cube_into_planes,
+)
 from flint.rmsynth import (
     FDFLabel,
     RMClean3DResults,
@@ -22,7 +29,101 @@ from flint.rmsynth import (
     write_rm_products,
 )
 
-task_convolve_cubes_to_common_beam = task(convolve_cubes_to_common_beam)
+task_convolve_plane_to_beam = task(convolve_plane_to_beam)
+
+
+def convolve_cubes_to_common_resolution(
+    cubes: dict[str, Path],
+    beam_shape: BeamShape,
+    output_path: Path | None = None,
+    beam_cutoff: float | None = None,
+    convol_suffix: str = "conv",
+) -> dict[str, Path]:
+    """Bring a set of FITS cubes to the one resolution described by
+    ``beam_shape``, writing new cubes and leaving the inputs as they are.
+
+    Each cube is split into its per-channel planes, every plane of every cube is
+    convolved as its own task, and the planes are then stacked back into a cube.
+    A 3D convolution would instead work through one cube at a time on a single
+    worker, and would pull each whole cube into memory to do it.
+
+    Args:
+        cubes (dict[str, Path]): The cubes to convolve, keyed however the caller wants the outputs keyed
+        beam_shape (BeamShape): The resolution every channel is brought to
+        output_path (Path | None, optional): Directory the new cubes are written into. Defaults to alongside each input cube.
+        beam_cutoff (float | None, optional): Channels coarser than this, in arcsec, are blanked rather than convolved to. Defaults to no cutoff.
+        convol_suffix (str, optional): The marker added to the name of a smoothed plane, and of the cube they are stacked into. Defaults to 'conv'.
+
+    Returns:
+        dict[str, Path]: The convolved cube for each key of ``cubes``
+    """
+    fitscube_options = FitsCubeOptions(
+        # The weight cubes are not convolved, so the convolved image cubes have
+        # to stay on the pixel and channel grid of the cubes they came from
+        bounding_box=False,
+        create_blanks=False,
+        # Convolution has already put the pixel values on a new scale, so
+        # leaving exact zeros be avoids reinterpreting them a second time
+        invalidate_zeros=False,
+        # rm-synth and the spice stage both read these cubes plane by plane, and
+        # astropy cannot memmap a gzip file
+        compress=False,
+        remove_original_images=True,
+    )
+
+    if output_path is not None:
+        output_path.mkdir(parents=True, exist_ok=True)
+
+    cube_parent = {
+        key: output_path if output_path is not None else cube.parent
+        for key, cube in cubes.items()
+    }
+    # A plane's name carries only the flint name fields, so cubes that agree on
+    # them (e.g. the same Stokes at differing stages) would clobber each other's
+    # planes were they split into the same directory
+    plane_paths = {
+        key: cube_parent[key] / f"{cube.stem}.planes" for key, cube in cubes.items()
+    }
+
+    split_planes = {
+        key: task_split_cube_into_planes.submit(cube=cube, output_path=plane_paths[key])
+        for key, cube in cubes.items()
+    }
+    # Resolved here so the planes can be mapped over individually below
+    planes_per_cube: dict[str, list[Path]] = {
+        key: future.result() for key, future in split_planes.items()
+    }
+
+    # One task per plane rather than per cube, so every channel of every cube is
+    # convolved across the cluster at once
+    convolved_planes = task_convolve_plane_to_beam.map(
+        plane=[plane for planes in planes_per_cube.values() for plane in planes],
+        beam_shape=unmapped(beam_shape),
+        cutoff=unmapped(beam_cutoff),
+        convol_suffix=unmapped(convol_suffix),
+    ).result()
+
+    cube_futures = {}
+    plane_idx = 0
+    for key, planes in planes_per_cube.items():
+        cube_futures[key] = task_combine_images_to_cube.submit(
+            images=convolved_planes[plane_idx : plane_idx + len(planes)],
+            prefix=str(cube_parent[key] / cubes[key].stem),
+            mode=convol_suffix,
+            fitscube_options=fitscube_options,
+        )
+        plane_idx += len(planes)
+    assert plane_idx == len(convolved_planes), (
+        f"Have {len(convolved_planes)} convolved planes across {plane_idx} channels"
+    )
+
+    convolved_cubes = {key: future.result() for key, future in cube_futures.items()}
+
+    # The convolved planes are removed as each cube is assembled, leaving the
+    # planes they were made from behind
+    task_remove_files_folders.submit(*plane_paths.values()).result()
+
+    return convolved_cubes
 
 
 @task

--- a/flint/prefect/common/rmsynth.py
+++ b/flint/prefect/common/rmsynth.py
@@ -22,13 +22,15 @@ from flint.rmsynth import (
 )
 
 
-# task_rmsynth = task(run_rmsynth_3d)
 @task
 def task_rmsynth(
     stokes_q_cube: Path,
     stokes_u_cube: Path,
     rmsynth_options: RMSynthOptions,
     stokes_i_cube: Path | None = None,
+    stokes_q_weight_cube: Path | None = None,
+    stokes_u_weight_cube: Path | None = None,
+    stokes_i_weight_cube: Path | None = None,
 ) -> RMSynth3DResults:
     from prefect_dask import get_dask_client
 
@@ -39,12 +41,14 @@ def task_rmsynth(
         return run_rmsynth_3d(
             stokes_q_cube=stokes_q_cube,
             stokes_u_cube=stokes_u_cube,
+            stokes_q_weight_cube=stokes_q_weight_cube,
+            stokes_u_weight_cube=stokes_u_weight_cube,
             rmsynth_options=rmsynth_options,
             stokes_i_cube=stokes_i_cube,
+            stokes_i_weight_cube=stokes_i_weight_cube,
         )
 
 
-# task_rmclean = task(run_rmclean_3d)
 @task
 def task_rmclean(
     rm_synth_results: RMSynth3DResults, rmclean_options: RMCleanOptions

--- a/flint/prefect/common/rmsynth.py
+++ b/flint/prefect/common/rmsynth.py
@@ -243,7 +243,6 @@ def task_write_rm_products(
     peak_products: list[FDFLabel],
     output_prefix: Path,
     moment_threshold_snr: float = 5.0,
-    peak_threshold_snr: float = 0.0,
 ) -> list[Path]:
     """Batch-compute and write the requested RM-synthesis/RM-CLEAN products"""
     from prefect_dask import get_dask_client
@@ -261,6 +260,5 @@ def task_write_rm_products(
             peak_products=peak_products,
             output_prefix=output_prefix,
             moment_threshold_snr=moment_threshold_snr,
-            peak_threshold_snr=peak_threshold_snr,
             dask_client=client,
         )

--- a/flint/prefect/common/spice.py
+++ b/flint/prefect/common/spice.py
@@ -1,0 +1,44 @@
+"""Prefect task wrappers for SPICE-style cube trimming (``flint.spice``)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from astropy.io import fits
+from astropy.wcs import WCS
+from fitscube.combine_fits import compress_cube
+from prefect import task
+
+from flint.coadd.linmos import BoundingBox
+from flint.convol import BeamShape
+from flint.options import SpiceOptions
+from flint.spice import island_bounding_boxes, load_component_table, spice_fits
+
+
+@task
+def task_get_spice_boxes(
+    reference_image: Path,
+    catalogue: Path,
+    spice_options: SpiceOptions,
+    beam_shape: BeamShape,
+    is_user_catalogue: bool,
+) -> list[BoundingBox]:
+    """Build the (single, shared) set of island bounding boxes for a field,
+    against ``reference_image``'s WCS/shape -- reused as-is for every
+    Stokes/plane/cube ``task_spice_fits`` is later applied to."""
+    header = fits.getheader(reference_image)
+    wcs = WCS(header)
+    image_shape = (header["NAXIS2"], header["NAXIS1"])
+
+    return island_bounding_boxes(
+        table=load_component_table(catalogue),
+        wcs=wcs,
+        image_shape=image_shape,
+        beam_shape=beam_shape,
+        spice_options=spice_options,
+        is_user_catalogue=is_user_catalogue,
+    )
+
+
+task_spice_fits = task(spice_fits)
+task_compress_cube = task(compress_cube)

--- a/flint/prefect/common/spice.py
+++ b/flint/prefect/common/spice.py
@@ -7,12 +7,16 @@ from pathlib import Path
 from astropy.io import fits
 from astropy.wcs import WCS
 from fitscube.combine_fits import compress_cube
-from prefect import task
 
-from flint.coadd.linmos import BoundingBox
 from flint.convol import BeamShape
 from flint.options import SpiceOptions
-from flint.spice import island_bounding_boxes, load_component_table, spice_fits
+from flint.prefect.caching import task
+from flint.spice import (
+    SkyBoundingBox,
+    island_sky_boxes,
+    load_component_table,
+    spice_fits,
+)
 
 
 @task
@@ -22,18 +26,13 @@ def task_get_spice_boxes(
     spice_options: SpiceOptions,
     beam_shape: BeamShape,
     is_user_catalogue: bool,
-) -> list[BoundingBox]:
-    """Build the (single, shared) set of island bounding boxes for a field,
-    against ``reference_image``'s WCS/shape -- reused as-is for every
-    Stokes/plane/cube ``task_spice_fits`` is later applied to."""
-    header = fits.getheader(reference_image)
-    wcs = WCS(header)
-    image_shape = (header["NAXIS2"], header["NAXIS1"])
+) -> list[SkyBoundingBox]:
+    """Build the set of island sky boxes for a field"""
+    wcs = WCS(fits.getheader(reference_image))
 
-    return island_bounding_boxes(
+    return island_sky_boxes(
         table=load_component_table(catalogue),
         wcs=wcs,
-        image_shape=image_shape,
         beam_shape=beam_shape,
         spice_options=spice_options,
         is_user_catalogue=is_user_catalogue,

--- a/flint/prefect/common/utils.py
+++ b/flint/prefect/common/utils.py
@@ -44,11 +44,16 @@ task_flag_antenna_from_casda_bandpass_table = task(
 def task_concatenate_holography(
     output_path: Path,
     holo_cubes: list[Path],
+    update_concat_holo_options: dict[str, Any] | None = None,
 ) -> Path:
     logger.info("Attempting to concatenate holography cubes")
     concat_holo_options = ConcatHoloOptions(
         output_path=output_path, holo_cubes=holo_cubes, max_workers=8
     )
+    if update_concat_holo_options:
+        concat_holo_options = concat_holo_options.with_options(
+            **update_concat_holo_options
+        )
 
     return concatenate_holography(concat_holo_options=concat_holo_options)
 

--- a/flint/prefect/flows/polarisation_pipeline.py
+++ b/flint/prefect/flows/polarisation_pipeline.py
@@ -303,6 +303,9 @@ def process_science_fields_pol(
                 holofile=pol_field_options.holofile,
                 cutoff=pol_field_options.pb_cutoff,
                 cleanup=True,
+                # Must match the untrimmed shape of the per-channel/cube images
+                # spice_fits later compares this reference's shape against.
+                trim_linmos_fits=False,
             ),
             field_summary=field_summary,
             holofile=pol_field_options.holofile,

--- a/flint/prefect/flows/polarisation_pipeline.py
+++ b/flint/prefect/flows/polarisation_pipeline.py
@@ -21,7 +21,7 @@ from flint.imager.wsclean import (
     WSCleanResult,
 )
 from flint.logging import logger
-from flint.ms import find_mss
+from flint.ms import MSsByBeam, find_mss
 from flint.naming import (
     CASDANameComponents,
     ProcessedNameComponents,
@@ -52,12 +52,17 @@ from flint.prefect.common.utils import (
     task_getattr,
 )
 
+# Marks images/cubes produced by this pipeline so they don't clash with the
+# continuum self-cal flow's own Stokes I/V products for the same MS/beam.
+POL_NAME_SUFFIX = "pol"
+
 
 @flow(name="Flint Polarisation Pipeline")
 def process_science_fields_pol(
     flint_ms_directory: Path,
     pol_field_options: PolFieldOptions,
     cube_division: ChannelDivision | None = None,
+    mss_by_beam: MSsByBeam | None = None,
 ) -> list[PrefectFuture[Any]]:
     # returned futures are resolved by prefect to fail the flow on task failure
     strategy = load_and_copy_strategy(
@@ -71,56 +76,68 @@ def process_science_fields_pol(
         logger.info("No strategy provided. Returning.")
         return []
 
-    # Get some placeholder names
-    science_mss = list(
-        find_mss(
-            mss_parent_path=flint_ms_directory,
-            expected_ms_count=pol_field_options.expected_ms,
-            data_column=strategy["defaults"].get("data_column", "DATA"),
-        )
-    )
-    # Check if MSs have been processed by Flint or have been provided by CASDA
-    from_flint_list = [
-        isinstance(extract_components_from_name(ms.path), ProcessedNameComponents)
-        for ms in science_mss
-    ]
-    from_casda_list = [
-        isinstance(extract_components_from_name(ms.path), CASDANameComponents)
-        for ms in science_mss
-    ]
-
-    if not any(from_flint_list) and not any(from_casda_list):
-        raise MSError("No valid MeasurementSets found! Data must be calibrated first.")
-
-    if any(from_flint_list) and any(from_casda_list):
-        raise MSError("Cannot mix Flint-processed and CASDA-provided MeasurementSets!")
-
-    if any(from_casda_list):
-        assert all(from_casda_list), (
-            "Some MeasurementSets are from Flint, some are from CASDA"
-        )
-        logger.info("Data are from CASDA, need to apply FixMS")
-        if pol_field_options.casa_container is None:
-            msg = "We need to apply FixMS to CASDA-provided data, but no CASA container provided"
-            raise MSError(msg)
-
-        corrected_mss = []
-        for ms in science_mss:
-            corrected_ms = task_preprocess_askap_ms.submit(
-                ms=ms,
+    if mss_by_beam is not None:
+        # Already Flint-processed, self-calibrated MSs handed down by the calling
+        # flow (e.g. the RACS-All continuum flow). No need to rediscover them on
+        # disk or check whether they are CASDA-provided.
+        logger.info("Using the measurement sets supplied by the calling flow")
+        resolved_mss_by_beam: MSsByBeam = mss_by_beam
+    else:
+        # Get some placeholder names
+        science_mss = list(
+            find_mss(
+                mss_parent_path=flint_ms_directory,
+                expected_ms_count=pol_field_options.expected_ms,
                 data_column=strategy["defaults"].get("data_column", "DATA"),
-                skip_rotation=False,
-                fix_stokes_factor=True,
-                apply_ms_transform=True,
-                casa_container=pol_field_options.casa_container,
-                rename=True,
             )
-            corrected_mss.append(corrected_ms)
-
-        assert len(corrected_mss) == len(science_mss), (
-            "Number of corrected MSs does not match number of input MSs"
         )
-        science_mss = corrected_mss
+        # Check if MSs have been processed by Flint or have been provided by CASDA
+        from_flint_list = [
+            isinstance(extract_components_from_name(ms.path), ProcessedNameComponents)
+            for ms in science_mss
+        ]
+        from_casda_list = [
+            isinstance(extract_components_from_name(ms.path), CASDANameComponents)
+            for ms in science_mss
+        ]
+
+        if not any(from_flint_list) and not any(from_casda_list):
+            raise MSError("No valid MeasurementSets found! Data must be calibrated first.")
+
+        if any(from_flint_list) and any(from_casda_list):
+            raise MSError("Cannot mix Flint-processed and CASDA-provided MeasurementSets!")
+
+        if any(from_casda_list):
+            assert all(from_casda_list), (
+                "Some MeasurementSets are from Flint, some are from CASDA"
+            )
+            logger.info("Data are from CASDA, need to apply FixMS")
+            if pol_field_options.casa_container is None:
+                msg = "We need to apply FixMS to CASDA-provided data, but no CASA container provided"
+                raise MSError(msg)
+
+            corrected_mss = []
+            for ms in science_mss:
+                corrected_ms = task_preprocess_askap_ms.submit(
+                    ms=ms,
+                    data_column=strategy["defaults"].get("data_column", "DATA"),
+                    skip_rotation=False,
+                    fix_stokes_factor=True,
+                    apply_ms_transform=True,
+                    casa_container=pol_field_options.casa_container,
+                    rename=True,
+                )
+                corrected_mss.append(corrected_ms)
+
+            assert len(corrected_mss) == len(science_mss), (
+                "Number of corrected MSs does not match number of input MSs"
+            )
+            science_mss = corrected_mss
+
+        # Each beam is a single MS when discovered this way (one SBID/band per directory)
+        resolved_mss_by_beam = tuple((ms,) for ms in science_mss)
+
+    science_mss = [ms for beam_mss in resolved_mss_by_beam for ms in beam_mss]
 
     field_summary = task_create_field_summary.submit(
         mss=science_mss,
@@ -147,13 +164,14 @@ def process_science_fields_pol(
     for polarisation in polarisations.keys():
         _image_sets = []
         with tags(f"polarisation-{polarisation}"):
-            for science_ms in science_mss:
+            for beam_mss in resolved_mss_by_beam:
                 update_wsclean_options = get_options_from_strategy(
                     strategy=strategy,
                     operation="polarisation",
                     mode="wsclean",
                     polarisation=polarisation,
                 )
+                update_wsclean_options["flint_name_suffix"] = POL_NAME_SUFFIX
                 if cube_division is not None:
                     update_wsclean_options = apply_cube_division(
                         update_wsclean_options=update_wsclean_options,
@@ -161,7 +179,7 @@ def process_science_fields_pol(
                     )
                 wsclean_result: PrefectFuture[WSCleanResult] = (
                     task_wsclean_imager.submit(
-                        in_ms=science_ms,
+                        in_ms=beam_mss,
                         wsclean_container=pol_field_options.wsclean_container,
                         make_cube_from_subbands=False,  # We will do this later
                         update_wsclean_options=update_wsclean_options,
@@ -258,6 +276,7 @@ def process_science_fields_pol(
                     stokesi_channel_groups=i_channel_groups,
                     field_summary=field_summary,
                     fitscube_options=fitscube_options,
+                    suffix_str=POL_NAME_SUFFIX,
                 )
             )
 

--- a/flint/prefect/flows/polarisation_pipeline.py
+++ b/flint/prefect/flows/polarisation_pipeline.py
@@ -141,6 +141,9 @@ def process_science_fields_pol(
 
     science_mss = [ms for beam_mss in resolved_mss_by_beam for ms in beam_mss]
 
+    logger.info(f"{science_mss=}")
+    logger.info(f"{pol_field_options.holofile=}")
+
     field_summary = task_create_field_summary.submit(
         mss=science_mss,
         holography_path=pol_field_options.holofile,

--- a/flint/prefect/flows/polarisation_pipeline.py
+++ b/flint/prefect/flows/polarisation_pipeline.py
@@ -15,6 +15,7 @@ from flint.configuration import (
     load_and_copy_strategy,
 )
 from flint.exceptions import MSError
+from flint.imager.channel_division import ChannelDivision, apply_cube_division
 from flint.imager.wsclean import (
     ImageSet,
     WSCleanResult,
@@ -55,6 +56,7 @@ from flint.prefect.common.utils import (
 def process_science_fields_pol(
     flint_ms_directory: Path,
     pol_field_options: PolFieldOptions,
+    cube_division: ChannelDivision | None = None,
 ) -> list[PrefectFuture[Any]]:
     # returned futures are resolved by prefect to fail the flow on task failure
     strategy = load_and_copy_strategy(
@@ -145,17 +147,23 @@ def process_science_fields_pol(
         _image_sets = []
         with tags(f"polarisation-{polarisation}"):
             for science_ms in science_mss:
+                update_wsclean_options = get_options_from_strategy(
+                    strategy=strategy,
+                    operation="polarisation",
+                    mode="wsclean",
+                    polarisation=polarisation,
+                )
+                if cube_division is not None:
+                    update_wsclean_options = apply_cube_division(
+                        update_wsclean_options=update_wsclean_options,
+                        cube_division=cube_division,
+                    )
                 wsclean_result: PrefectFuture[WSCleanResult] = (
                     task_wsclean_imager.submit(
                         in_ms=science_ms,
                         wsclean_container=pol_field_options.wsclean_container,
                         make_cube_from_subbands=False,  # We will do this later
-                        update_wsclean_options=get_options_from_strategy(
-                            strategy=strategy,
-                            operation="polarisation",
-                            mode="wsclean",
-                            polarisation=polarisation,
-                        ),
+                        update_wsclean_options=update_wsclean_options,
                     )
                 )
                 _image_set: PrefectFuture[ImageSet] = task_getattr.submit(

--- a/flint/prefect/flows/polarisation_pipeline.py
+++ b/flint/prefect/flows/polarisation_pipeline.py
@@ -102,10 +102,12 @@ def process_science_fields_pol(
         ]
 
         if not any(from_flint_list) and not any(from_casda_list):
-            raise MSError("No valid MeasurementSets found! Data must be calibrated first.")
+            msg = "No valid MeasurementSets found! Data must be calibrated first."
+            raise MSError(msg)
 
         if any(from_flint_list) and any(from_casda_list):
-            raise MSError("Cannot mix Flint-processed and CASDA-provided MeasurementSets!")
+            msg = "Cannot mix Flint-processed and CASDA-provided MeasurementSets!"
+            raise MSError(msg)
 
         if any(from_casda_list):
             assert all(from_casda_list), (

--- a/flint/prefect/flows/polarisation_pipeline.py
+++ b/flint/prefect/flows/polarisation_pipeline.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from functools import partial
 from pathlib import Path
 from typing import Any
 
@@ -34,6 +35,7 @@ from flint.options import (
     PolFieldOptions,
     RMCleanOptions,
     RMSynthOptions,
+    SpiceOptions,
     dump_field_options_to_yaml,
 )
 from flint.prefect.clusters import get_dask_runner
@@ -43,14 +45,22 @@ from flint.prefect.common.imaging import (
     task_create_name_from_common_fields,
     task_get_channel_images_from_paths,
     task_get_common_beam_from_image_set,
+    task_get_mfs_image_from_paths,
+    task_linmos_images,
     task_merge_image_sets,
     task_preprocess_askap_ms,
     task_remove_files_folders,
+    task_run_bane_and_aegean,
     task_split_and_get_image_set,
     task_transpose_and_sort_channel_images,
     task_wsclean_imager,
 )
 from flint.prefect.common.rmsynth import task_rmsynth_and_write_products
+from flint.prefect.common.spice import (
+    task_compress_cube,
+    task_get_spice_boxes,
+    task_spice_fits,
+)
 from flint.prefect.common.utils import (
     task_create_field_summary,
     task_getattr,
@@ -210,6 +220,11 @@ def process_science_fields_pol(
     # per-channel images (rather than cubing per beam) so we can co-add across
     # beams one channel at a time.
     stokes_beam_channel_images: dict[str, list[PrefectFuture[list[Path]]]] = {}
+    # Per-beam Stokes I MFS images, used by run_spice both as the field WCS
+    # reference for box-building and (absent a user spice_catalogue) as the
+    # image source-found against. wsclean already produces these; only the
+    # collection here is new.
+    beam_mfs_images: list[PrefectFuture[Path]] = []
     for polarisation, image_set_list in image_sets_dict.items():
         with tags(f"polarisation-{polarisation}"):
             # Get the individual Stokes parameters in case of joint imaging
@@ -231,6 +246,12 @@ def process_science_fields_pol(
                             beam_shape=common_beam_shape,
                             cutoff=pol_field_options.beam_cutoff,
                         )
+                        if stokes == "i" and pol_field_options.run_spice:
+                            beam_mfs_images.append(
+                                task_get_mfs_image_from_paths.submit(
+                                    paths=convolved_image_list
+                                )
+                            )
                         channel_image_list = task_get_channel_images_from_paths.submit(
                             paths=convolved_image_list
                         )
@@ -262,6 +283,67 @@ def process_science_fields_pol(
         )
     )
 
+    island_boxes: PrefectFuture[list] | None = None
+    if pol_field_options.run_spice:
+        # Required even with a user-supplied spice_catalogue: the MFS mosaic
+        # built below is the earliest field-level WCS reference available,
+        # needed to turn that catalogue's RA/Dec into pixel boxes.
+        assert i_channel_groups is not None, (
+            "run_spice requires the 'total' polarisation (Stokes I) to have been imaged"
+        )
+        assert (
+            pol_field_options.spice_catalogue is not None
+            or pol_field_options.aegean_container is not None
+        ), "run_spice without a spice_catalogue requires an aegean_container"
+
+        mfs_linmos_result = task_linmos_images.submit(
+            image_list=beam_mfs_images,
+            container=pol_field_options.yandasoft_container,
+            linmos_options=LinmosOptions(
+                holofile=pol_field_options.holofile,
+                cutoff=pol_field_options.pb_cutoff,
+                cleanup=True,
+            ),
+            field_summary=field_summary,
+            holofile=pol_field_options.holofile,
+        )
+        mfs_image_path = task_getattr.submit(mfs_linmos_result, "image_fits")
+
+        is_user_catalogue = pol_field_options.spice_catalogue is not None
+        if is_user_catalogue:
+            catalogue_path = pol_field_options.spice_catalogue
+        else:
+            aegean_outputs = task_run_bane_and_aegean.submit(
+                image=mfs_linmos_result,
+                aegean_container=pol_field_options.aegean_container,
+                update_bane_options=get_options_from_strategy(
+                    strategy=strategy, operation="polarisation", mode="bane"
+                ),
+                update_aegean_options=get_options_from_strategy(
+                    strategy=strategy, operation="polarisation", mode="aegean"
+                ),
+            )
+            catalogue_path = task_getattr.submit(aegean_outputs, "comp")
+
+        spice_options = SpiceOptions(
+            **get_options_from_strategy(
+                strategy=strategy, operation="polarisation", mode="spice"
+            )
+        )
+        island_boxes = task_get_spice_boxes.submit(
+            reference_image=mfs_image_path,
+            catalogue=catalogue_path,
+            spice_options=spice_options,
+            beam_shape=common_beam_shape,
+            is_user_catalogue=is_user_catalogue,
+        )
+
+    # Whether anything downstream needs the full-size (unspiced) cube: either
+    # spice is off entirely, or rm-synth is on and reading the full cube.
+    need_full_cube = not pol_field_options.run_spice or (
+        pol_field_options.run_rmsynth and not pol_field_options.rmsynth_on_spiced_cubes
+    )
+
     cube_results: list[PrefectFuture[Path]] = []
     stokes_image_cubes: dict[str, PrefectFuture[Path]] = {}
     all_input_images: list[Path] = []
@@ -283,6 +365,9 @@ def process_science_fields_pol(
                 field_summary=field_summary,
                 fitscube_options=fitscube_options,
                 suffix_str=POL_NAME_SUFFIX,
+                plane_post_process=partial(task_spice_fits.submit, boxes=island_boxes)
+                if pol_field_options.run_spice and not need_full_cube
+                else None,
             )
             stokes_image_cubes[stokes] = stokes_cubes[0]
             cube_results.extend(stokes_cubes)
@@ -324,6 +409,34 @@ def process_science_fields_pol(
             moment_products=pol_field_options.rmsynth_moment_products,
             output_prefix=output_prefix,
         )
+
+    if pol_field_options.run_spice:
+        if need_full_cube:
+            # Case 3: rm-synth (always on here, see need_full_cube above) has
+            # already read these full cubes -- now replace them in place.
+            spiced_cubes = [
+                task_spice_fits.submit(
+                    fits_path=cube, boxes=island_boxes, wait_for=[rmsynth_result]
+                )
+                for cube in cube_results
+            ]
+            compress_wait_for = None
+        else:
+            # Case 2: cube_results are already the spiced cubes (spice ran as
+            # plane_post_process before cubing). If rm-synth read them
+            # (rmsynth_on_spiced_cubes), keep them uncompressed until it's done.
+            spiced_cubes = cube_results
+            compress_wait_for = [rmsynth_result] if rmsynth_result else None
+
+        cube_results = [
+            task_compress_cube.submit(
+                out_cube=cube,
+                method=spice_options.compress_method,
+                max_workers=spice_options.compress_max_workers,
+                wait_for=compress_wait_for,
+            )
+            for cube in spiced_cubes
+        ]
 
     return [*cube_results, remove_result, *([rmsynth_result] if rmsynth_result else [])]
 

--- a/flint/prefect/flows/polarisation_pipeline.py
+++ b/flint/prefect/flows/polarisation_pipeline.py
@@ -78,6 +78,30 @@ class PolPipelineResult(BaseOptions):
     """Every future the polarisation stage produced, propagated so Prefect still detects any of their failures"""
 
 
+def _no_products(
+    terminal_futures: list[PrefectFuture[Any]] | None = None,
+) -> PolPipelineResult:
+    """The result of a polarisation stage that imaged nothing.
+
+    Built here rather than at each early return so that a field added to
+    ``PolPipelineResult`` cannot turn one of them into a ValidationError: the
+    downstream rm-synth stage reads ``weight_cubes`` off this, and an early
+    return that forgot it failed only once the flow was already running.
+
+    Args:
+        terminal_futures (list[PrefectFuture[Any]] | None, optional): Futures produced before the stage gave up, propagated so Prefect still detects their failures. Defaults to None.
+
+    Returns:
+        PolPipelineResult: An empty result carrying only ``terminal_futures``
+    """
+    return PolPipelineResult(
+        stokes_cubes={},
+        weight_cubes={},
+        mfs_products={},
+        terminal_futures=terminal_futures or [],
+    )
+
+
 @flow(name="Flint Polarisation Pipeline")
 def process_science_fields_pol(
     flint_ms_directory: Path,
@@ -105,9 +129,7 @@ def process_science_fields_pol(
 
     if strategy is None:
         logger.info("No strategy provided. Returning.")
-        return PolPipelineResult(
-            stokes_cubes={}, weight_cubes={}, mfs_products={}, terminal_futures=[]
-        )
+        return _no_products()
 
     if mss_by_beam is not None:
         # Already Flint-processed, self-calibrated MSs handed down by the calling
@@ -190,9 +212,7 @@ def process_science_fields_pol(
 
     if pol_field_options.wsclean_container is None:
         logger.info("No wsclean container provided. Returning. ")
-        return PolPipelineResult(
-            stokes_cubes={}, mfs_products={}, terminal_futures=[field_summary]
-        )
+        return _no_products(terminal_futures=[field_summary])
 
     polarisations: dict[str, str] = strategy.get("polarisation", {"total": {}})
 

--- a/flint/prefect/flows/polarisation_pipeline.py
+++ b/flint/prefect/flows/polarisation_pipeline.py
@@ -70,6 +70,8 @@ class PolPipelineResult(BaseOptions):
 
     stokes_cubes: dict[str, Path]
     """The full, unspiced Stokes cube written for each imaged polarisation (e.g. 'i', 'q', 'u', 'v')"""
+    weight_cubes: dict[str, Path]
+    """The full Stokes weights written for each imaged polarisation (e.g. 'i', 'q', 'u', 'v')"""
     mfs_products: dict[str, dict[str, Path]]
     """MFS image/model/residual products co-added per Stokes parameter, keyed by Stokes ('i', 'q', 'u', 'v') then product type ('image', 'model', 'residual'). Only populated for Stokes imaged under a polarisation with ``WSCleanOptions.flint_save_mfs_products`` set"""
     terminal_futures: list[PrefectFuture[Any]]
@@ -103,7 +105,7 @@ def process_science_fields_pol(
 
     if strategy is None:
         logger.info("No strategy provided. Returning.")
-        return PolPipelineResult(stokes_cubes={}, mfs_products={}, terminal_futures=[])
+        return PolPipelineResult(stokes_cubes={}, weight_cubes={}, mfs_products={}, terminal_futures=[])
 
     if mss_by_beam is not None:
         # Already Flint-processed, self-calibrated MSs handed down by the calling
@@ -340,6 +342,7 @@ def process_science_fields_pol(
 
     cube_results: list[PrefectFuture[Path]] = []
     stokes_image_cubes: dict[str, PrefectFuture[Path]] = {}
+    stokes_weight_cubes: dict[str, PrefectFuture[Path]] = {}
     all_input_images: list[Path] = []
     for stokes, channel_groups in stokes_channel_groups.items():
         with tags(f"stokes-{stokes}"):
@@ -360,7 +363,7 @@ def process_science_fields_pol(
                 fitscube_options=fitscube_options,
                 suffix_str=POL_NAME_SUFFIX,
             )
-            stokes_image_cubes[stokes] = stokes_cubes[0]
+            stokes_image_cubes[stokes], stokes_weight_cubes[stokes] = stokes_cubes
             cube_results.extend(stokes_cubes)
 
     # Remove the convolved per-beam channel images now that every cube is built.
@@ -424,6 +427,9 @@ def process_science_fields_pol(
     return PolPipelineResult(
         stokes_cubes={
             stokes: future.result() for stokes, future in stokes_image_cubes.items()
+        },
+        weight_cubes={
+            stokes: future.result() for stokes, future in stokes_weight_cubes.items()
         },
         mfs_products={
             stokes: {

--- a/flint/prefect/flows/polarisation_pipeline.py
+++ b/flint/prefect/flows/polarisation_pipeline.py
@@ -11,6 +11,7 @@ from prefect.futures import PrefectFuture
 from flint.coadd.linmos import LinmosOptions
 from flint.configuration import (
     POLARISATION_MAPPING,
+    Strategy,
     get_options_from_strategy,
     load_and_copy_strategy,
 )
@@ -106,6 +107,29 @@ def _no_products(
         mfs_products={},
         terminal_futures=terminal_futures or [],
     )
+
+
+def _polarisations_to_image(strategy: Strategy) -> dict[str, Any]:
+    """Pull the polarisations to image out of the strategy's polarisation operation.
+
+    The operation also carries modes that apply across all polarisations (e.g.
+    ``fitscube``, ``fftbane``), which sit alongside the polarisation keys. Only
+    the polarisation keys describe something to image.
+
+    Args:
+        strategy (Strategy): The loaded strategy
+
+    Returns:
+        dict[str, Any]: Polarisation name and its scoped modes. Falls back to Stokes I when the strategy names none.
+    """
+    polarisation_scope = strategy.get("polarisation", {})
+    polarisations = {
+        key: value
+        for key, value in polarisation_scope.items()
+        if key in POLARISATION_MAPPING
+    }
+
+    return polarisations or {"total": {}}
 
 
 @flow(name="Flint Polarisation Pipeline")
@@ -220,7 +244,7 @@ def process_science_fields_pol(
         logger.info("No wsclean container provided. Returning. ")
         return _no_products(terminal_futures=[field_summary])
 
-    polarisations: dict[str, str] = strategy.get("polarisation", {"total": {}})
+    polarisations = _polarisations_to_image(strategy=strategy)
 
     # Solved once for all beams, and before any imaging
     cube_division: ChannelDivision | None = None

--- a/flint/prefect/flows/polarisation_pipeline.py
+++ b/flint/prefect/flows/polarisation_pipeline.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
-from functools import partial
 from pathlib import Path
 from typing import Any
 
-from capn_crunch import add_options_to_parser, create_options_from_parser
+from capn_crunch import BaseOptions, add_options_to_parser, create_options_from_parser
 from configargparse import ArgumentParser
 from prefect import flow, tags
 from prefect.futures import PrefectFuture
@@ -16,7 +15,11 @@ from flint.configuration import (
     load_and_copy_strategy,
 )
 from flint.exceptions import MSError
-from flint.imager.channel_division import ChannelDivision, apply_cube_division
+from flint.imager.channel_division import (
+    ChannelDivision,
+    apply_cube_division,
+    channel_division_for_beams,
+)
 from flint.imager.wsclean import (
     ImageSet,
     WSCleanResult,
@@ -33,16 +36,12 @@ from flint.naming import (
 from flint.options import (
     FitsCubeOptions,
     PolFieldOptions,
-    RMCleanOptions,
-    RMSynthOptions,
-    SpiceOptions,
     dump_field_options_to_yaml,
 )
 from flint.prefect.clusters import get_dask_runner
 from flint.prefect.common.imaging import (
     linmos_channel_groups_to_cubes,
     task_convolve_images,
-    task_create_name_from_common_fields,
     task_get_channel_images_from_paths,
     task_get_common_beam_from_image_set,
     task_get_mfs_image_from_paths,
@@ -50,16 +49,9 @@ from flint.prefect.common.imaging import (
     task_merge_image_sets,
     task_preprocess_askap_ms,
     task_remove_files_folders,
-    task_run_bane_and_aegean,
     task_split_and_get_image_set,
     task_transpose_and_sort_channel_images,
     task_wsclean_imager,
-)
-from flint.prefect.common.rmsynth import task_rmsynth_and_write_products
-from flint.prefect.common.spice import (
-    task_compress_cube,
-    task_get_spice_boxes,
-    task_spice_fits,
 )
 from flint.prefect.common.utils import (
     task_create_field_summary,
@@ -71,14 +63,37 @@ from flint.prefect.common.utils import (
 POL_NAME_SUFFIX = "pol"
 
 
+class PolPipelineResult(BaseOptions):
+    """Return value of ``process_science_fields_pol``, handed in-memory to
+    the rm-synth/clean and spice-compression stages of the ``racs-all``
+    flow-of-flows."""
+
+    stokes_cubes: dict[str, Path]
+    """The full, unspiced Stokes cube written for each imaged polarisation (e.g. 'i', 'q', 'u', 'v')"""
+    mfs_products: dict[str, dict[str, Path]]
+    """MFS image/model/residual products co-added per Stokes parameter, keyed by Stokes ('i', 'q', 'u', 'v') then product type ('image', 'model', 'residual'). Only populated for Stokes imaged under a polarisation with ``WSCleanOptions.flint_save_mfs_products`` set"""
+    terminal_futures: list[PrefectFuture[Any]]
+    """Every future the polarisation stage produced, propagated so Prefect still detects any of their failures"""
+
+
 @flow(name="Flint Polarisation Pipeline")
 def process_science_fields_pol(
     flint_ms_directory: Path,
     pol_field_options: PolFieldOptions,
-    cube_division: ChannelDivision | None = None,
     mss_by_beam: MSsByBeam | None = None,
-) -> list[PrefectFuture[Any]]:
-    # returned futures are resolved by prefect to fail the flow on task failure
+    compress_cubes: bool | None = None,
+) -> PolPipelineResult:
+    """Image a field in polarisation and co-add the per-beam products.
+
+    Args:
+        flint_ms_directory (Path): Directory holding the measurement sets to image
+        pol_field_options (PolFieldOptions): Options controlling the polarisation imaging
+        mss_by_beam (MSsByBeam | None, optional): Already Flint-processed measurement sets handed down by a calling flow, rather than rediscovered on disk. Defaults to None.
+        compress_cubes (bool | None, optional): Overrides the strategy ``fitscube`` compress setting. A calling flow that reads these cubes afterwards (rm-synth, spice) has to set it False, since astropy cannot memmap a gzip file and a chunked read would inflate the whole cube into memory. None honours the strategy. Defaults to None.
+
+    Returns:
+        PolPipelineResult: Stokes cubes, co-added MFS products, and the futures to wait on
+    """
     strategy = load_and_copy_strategy(
         output_split_science_path=flint_ms_directory,
         imaging_strategy=pol_field_options.imaging_strategy,
@@ -88,7 +103,7 @@ def process_science_fields_pol(
 
     if strategy is None:
         logger.info("No strategy provided. Returning.")
-        return []
+        return PolPipelineResult(stokes_cubes={}, mfs_products={}, terminal_futures=[])
 
     if mss_by_beam is not None:
         # Already Flint-processed, self-calibrated MSs handed down by the calling
@@ -171,9 +186,25 @@ def process_science_fields_pol(
 
     if pol_field_options.wsclean_container is None:
         logger.info("No wsclean container provided. Returning. ")
-        return [field_summary]
+        return PolPipelineResult(
+            stokes_cubes={}, mfs_products={}, terminal_futures=[field_summary]
+        )
 
     polarisations: dict[str, str] = strategy.get("polarisation", {"total": {}})
+
+    # Solved once for all beams, and before any imaging
+    cube_division: ChannelDivision | None = None
+    if pol_field_options.pol_cube_channel_width:
+        cube_division = channel_division_for_beams(
+            mss_by_beam=[
+                [
+                    ms.result() if isinstance(ms, PrefectFuture) else ms
+                    for ms in beam_mss
+                ]
+                for beam_mss in resolved_mss_by_beam
+            ],
+            target_width=pol_field_options.pol_cube_channel_width,
+        )
 
     image_sets_dict: dict[str, PrefectFuture[ImageSet]] = {}
     image_sets_list: list[PrefectFuture[ImageSet]] = []
@@ -193,12 +224,16 @@ def process_science_fields_pol(
                         update_wsclean_options=update_wsclean_options,
                         cube_division=cube_division,
                     )
+                save_mfs_products = update_wsclean_options.get(
+                    "flint_save_mfs_products", False
+                )
                 wsclean_result: PrefectFuture[WSCleanResult] = (
                     task_wsclean_imager.submit(
                         in_ms=beam_mss,
                         wsclean_container=pol_field_options.wsclean_container,
                         make_cube_from_subbands=False,  # We will do this later
                         update_wsclean_options=update_wsclean_options,
+                        extra_output_types=("model",) if save_mfs_products else None,
                     )
                 )
                 _image_set: PrefectFuture[ImageSet] = task_getattr.submit(
@@ -220,42 +255,60 @@ def process_science_fields_pol(
     # per-channel images (rather than cubing per beam) so we can co-add across
     # beams one channel at a time.
     stokes_beam_channel_images: dict[str, list[PrefectFuture[list[Path]]]] = {}
-    # Per-beam Stokes I MFS images, used by run_spice both as the field WCS
-    # reference for box-building and (absent a user spice_catalogue) as the
-    # image source-found against. wsclean already produces these; only the
-    # collection here is new.
-    beam_mfs_images: list[PrefectFuture[Path]] = []
+    # Per-beam MFS image/model/residual, collected per Stokes whenever that
+    # Stokes' polarisation strategy sets flint_save_mfs_products. Co-added
+    # further down the same way as the science image/cube.
+    mfs_beam_images: dict[str, dict[str, list[PrefectFuture[Path]]]] = {}
     for polarisation, image_set_list in image_sets_dict.items():
         with tags(f"polarisation-{polarisation}"):
             # Get the individual Stokes parameters in case of joint imaging
             if polarisation not in POLARISATION_MAPPING.keys():
                 raise ValueError(f"Unknown polarisation {polarisation}")
             stokes_list = list(POLARISATION_MAPPING[polarisation])
+
+            save_mfs_products = get_options_from_strategy(
+                strategy=strategy,
+                operation="polarisation",
+                mode="wsclean",
+                polarisation=polarisation,
+            ).get("flint_save_mfs_products", False)
+            product_types = (
+                ("image", "model", "residual") if save_mfs_products else ("image",)
+            )
+
             for stokes in stokes_list:
                 with tags(f"stokes-{stokes}"):
                     beam_channel_images: list[PrefectFuture[list[Path]]] = []
-                    for image_set in image_set_list:
-                        stokes_image_list = task_split_and_get_image_set.submit(
-                            image_set=image_set,
-                            get=stokes,
-                            by="pol",
-                            mode="image",
-                        )
-                        convolved_image_list = task_convolve_images.submit(
-                            image_paths=stokes_image_list,
-                            beam_shape=common_beam_shape,
-                            cutoff=pol_field_options.beam_cutoff,
-                        )
-                        if stokes == "i" and pol_field_options.run_spice:
-                            beam_mfs_images.append(
-                                task_get_mfs_image_from_paths.submit(
-                                    paths=convolved_image_list
-                                )
+                    for product_type in product_types:
+                        beam_mfs_images: list[PrefectFuture[Path]] = []
+                        for image_set in image_set_list:
+                            stokes_image_list = task_split_and_get_image_set.submit(
+                                image_set=image_set,
+                                get=stokes,
+                                by="pol",
+                                mode=product_type,
                             )
-                        channel_image_list = task_get_channel_images_from_paths.submit(
-                            paths=convolved_image_list
-                        )
-                        beam_channel_images.append(channel_image_list)
+                            convolved_image_list = task_convolve_images.submit(
+                                image_paths=stokes_image_list,
+                                beam_shape=common_beam_shape,
+                                cutoff=pol_field_options.beam_cutoff,
+                            )
+                            if save_mfs_products:
+                                beam_mfs_images.append(
+                                    task_get_mfs_image_from_paths.submit(
+                                        paths=convolved_image_list
+                                    )
+                                )
+                            if product_type == "image":
+                                beam_channel_images.append(
+                                    task_get_channel_images_from_paths.submit(
+                                        paths=convolved_image_list
+                                    )
+                                )
+                        if save_mfs_products:
+                            mfs_beam_images.setdefault(stokes, {})[product_type] = (
+                                beam_mfs_images
+                            )
                     stokes_beam_channel_images[stokes] = beam_channel_images
 
     # Regroup each Stokes' per-beam channel images into per-channel beam groups
@@ -282,70 +335,8 @@ def process_science_fields_pol(
             mode="fitscube",
         )
     )
-
-    island_boxes: PrefectFuture[list] | None = None
-    if pol_field_options.run_spice:
-        # Required even with a user-supplied spice_catalogue: the MFS mosaic
-        # built below is the earliest field-level WCS reference available,
-        # needed to turn that catalogue's RA/Dec into pixel boxes.
-        assert i_channel_groups is not None, (
-            "run_spice requires the 'total' polarisation (Stokes I) to have been imaged"
-        )
-        assert (
-            pol_field_options.spice_catalogue is not None
-            or pol_field_options.aegean_container is not None
-        ), "run_spice without a spice_catalogue requires an aegean_container"
-
-        mfs_linmos_result = task_linmos_images.submit(
-            image_list=beam_mfs_images,
-            container=pol_field_options.yandasoft_container,
-            linmos_options=LinmosOptions(
-                holofile=pol_field_options.holofile,
-                cutoff=pol_field_options.pb_cutoff,
-                cleanup=True,
-                # Must match the untrimmed shape of the per-channel/cube images
-                # spice_fits later compares this reference's shape against.
-                trim_linmos_fits=False,
-            ),
-            field_summary=field_summary,
-            holofile=pol_field_options.holofile,
-        )
-        mfs_image_path = task_getattr.submit(mfs_linmos_result, "image_fits")
-
-        is_user_catalogue = pol_field_options.spice_catalogue is not None
-        if is_user_catalogue:
-            catalogue_path = pol_field_options.spice_catalogue
-        else:
-            aegean_outputs = task_run_bane_and_aegean.submit(
-                image=mfs_linmos_result,
-                aegean_container=pol_field_options.aegean_container,
-                update_bane_options=get_options_from_strategy(
-                    strategy=strategy, operation="polarisation", mode="bane"
-                ),
-                update_aegean_options=get_options_from_strategy(
-                    strategy=strategy, operation="polarisation", mode="aegean"
-                ),
-            )
-            catalogue_path = task_getattr.submit(aegean_outputs, "comp")
-
-        spice_options = SpiceOptions(
-            **get_options_from_strategy(
-                strategy=strategy, operation="polarisation", mode="spice"
-            )
-        )
-        island_boxes = task_get_spice_boxes.submit(
-            reference_image=mfs_image_path,
-            catalogue=catalogue_path,
-            spice_options=spice_options,
-            beam_shape=common_beam_shape,
-            is_user_catalogue=is_user_catalogue,
-        )
-
-    # Whether anything downstream needs the full-size (unspiced) cube: either
-    # spice is off entirely, or rm-synth is on and reading the full cube.
-    need_full_cube = not pol_field_options.run_spice or (
-        pol_field_options.run_rmsynth and not pol_field_options.rmsynth_on_spiced_cubes
-    )
+    if compress_cubes is not None:
+        fitscube_options = fitscube_options.with_options(compress=compress_cubes)
 
     cube_results: list[PrefectFuture[Path]] = []
     stokes_image_cubes: dict[str, PrefectFuture[Path]] = {}
@@ -368,9 +359,6 @@ def process_science_fields_pol(
                 field_summary=field_summary,
                 fitscube_options=fitscube_options,
                 suffix_str=POL_NAME_SUFFIX,
-                plane_post_process=partial(task_spice_fits.submit, boxes=island_boxes)
-                if pol_field_options.run_spice and not need_full_cube
-                else None,
             )
             stokes_image_cubes[stokes] = stokes_cubes[0]
             cube_results.extend(stokes_cubes)
@@ -381,67 +369,71 @@ def process_science_fields_pol(
         *all_input_images, wait_for=cube_results
     )
 
-    rmsynth_result: PrefectFuture[list[Path]] | None = None
-    if pol_field_options.run_rmsynth:
-        assert "q" in stokes_image_cubes and "u" in stokes_image_cubes, (
-            "run_rmsynth requires the 'linear' polarisation (Stokes Q/U) to have been imaged"
-        )
-        # Mirrors the i_channel_groups leakage-correction gating above: use
-        # Stokes I if it was imaged, otherwise skip the fractional-pol correction.
-        stokes_i_cube = stokes_image_cubes.get("i")
-        rmsynth_options = RMSynthOptions(
-            **get_options_from_strategy(
-                strategy=strategy, operation="rmsynth", mode="rmsynth"
-            )
-        )
-        rmclean_options = RMCleanOptions(
-            **get_options_from_strategy(
-                strategy=strategy, operation="rmsynth", mode="rmclean"
-            )
-        )
-        output_prefix = task_create_name_from_common_fields.submit(
-            in_paths=(stokes_image_cubes["q"], stokes_image_cubes["u"])
-        )
-        rmsynth_result = task_rmsynth_and_write_products.submit(
-            stokes_q_cube=stokes_image_cubes["q"],
-            stokes_u_cube=stokes_image_cubes["u"],
-            stokes_i_cube=stokes_i_cube,
-            rmsynth_options=rmsynth_options,
-            rmclean_options=rmclean_options,
-            cube_products=pol_field_options.rmsynth_cube_products,
-            moment_products=pol_field_options.rmsynth_moment_products,
-            output_prefix=output_prefix,
-        )
+    # Co-add the MFS image/model/residual products collected above the same way
+    # as the science cube: PB-correct via linmos, leakage-correct against the
+    # matching Stokes I MFS product where available, then clean up the
+    # per-beam convolved intermediates.
+    mfs_products: dict[str, dict[str, PrefectFuture[Path]]] = {}
+    all_mfs_input_images: list[PrefectFuture[Path]] = []
+    mfs_linmos_results: list[PrefectFuture[Path]] = []
+    for stokes, product_type_images in mfs_beam_images.items():
+        with tags(f"stokes-{stokes}"):
+            for product_type, beam_images in product_type_images.items():
+                with tags(f"product-{product_type}"):
+                    stokesi_images: list[Path] | None = None
+                    if stokes != "i":
+                        i_beam_images = mfs_beam_images.get("i", {}).get(product_type)
+                        if i_beam_images is not None:
+                            stokesi_images = [
+                                future.result() for future in i_beam_images
+                            ]
 
-    if pol_field_options.run_spice:
-        if need_full_cube:
-            # Case 3: rm-synth (always on here, see need_full_cube above) has
-            # already read these full cubes -- now replace them in place.
-            spiced_cubes = [
-                task_spice_fits.submit(
-                    fits_path=cube, boxes=island_boxes, wait_for=[rmsynth_result]
-                )
-                for cube in cube_results
-            ]
-            compress_wait_for = None
-        else:
-            # Case 2: cube_results are already the spiced cubes (spice ran as
-            # plane_post_process before cubing). If rm-synth read them
-            # (rmsynth_on_spiced_cubes), keep them uncompressed until it's done.
-            spiced_cubes = cube_results
-            compress_wait_for = [rmsynth_result] if rmsynth_result else None
+                    mfs_linmos_result = task_linmos_images.submit(
+                        image_list=beam_images,
+                        container=pol_field_options.yandasoft_container,
+                        linmos_options=LinmosOptions(
+                            holofile=pol_field_options.holofile,
+                            cutoff=pol_field_options.pb_cutoff,
+                            stokesi_images=stokesi_images,
+                            force_remove_leakage=force_remove_leakage,
+                            cleanup=True,
+                        ),
+                        field_summary=field_summary,
+                        suffix_str=f"{POL_NAME_SUFFIX}.{product_type}",
+                        holofile=pol_field_options.holofile,
+                    )
+                    mfs_image_path = task_getattr.submit(
+                        mfs_linmos_result, "image_fits"
+                    )
+                    mfs_products.setdefault(stokes, {})[product_type] = mfs_image_path
+                    all_mfs_input_images.extend(beam_images)
+                    mfs_linmos_results.append(mfs_image_path)
 
-        cube_results = [
-            task_compress_cube.submit(
-                out_cube=cube,
-                method=spice_options.compress_method,
-                max_workers=spice_options.compress_max_workers,
-                wait_for=compress_wait_for,
-            )
-            for cube in spiced_cubes
-        ]
+    remove_mfs_result = (
+        task_remove_files_folders.submit(
+            *all_mfs_input_images, wait_for=mfs_linmos_results
+        )
+        if all_mfs_input_images
+        else None
+    )
 
-    return [*cube_results, remove_result, *([rmsynth_result] if rmsynth_result else [])]
+    terminal_futures: list[PrefectFuture[Any]] = [*cube_results, remove_result]
+    if remove_mfs_result is not None:
+        terminal_futures.append(remove_mfs_result)
+
+    return PolPipelineResult(
+        stokes_cubes={
+            stokes: future.result() for stokes, future in stokes_image_cubes.items()
+        },
+        mfs_products={
+            stokes: {
+                product_type: future.result()
+                for product_type, future in product_type_futures.items()
+            }
+            for stokes, product_type_futures in mfs_products.items()
+        },
+        terminal_futures=terminal_futures,
+    )
 
 
 def setup_run_process_science_field(

--- a/flint/prefect/flows/polarisation_pipeline.py
+++ b/flint/prefect/flows/polarisation_pipeline.py
@@ -105,7 +105,9 @@ def process_science_fields_pol(
 
     if strategy is None:
         logger.info("No strategy provided. Returning.")
-        return PolPipelineResult(stokes_cubes={}, weight_cubes={}, mfs_products={}, terminal_futures=[])
+        return PolPipelineResult(
+            stokes_cubes={}, weight_cubes={}, mfs_products={}, terminal_futures=[]
+        )
 
     if mss_by_beam is not None:
         # Already Flint-processed, self-calibrated MSs handed down by the calling

--- a/flint/prefect/flows/polarisation_pipeline.py
+++ b/flint/prefect/flows/polarisation_pipeline.py
@@ -40,13 +40,12 @@ from flint.options import (
 )
 from flint.prefect.clusters import get_dask_runner
 from flint.prefect.common.imaging import (
+    convolve_channel_groups_to_natural_resolution,
+    convolve_mfs_beam_images_to_common_resolution,
     linmos_channel_groups_to_cubes,
-    task_convolve_images,
     task_get_channel_images_from_paths,
-    task_get_common_beam_from_image_set,
     task_get_mfs_image_from_paths,
     task_linmos_images,
-    task_merge_image_sets,
     task_preprocess_askap_ms,
     task_remove_files_folders,
     task_split_and_get_image_set,
@@ -231,7 +230,6 @@ def process_science_fields_pol(
         )
 
     image_sets_dict: dict[str, PrefectFuture[ImageSet]] = {}
-    image_sets_list: list[PrefectFuture[ImageSet]] = []
     for polarisation in polarisations.keys():
         _image_sets = []
         with tags(f"polarisation-{polarisation}"):
@@ -264,20 +262,14 @@ def process_science_fields_pol(
                     wsclean_result, "image_set"
                 )
                 _image_sets.append(_image_set)
-                image_sets_list.append(_image_set)
         image_sets_dict[polarisation] = _image_sets
 
-    merged_image_set = task_merge_image_sets.submit(image_sets=image_sets_list)
-
-    common_beam_shape = task_get_common_beam_from_image_set.submit(
-        image_set=merged_image_set,
-        cutoff=pol_field_options.beam_cutoff,
-        fixed_beam_shape=pol_field_options.fixed_beam_shape,
-    )
-
-    # Convolve every beam's sub-band images to the common beam, keeping the
-    # per-channel images (rather than cubing per beam) so we can co-add across
-    # beams one channel at a time.
+    # Split each beam's images out per Stokes, leaving them unconvolved. The
+    # cubes are brought to a 'natural' resolution, one common beam per channel,
+    # and a channel's beam is solved over every beam image of every Stokes at
+    # that channel, so nothing can be convolved until all of them are in hand.
+    # The RM-synthesis stage brings its own inputs to a single 'total' beam; that
+    # is a resolution to synthesise at, not one to archive the cubes at.
     stokes_beam_channel_images: dict[str, list[PrefectFuture[list[Path]]]] = {}
     # Per-beam MFS image/model/residual, collected per Stokes whenever that
     # Stokes' polarisation strategy sets flint_save_mfs_products. Co-added
@@ -312,21 +304,16 @@ def process_science_fields_pol(
                                 by="pol",
                                 mode=product_type,
                             )
-                            convolved_image_list = task_convolve_images.submit(
-                                image_paths=stokes_image_list,
-                                beam_shape=common_beam_shape,
-                                cutoff=pol_field_options.beam_cutoff,
-                            )
                             if save_mfs_products:
                                 beam_mfs_images.append(
                                     task_get_mfs_image_from_paths.submit(
-                                        paths=convolved_image_list
+                                        paths=stokes_image_list
                                     )
                                 )
                             if product_type == "image":
                                 beam_channel_images.append(
                                     task_get_channel_images_from_paths.submit(
-                                        paths=convolved_image_list
+                                        paths=stokes_image_list
                                     )
                                 )
                         if save_mfs_products:
@@ -336,14 +323,20 @@ def process_science_fields_pol(
                     stokes_beam_channel_images[stokes] = beam_channel_images
 
     # Regroup each Stokes' per-beam channel images into per-channel beam groups
-    # so linmos can run one channel at a time in parallel. Resolving here blocks
-    # until the convolutions above have completed.
+    # so a beam can be solved for each channel, and so linmos can then run one
+    # channel at a time in parallel. Resolving here blocks until the imaging
+    # above has completed.
     stokes_channel_groups: dict[str, list[list[Path]]] = {
         stokes: task_transpose_and_sort_channel_images.submit(
             beam_channel_images=beam_channel_images
         ).result()
         for stokes, beam_channel_images in stokes_beam_channel_images.items()
     }
+    stokes_channel_groups = convolve_channel_groups_to_natural_resolution(
+        stokes_channel_groups=stokes_channel_groups,
+        cutoff=pol_field_options.beam_cutoff,
+        fixed_beam_shape=pol_field_options.fixed_beam_shape,
+    )
 
     # Stokes I beam images (per channel) are needed to correct widefield leakage
     # in the Stokes Q/U mosaics. If Stokes I was not imaged we cannot do this.
@@ -394,24 +387,37 @@ def process_science_fields_pol(
         *all_input_images, wait_for=cube_results
     )
 
+    # An MFS product has no frequency axis for a natural beam to vary over, so
+    # the MFS images get a single common beam of their own rather than the one
+    # the coarsest channel of the cube needed. Resolving the futures here blocks
+    # until the imaging has completed, which the beam solve needs regardless.
+    mfs_beam_paths: dict[str, dict[str, list[Path]]] = {
+        stokes: {
+            product_type: [future.result() for future in beam_images]
+            for product_type, beam_images in product_type_images.items()
+        }
+        for stokes, product_type_images in mfs_beam_images.items()
+    }
+    mfs_beam_paths = convolve_mfs_beam_images_to_common_resolution(
+        mfs_beam_images=mfs_beam_paths,
+        cutoff=pol_field_options.beam_cutoff,
+        fixed_beam_shape=pol_field_options.fixed_beam_shape,
+    )
+
     # Co-add the MFS image/model/residual products collected above the same way
     # as the science cube: PB-correct via linmos, leakage-correct against the
     # matching Stokes I MFS product where available, then clean up the
     # per-beam convolved intermediates.
     mfs_products: dict[str, dict[str, PrefectFuture[Path]]] = {}
-    all_mfs_input_images: list[PrefectFuture[Path]] = []
+    all_mfs_input_images: list[Path] = []
     mfs_linmos_results: list[PrefectFuture[Path]] = []
-    for stokes, product_type_images in mfs_beam_images.items():
+    for stokes, product_type_images in mfs_beam_paths.items():
         with tags(f"stokes-{stokes}"):
             for product_type, beam_images in product_type_images.items():
                 with tags(f"product-{product_type}"):
                     stokesi_images: list[Path] | None = None
                     if stokes != "i":
-                        i_beam_images = mfs_beam_images.get("i", {}).get(product_type)
-                        if i_beam_images is not None:
-                            stokesi_images = [
-                                future.result() for future in i_beam_images
-                            ]
+                        stokesi_images = mfs_beam_paths.get("i", {}).get(product_type)
 
                     mfs_linmos_result = task_linmos_images.submit(
                         image_list=beam_images,

--- a/flint/prefect/flows/polarisation_pipeline.py
+++ b/flint/prefect/flows/polarisation_pipeline.py
@@ -30,12 +30,15 @@ from flint.naming import (
 )
 from flint.options import (
     PolFieldOptions,
+    RMCleanOptions,
+    RMSynthOptions,
     dump_field_options_to_yaml,
 )
 from flint.prefect.clusters import get_dask_runner
 from flint.prefect.common.imaging import (
     linmos_channel_groups_to_cubes,
     task_convolve_images,
+    task_create_name_from_common_fields,
     task_get_channel_images_from_paths,
     task_get_common_beam_from_image_set,
     task_merge_image_sets,
@@ -45,6 +48,7 @@ from flint.prefect.common.imaging import (
     task_transpose_and_sort_channel_images,
     task_wsclean_imager,
 )
+from flint.prefect.common.rmsynth import task_rmsynth_and_write_products
 from flint.prefect.common.utils import (
     task_create_field_summary,
     task_getattr,
@@ -221,27 +225,28 @@ def process_science_fields_pol(
 
     assert pol_field_options.yandasoft_container is not None
     cube_results: list[PrefectFuture[Path]] = []
+    stokes_image_cubes: dict[str, PrefectFuture[Path]] = {}
     all_input_images: list[Path] = []
     for stokes, channel_groups in stokes_channel_groups.items():
         with tags(f"stokes-{stokes}"):
             all_input_images.extend(
                 [image for beam_images in channel_groups for image in beam_images]
             )
-            cube_results.extend(
-                linmos_channel_groups_to_cubes(
-                    channel_groups=channel_groups,
-                    container=pol_field_options.yandasoft_container,
-                    linmos_options=LinmosOptions(
-                        holofile=pol_field_options.holofile,
-                        cutoff=pol_field_options.pb_cutoff,
-                        force_remove_leakage=force_remove_leakage,
-                        trim_linmos_fits=pol_field_options.trim_linmos_fits,
-                        cleanup=True,
-                    ),
-                    stokesi_channel_groups=i_channel_groups,
-                    field_summary=field_summary,
-                )
+            stokes_cubes = linmos_channel_groups_to_cubes(
+                channel_groups=channel_groups,
+                container=pol_field_options.yandasoft_container,
+                linmos_options=LinmosOptions(
+                    holofile=pol_field_options.holofile,
+                    cutoff=pol_field_options.pb_cutoff,
+                    force_remove_leakage=force_remove_leakage,
+                    trim_linmos_fits=pol_field_options.trim_linmos_fits,
+                    cleanup=True,
+                ),
+                stokesi_channel_groups=i_channel_groups,
+                field_summary=field_summary,
             )
+            stokes_image_cubes[stokes] = stokes_cubes[0]
+            cube_results.extend(stokes_cubes)
 
     # Remove the convolved per-beam channel images now that every cube is built.
     # Stokes I images are kept until here as they feed the Q/U leakage correction.
@@ -249,7 +254,39 @@ def process_science_fields_pol(
         *all_input_images, wait_for=cube_results
     )
 
-    return [*cube_results, remove_result]
+    rmsynth_result: PrefectFuture[list[Path]] | None = None
+    if pol_field_options.run_rmsynth:
+        assert "q" in stokes_image_cubes and "u" in stokes_image_cubes, (
+            "run_rmsynth requires the 'linear' polarisation (Stokes Q/U) to have been imaged"
+        )
+        # Mirrors the i_channel_groups leakage-correction gating above: use
+        # Stokes I if it was imaged, otherwise skip the fractional-pol correction.
+        stokes_i_cube = stokes_image_cubes.get("i")
+        rmsynth_options = RMSynthOptions(
+            **get_options_from_strategy(
+                strategy=strategy, operation="rmsynth", mode="rmsynth"
+            )
+        )
+        rmclean_options = RMCleanOptions(
+            **get_options_from_strategy(
+                strategy=strategy, operation="rmsynth", mode="rmclean"
+            )
+        )
+        output_prefix = task_create_name_from_common_fields.submit(
+            in_paths=(stokes_image_cubes["q"], stokes_image_cubes["u"])
+        )
+        rmsynth_result = task_rmsynth_and_write_products.submit(
+            stokes_q_cube=stokes_image_cubes["q"],
+            stokes_u_cube=stokes_image_cubes["u"],
+            stokes_i_cube=stokes_i_cube,
+            rmsynth_options=rmsynth_options,
+            rmclean_options=rmclean_options,
+            cube_products=pol_field_options.rmsynth_cube_products,
+            moment_products=pol_field_options.rmsynth_moment_products,
+            output_prefix=output_prefix,
+        )
+
+    return [*cube_results, remove_result, *([rmsynth_result] if rmsynth_result else [])]
 
 
 def setup_run_process_science_field(

--- a/flint/prefect/flows/polarisation_pipeline.py
+++ b/flint/prefect/flows/polarisation_pipeline.py
@@ -34,6 +34,7 @@ from flint.naming import (
     get_sbid_from_path,
 )
 from flint.options import (
+    FFTBANEOptions,
     FitsCubeOptions,
     PolFieldOptions,
     dump_field_options_to_yaml,
@@ -71,6 +72,10 @@ class PolPipelineResult(BaseOptions):
     """The full, unspiced Stokes cube written for each imaged polarisation (e.g. 'i', 'q', 'u', 'v')"""
     weight_cubes: dict[str, Path]
     """The full Stokes weights written for each imaged polarisation (e.g. 'i', 'q', 'u', 'v')"""
+    bkg_cubes: dict[str, Path] = {}
+    """BANE background cube per imaged polarisation. Empty unless asked for"""
+    rms_cubes: dict[str, Path] = {}
+    """BANE RMS cube per imaged polarisation, measured off the co-added planes. Empty unless asked for"""
     mfs_products: dict[str, dict[str, Path]]
     """MFS image/model/residual products co-added per Stokes parameter, keyed by Stokes ('i', 'q', 'u', 'v') then product type ('image', 'model', 'residual'). Only populated for Stokes imaged under a polarisation with ``WSCleanOptions.flint_save_mfs_products`` set"""
     terminal_futures: list[PrefectFuture[Any]]
@@ -96,6 +101,8 @@ def _no_products(
     return PolPipelineResult(
         stokes_cubes={},
         weight_cubes={},
+        bkg_cubes={},
+        rms_cubes={},
         mfs_products={},
         terminal_futures=terminal_futures or [],
     )
@@ -355,9 +362,23 @@ def process_science_fields_pol(
     if compress_cubes is not None:
         fitscube_options = fitscube_options.with_options(compress=compress_cubes)
 
+    # Parameters from the strategy, the switch from the flow options, as with
+    # every other stage
+    fft_bane_options = (
+        FFTBANEOptions(
+            **get_options_from_strategy(
+                strategy=strategy, operation="polarisation", mode="fftbane"
+            )
+        )
+        if pol_field_options.bane_noise
+        else None
+    )
+
     cube_results: list[PrefectFuture[Path]] = []
     stokes_image_cubes: dict[str, PrefectFuture[Path]] = {}
     stokes_weight_cubes: dict[str, PrefectFuture[Path]] = {}
+    stokes_bkg_cubes: dict[str, PrefectFuture[Path]] = {}
+    stokes_rms_cubes: dict[str, PrefectFuture[Path]] = {}
     all_input_images: list[Path] = []
     for stokes, channel_groups in stokes_channel_groups.items():
         with tags(f"stokes-{stokes}"):
@@ -377,9 +398,14 @@ def process_science_fields_pol(
                 field_summary=field_summary,
                 fitscube_options=fitscube_options,
                 suffix_str=POL_NAME_SUFFIX,
+                fft_bane_options=fft_bane_options,
             )
-            stokes_image_cubes[stokes], stokes_weight_cubes[stokes] = stokes_cubes
-            cube_results.extend(stokes_cubes)
+            stokes_image_cubes[stokes] = stokes_cubes.image
+            stokes_weight_cubes[stokes] = stokes_cubes.weight
+            if stokes_cubes.bkg is not None and stokes_cubes.rms is not None:
+                stokes_bkg_cubes[stokes] = stokes_cubes.bkg
+                stokes_rms_cubes[stokes] = stokes_cubes.rms
+            cube_results.extend(stokes_cubes.futures)
 
     # Remove the convolved per-beam channel images now that every cube is built.
     # Stokes I images are kept until here as they feed the Q/U leakage correction.
@@ -455,6 +481,12 @@ def process_science_fields_pol(
     return PolPipelineResult(
         stokes_cubes={
             stokes: future.result() for stokes, future in stokes_image_cubes.items()
+        },
+        bkg_cubes={
+            stokes: future.result() for stokes, future in stokes_bkg_cubes.items()
+        },
+        rms_cubes={
+            stokes: future.result() for stokes, future in stokes_rms_cubes.items()
         },
         weight_cubes={
             stokes: future.result() for stokes, future in stokes_weight_cubes.items()

--- a/flint/prefect/flows/polarisation_pipeline.py
+++ b/flint/prefect/flows/polarisation_pipeline.py
@@ -141,9 +141,6 @@ def process_science_fields_pol(
 
     science_mss = [ms for beam_mss in resolved_mss_by_beam for ms in beam_mss]
 
-    logger.info(f"{science_mss=}")
-    logger.info(f"{pol_field_options.holofile=}")
-
     field_summary = task_create_field_summary.submit(
         mss=science_mss,
         holography_path=pol_field_options.holofile,

--- a/flint/prefect/flows/racs_all_continuum_selfcal.py
+++ b/flint/prefect/flows/racs_all_continuum_selfcal.py
@@ -17,7 +17,6 @@ from capn_crunch import (
 )
 from configargparse import ArgumentParser
 from prefect import flow, tags, unmapped
-from prefect.context import get_run_context
 from prefect.futures import PrefectFuture
 
 from flint.catalogue import verify_reference_catalogues
@@ -289,7 +288,7 @@ def process_racs_all_field(
     # returned futures are resolved by prefect to fail the flow on task failure
     terminal_futures: list[PrefectFuture[Any]] = []
     # Get the current run context to examine, provide to sub-flows
-    run_context = get_run_context()
+    # run_context = get_run_context()
 
     # Any sanity checks will go in here, mateee
     _check_racs_all_options(racs_all_options=racs_all_options)
@@ -635,21 +634,29 @@ def process_racs_all_field(
                 tuple([ms.result() for ms in beam_result.mss])
                 for beam_result in imaging_results[racs_all_options.rounds]
             )
-            low_sbid = get_sbid_from_path(path=racs_all_options.low_data)
+            # low_sbid = get_sbid_from_path(path=racs_all_options.low_data)
 
             # sub-flows do no inherit the task runner, they use the specified
             # running in their decorator flow argument. Overwrite it here with
             # the current runner
-            pol_futures = process_science_fields_pol.with_options(
-                task_runner=run_context.task_runner,
-                name=f"RACS All polarisation -- {low_sbid}",
-            )(
+            # pol_futures = process_science_fields_pol.with_options(
+            #     task_runner=run_context.task_runner,
+            #     name=f"RACS All polarisation -- {low_sbid}",
+            # )(
+            #     flint_ms_directory=output_science_path,
+            #     pol_field_options=resolved_pol_field_options,
+            #     cube_division=pol_cube_division,
+            #     mss_by_beam=final_round_mss_by_beam,
+            #     wait_for=terminal_futures,
+            # )
+
+            pol_futures = process_science_fields_pol.fn(
                 flint_ms_directory=output_science_path,
                 pol_field_options=resolved_pol_field_options,
                 cube_division=pol_cube_division,
                 mss_by_beam=final_round_mss_by_beam,
-                wait_for=terminal_futures,
             )
+
             terminal_futures.extend(pol_futures)
 
     return terminal_futures

--- a/flint/prefect/flows/racs_all_continuum_selfcal.py
+++ b/flint/prefect/flows/racs_all_continuum_selfcal.py
@@ -17,6 +17,7 @@ from capn_crunch import (
 )
 from configargparse import ArgumentParser
 from prefect import flow, tags, unmapped
+from prefect.context import get_run_context
 from prefect.futures import PrefectFuture
 
 from flint.catalogue import verify_reference_catalogues
@@ -287,6 +288,8 @@ def process_racs_all_field(
 ) -> list[PrefectFuture[Any]]:
     # returned futures are resolved by prefect to fail the flow on task failure
     terminal_futures: list[PrefectFuture[Any]] = []
+    # Get the current run context to examine, provide to sub-flows
+    run_context = get_run_context()
 
     # Any sanity checks will go in here, mateee
     _check_racs_all_options(racs_all_options=racs_all_options)
@@ -625,7 +628,15 @@ def process_racs_all_field(
                 tuple(beam_result.mss)
                 for beam_result in imaging_results[racs_all_options.rounds]
             )
-            pol_futures = process_science_fields_pol(
+            low_sbid = get_sbid_from_path(path=racs_all_options.low_data)
+
+            # sub-flows do no inherit the task runner, they use the specified
+            # running in their decorator flow argument. Overwrite it here with
+            # the current runner
+            pol_futures = process_science_fields_pol.with_options(
+                task_runner=run_context.task_runner,
+                name=f"RACS All polarisation -- {low_sbid}",
+            )(
                 flint_ms_directory=output_science_path,
                 pol_field_options=resolved_pol_field_options,
                 cube_division=pol_cube_division,

--- a/flint/prefect/flows/racs_all_continuum_selfcal.py
+++ b/flint/prefect/flows/racs_all_continuum_selfcal.py
@@ -362,6 +362,12 @@ def process_racs_all_field(
         racs_all_options=racs_all_options, output_science_path=output_science_path
     )
     if isinstance(holography_path, Path):
+        update_concat_holo_options = get_options_from_strategy(
+            strategy=strategy,
+            mode="concatholo",
+            round_info=0,
+            operation="selfcal",
+        )
         holography_path = task_concatenate_holography.submit(
             output_path=holography_path,
             holo_cubes=[
@@ -369,6 +375,7 @@ def process_racs_all_field(
                 racs_all_options.mid_holofile,
                 racs_all_options.high_holofile,
             ],
+            update_concat_holo_options=update_concat_holo_options,
         )
         terminal_futures.append(holography_path)
 

--- a/flint/prefect/flows/racs_all_continuum_selfcal.py
+++ b/flint/prefect/flows/racs_all_continuum_selfcal.py
@@ -566,6 +566,8 @@ def process_racs_all_field(
                     aegean_outputs=aegean_outputs,
                     round=selfcal_round if selfcal_round > 0 else None,
                 )
+                terminal_futures.append(field_summary)
+
                 if selfcal_round in (0, racs_all_options.rounds):
                     val_results = validation_items(
                         field_summary=field_summary,
@@ -620,6 +622,11 @@ def process_racs_all_field(
                 if pol_field_options is not None
                 else racs_all_options_to_pol_field_options(racs_all_options)
             )
+            resolved_pol_field_options = resolved_pol_field_options.with_options(
+                holofile=holography_path.result()
+                if isinstance(holography_path, PrefectFuture)
+                else holography_path
+            )
             # Hand down the final round's per-beam self-calibrated MSs directly, rather
             # than having the polarisation flow rediscover MSs by globbing the output
             # directory. These are still Prefect futures - passing them here is what
@@ -643,8 +650,6 @@ def process_racs_all_field(
                 mss_by_beam=final_round_mss_by_beam,
             )
             terminal_futures.extend(pol_futures)
-
-    terminal_futures.append(field_summary)
 
     return terminal_futures
 

--- a/flint/prefect/flows/racs_all_continuum_selfcal.py
+++ b/flint/prefect/flows/racs_all_continuum_selfcal.py
@@ -642,7 +642,10 @@ def process_racs_all_field(
             # the current runner
             from prefect_dask import DaskTaskRunner
 
-            sub_flow_runner = DaskTaskRunner(address=run_context.task_runner.address)  # type: ignore
+            sub_flow_runner = DaskTaskRunner(
+                cluster_class=run_context.task_runner.cluster_class,
+                cluster_kwargs=run_context.task_runner.cluster_kwargs,
+            )
 
             pol_futures = process_science_fields_pol.with_options(
                 task_runner=sub_flow_runner,

--- a/flint/prefect/flows/racs_all_continuum_selfcal.py
+++ b/flint/prefect/flows/racs_all_continuum_selfcal.py
@@ -41,8 +41,8 @@ from flint.naming import (
     get_sbid_from_path,
 )
 from flint.options import (
-    PolFieldOptions,
     FitsCubeOptions,
+    PolFieldOptions,
     RACSAllOptions,
     dump_field_options_to_yaml,
     pol_field_options_cli_class,

--- a/flint/prefect/flows/racs_all_continuum_selfcal.py
+++ b/flint/prefect/flows/racs_all_continuum_selfcal.py
@@ -648,6 +648,7 @@ def process_racs_all_field(
                 pol_field_options=resolved_pol_field_options,
                 cube_division=pol_cube_division,
                 mss_by_beam=final_round_mss_by_beam,
+                wait_for=terminal_futures,
             )
             terminal_futures.extend(pol_futures)
 

--- a/flint/prefect/flows/racs_all_continuum_selfcal.py
+++ b/flint/prefect/flows/racs_all_continuum_selfcal.py
@@ -659,13 +659,6 @@ def process_racs_all_field(
                 wait_for=terminal_futures,
             )
 
-            # pol_futures = process_science_fields_pol.fn(
-            #     flint_ms_directory=output_science_path,
-            #     pol_field_options=resolved_pol_field_options,
-            #     cube_division=pol_cube_division,
-            #     mss_by_beam=final_round_mss_by_beam,
-            # )
-
             terminal_futures.extend(pol_futures)
 
     return terminal_futures

--- a/flint/prefect/flows/racs_all_continuum_selfcal.py
+++ b/flint/prefect/flows/racs_all_continuum_selfcal.py
@@ -645,6 +645,7 @@ def process_racs_all_field(
             sub_flow_runner = DaskTaskRunner(
                 cluster_class=run_context.task_runner.cluster_class,
                 cluster_kwargs=run_context.task_runner.cluster_kwargs,
+                adapt_kwargs=run_context.task_runner.adapt_kwargs,
             )
 
             pol_futures = process_science_fields_pol.with_options(

--- a/flint/prefect/flows/racs_all_continuum_selfcal.py
+++ b/flint/prefect/flows/racs_all_continuum_selfcal.py
@@ -40,8 +40,10 @@ from flint.naming import (
     get_sbid_from_path,
 )
 from flint.options import (
+    PolFieldOptions,
     RACSAllOptions,
     dump_field_options_to_yaml,
+    pol_field_options_cli_class,
     racs_all_options_to_pol_field_options,
 )
 from flint.prefect.clusters import get_dask_runner
@@ -281,6 +283,7 @@ def all_holography_available(
 @flow
 def process_racs_all_field(
     racs_all_options: RACSAllOptions,
+    pol_field_options: PolFieldOptions | None = None,
 ) -> list[PrefectFuture[Any]]:
     # returned futures are resolved by prefect to fail the flow on task failure
     terminal_futures: list[PrefectFuture[Any]] = []
@@ -574,11 +577,14 @@ def process_racs_all_field(
 
     if racs_all_options.run_polarisation:
         with tags("polarisation"):
+            resolved_pol_field_options = (
+                pol_field_options
+                if pol_field_options is not None
+                else racs_all_options_to_pol_field_options(racs_all_options)
+            )
             pol_futures = process_science_fields_pol(
                 flint_ms_directory=output_science_path,
-                pol_field_options=racs_all_options_to_pol_field_options(
-                    racs_all_options
-                ),
+                pol_field_options=resolved_pol_field_options,
                 cube_division=pol_cube_division,
             )
             terminal_futures.extend(pol_futures)
@@ -589,13 +595,16 @@ def process_racs_all_field(
 
 
 def setup_run_racs_all_field(
-    cluster_config: Path, racs_all_options: RACSAllOptions
+    cluster_config: Path,
+    racs_all_options: RACSAllOptions,
+    pol_field_options: PolFieldOptions | None = None,
 ) -> None:
     """The main launch script for the RACS-All processing flow
 
     Args:
         cluster_config (Path): Path to the dask configuration yaml file to define the cluster
         racs_all_options (RACSAllOptions): Options around the processing of RACS-All field
+        pol_field_options (PolFieldOptions | None, optional): Options for the polarisation imaging pipeline, used if ``racs_all_options.run_polarisation`` is set. Derived from ``racs_all_options`` if not provided. Defaults to None.
     """
 
     low_sbid = get_sbid_from_path(path=racs_all_options.low_data)
@@ -604,7 +613,7 @@ def setup_run_racs_all_field(
 
     process_racs_all_field.with_options(
         name=f"RACS All -- {low_sbid}", task_runner=dask_task_runner
-    )(racs_all_options=racs_all_options)
+    )(racs_all_options=racs_all_options, pol_field_options=pol_field_options)
 
 
 def get_parser() -> ArgumentParser:
@@ -628,6 +637,11 @@ def get_parser() -> ArgumentParser:
     )
 
     parser = add_options_to_parser(parser=parser, options_class=RACSAllOptions)
+    parser = add_options_to_parser(
+        parser=parser,
+        options_class=pol_field_options_cli_class(RACSAllOptions),
+        description="Polarisation processing options",
+    )
 
     return parser
 
@@ -640,9 +654,14 @@ def cli() -> None:
     racs_all_options = create_options_from_parser(
         parser_namespace=args, options_class=RACSAllOptions
     )
+    pol_field_options = create_options_from_parser(
+        parser_namespace=args, options_class=PolFieldOptions
+    )
 
     setup_run_racs_all_field(
-        cluster_config=args.cluster_config, racs_all_options=racs_all_options
+        cluster_config=args.cluster_config,
+        racs_all_options=racs_all_options,
+        pol_field_options=pol_field_options,
     )
 
 

--- a/flint/prefect/flows/racs_all_continuum_selfcal.py
+++ b/flint/prefect/flows/racs_all_continuum_selfcal.py
@@ -17,6 +17,7 @@ from capn_crunch import (
 )
 from configargparse import ArgumentParser
 from prefect import flow, tags, unmapped
+from prefect.context import get_run_context
 from prefect.futures import PrefectFuture
 
 from flint.catalogue import verify_reference_catalogues
@@ -288,7 +289,7 @@ def process_racs_all_field(
     # returned futures are resolved by prefect to fail the flow on task failure
     terminal_futures: list[PrefectFuture[Any]] = []
     # Get the current run context to examine, provide to sub-flows
-    # run_context = get_run_context()
+    run_context = get_run_context()
 
     # Any sanity checks will go in here, mateee
     _check_racs_all_options(racs_all_options=racs_all_options)
@@ -634,28 +635,32 @@ def process_racs_all_field(
                 tuple([ms.result() for ms in beam_result.mss])
                 for beam_result in imaging_results[racs_all_options.rounds]
             )
-            # low_sbid = get_sbid_from_path(path=racs_all_options.low_data)
+            low_sbid = get_sbid_from_path(path=racs_all_options.low_data)
 
             # sub-flows do no inherit the task runner, they use the specified
             # running in their decorator flow argument. Overwrite it here with
             # the current runner
-            # pol_futures = process_science_fields_pol.with_options(
-            #     task_runner=run_context.task_runner,
-            #     name=f"RACS All polarisation -- {low_sbid}",
-            # )(
-            #     flint_ms_directory=output_science_path,
-            #     pol_field_options=resolved_pol_field_options,
-            #     cube_division=pol_cube_division,
-            #     mss_by_beam=final_round_mss_by_beam,
-            #     wait_for=terminal_futures,
-            # )
+            from prefect_dask import DaskTaskRunner
 
-            pol_futures = process_science_fields_pol.fn(
+            sub_flow_runner = DaskTaskRunner(address=run_context.task_runner.address)  # type: ignore
+
+            pol_futures = process_science_fields_pol.with_options(
+                task_runner=sub_flow_runner,
+                name=f"RACS All polarisation -- {low_sbid}",
+            )(
                 flint_ms_directory=output_science_path,
                 pol_field_options=resolved_pol_field_options,
                 cube_division=pol_cube_division,
                 mss_by_beam=final_round_mss_by_beam,
+                wait_for=terminal_futures,
             )
+
+            # pol_futures = process_science_fields_pol.fn(
+            #     flint_ms_directory=output_science_path,
+            #     pol_field_options=resolved_pol_field_options,
+            #     cube_division=pol_cube_division,
+            #     mss_by_beam=final_round_mss_by_beam,
+            # )
 
             terminal_futures.extend(pol_futures)
 

--- a/flint/prefect/flows/racs_all_continuum_selfcal.py
+++ b/flint/prefect/flows/racs_all_continuum_selfcal.py
@@ -12,12 +12,12 @@ from pathlib import Path
 from typing import Any
 
 from capn_crunch import (
+    BaseOptions,
     add_options_to_parser,
     create_options_from_parser,
 )
 from configargparse import ArgumentParser
 from prefect import flow, tags, unmapped
-from prefect.context import get_run_context
 from prefect.futures import PrefectFuture
 
 from flint.catalogue import verify_reference_catalogues
@@ -43,11 +43,8 @@ from flint.naming import (
 )
 from flint.options import (
     FitsCubeOptions,
-    PolFieldOptions,
     RACSAllOptions,
     dump_field_options_to_yaml,
-    pol_field_options_cli_class,
-    racs_all_options_to_pol_field_options,
 )
 from flint.prefect.clusters import get_dask_runner
 from flint.prefect.common.imaging import (
@@ -70,7 +67,6 @@ from flint.prefect.common.utils import (
     task_update_field_summary,
     task_update_with_options,
 )
-from flint.prefect.flows.polarisation_pipeline import process_science_fields_pol
 from flint.summary import BeamSummary
 
 
@@ -85,6 +81,22 @@ class LoopFutures:
     """Imaging results from wsclean imaging"""
     ms_summaries: list[MSSummary] | None = None
     """Results from a MS description"""
+
+
+class RACSContinuumResult(BaseOptions):
+    """Return value of ``process_racs_all_continuum``, handed in-memory to the
+    polarisation stage of the ``racs-all`` flow-of-flows rather than having
+    it rediscover measurement sets and paths by globbing the output
+    directory."""
+
+    mss_by_beam: tuple[tuple[MS, ...], ...]
+    """The final round's per-beam self-calibrated measurement sets. Structurally equivalent to ``flint.ms.MSsByBeam``"""
+    holography_path: Path | None
+    """Path to the holography FITS cube used when co-adding beams, if any"""
+    output_science_path: Path
+    """Directory the continuum imaging stage wrote its output products into"""
+    terminal_futures: list[PrefectFuture[Any]]
+    """Every future the continuum imaging stage produced, propagated so Prefect still detects any of their failures"""
 
 
 def _check_racs_all_options(racs_all_options: RACSAllOptions) -> None:
@@ -125,12 +137,6 @@ def _check_racs_all_options(racs_all_options: RACSAllOptions) -> None:
             raise ValueError(
                 "Unable to create linmos cubes without a yandasoft container"
             )
-    if racs_all_options.run_polarisation:
-        if not racs_all_options.yandasoft_container:
-            raise ValueError(
-                "Unable to run polarisation imaging without a yandasoft container"
-            )
-
     # For the moment we make sure that this is provided. Can consider moving to mandatory argument in
     # the model definition
     assert (
@@ -282,14 +288,11 @@ def all_holography_available(
 
 
 @flow
-def process_racs_all_field(
+def process_racs_all_continuum(
     racs_all_options: RACSAllOptions,
-    pol_field_options: PolFieldOptions | None = None,
-) -> list[PrefectFuture[Any]]:
+) -> RACSContinuumResult:
     # returned futures are resolved by prefect to fail the flow on task failure
     terminal_futures: list[PrefectFuture[Any]] = []
-    # Get the current run context to examine, provide to sub-flows
-    run_context = get_run_context()
 
     # Any sanity checks will go in here, mateee
     _check_racs_all_options(racs_all_options=racs_all_options)
@@ -323,15 +326,6 @@ def process_racs_all_field(
         cube_division = channel_division_for_beams(
             mss_by_beam=science_mss_by_beam,
             target_width=racs_all_options.cube_channel_width,
-        )
-
-    # Polarisation may use a different channelisation to the self-cal cube, so it
-    # is solved independently from the same beam frequency lists
-    pol_cube_division: ChannelDivision | None = None
-    if racs_all_options.run_polarisation and racs_all_options.pol_cube_channel_width:
-        pol_cube_division = channel_division_for_beams(
-            mss_by_beam=science_mss_by_beam,
-            target_width=racs_all_options.pol_cube_channel_width,
         )
 
     dump_field_options_to_yaml(
@@ -622,77 +616,45 @@ def process_racs_all_field(
                 )
                 terminal_futures.extend(linmos_cubes)
 
-    if racs_all_options.run_polarisation:
-        with tags("polarisation"):
-            resolved_pol_field_options = (
-                pol_field_options
-                if pol_field_options is not None
-                else racs_all_options_to_pol_field_options(racs_all_options)
-            )
-            resolved_pol_field_options = resolved_pol_field_options.with_options(
-                holofile=holography_path.result()
-                if isinstance(holography_path, PrefectFuture)
-                else holography_path
-            )
-            # Hand down the final round's per-beam self-calibrated MSs directly, rather
-            # than having the polarisation flow rediscover MSs by globbing the output
-            # directory. These are still Prefect futures - passing them here is what
-            # makes prefect wait for the self-cal loop to finish before imaging starts.
-            final_round_mss_by_beam: MSsByBeam = tuple(
-                tuple([ms.result() for ms in beam_result.mss])
-                for beam_result in imaging_results[racs_all_options.rounds]
-            )
-            low_sbid = get_sbid_from_path(path=racs_all_options.low_data)
+    resolved_holography_path = (
+        holography_path.result()
+        if isinstance(holography_path, PrefectFuture)
+        else holography_path
+    )
+    # Final round's per-beam self-calibrated MSs, resolved from futures so the
+    # racs-all flow-of-flows can hand them to the polarisation stage in-memory
+    # rather than having it rediscover MSs by globbing the output directory.
+    final_round_mss_by_beam: tuple[tuple[MS, ...], ...] = tuple(
+        tuple([ms.result() for ms in beam_result.mss])
+        for beam_result in imaging_results[racs_all_options.rounds]
+    )
 
-            # sub-flows do no inherit the task runner, they use the specified
-            # running in their decorator flow argument. Overwrite it here with
-            # the current runner
-            # from prefect_dask import DaskTaskRunner
-
-            sub_flow_runner = run_context.task_runner.duplicate()
-
-            # sub_flow_runner = DaskTaskRunner(
-            #     cluster_class=run_context.task_runner.cluster_class,
-            #     cluster_kwargs=run_context.task_runner.cluster_kwargs,
-            #     adapt_kwargs=run_context.task_runner.adapt_kwargs,
-            # )
-
-            pol_futures = process_science_fields_pol.with_options(
-                task_runner=sub_flow_runner,
-                name=f"RACS All polarisation -- {low_sbid}",
-            )(
-                flint_ms_directory=output_science_path,
-                pol_field_options=resolved_pol_field_options,
-                cube_division=pol_cube_division,
-                mss_by_beam=final_round_mss_by_beam,
-                wait_for=terminal_futures,
-            )
-
-            terminal_futures.extend(pol_futures)
-
-    return terminal_futures
+    return RACSContinuumResult(
+        mss_by_beam=final_round_mss_by_beam,
+        holography_path=resolved_holography_path,
+        output_science_path=output_science_path,
+        terminal_futures=terminal_futures,
+    )
 
 
-def setup_run_racs_all_field(
+def setup_run_racs_all_continuum(
     cluster_config: Path,
     racs_all_options: RACSAllOptions,
-    pol_field_options: PolFieldOptions | None = None,
 ) -> None:
-    """The main launch script for the RACS-All processing flow
+    """The main launch script for the RACS-All continuum imaging/self-cal flow
 
     Args:
         cluster_config (Path): Path to the dask configuration yaml file to define the cluster
         racs_all_options (RACSAllOptions): Options around the processing of RACS-All field
-        pol_field_options (PolFieldOptions | None, optional): Options for the polarisation imaging pipeline, used if ``racs_all_options.run_polarisation`` is set. Derived from ``racs_all_options`` if not provided. Defaults to None.
     """
 
     low_sbid = get_sbid_from_path(path=racs_all_options.low_data)
 
     dask_task_runner = get_dask_runner(cluster=cluster_config)
 
-    process_racs_all_field.with_options(
+    process_racs_all_continuum.with_options(
         name=f"RACS All -- {low_sbid}", task_runner=dask_task_runner
-    )(racs_all_options=racs_all_options, pol_field_options=pol_field_options)
+    )(racs_all_options=racs_all_options)
 
 
 def get_parser() -> ArgumentParser:
@@ -716,11 +678,6 @@ def get_parser() -> ArgumentParser:
     )
 
     parser = add_options_to_parser(parser=parser, options_class=RACSAllOptions)
-    parser = add_options_to_parser(
-        parser=parser,
-        options_class=pol_field_options_cli_class(RACSAllOptions),
-        description="Polarisation processing options",
-    )
 
     return parser
 
@@ -733,14 +690,10 @@ def cli() -> None:
     racs_all_options = create_options_from_parser(
         parser_namespace=args, options_class=RACSAllOptions
     )
-    pol_field_options = create_options_from_parser(
-        parser_namespace=args, options_class=PolFieldOptions
-    )
 
-    setup_run_racs_all_field(
+    setup_run_racs_all_continuum(
         cluster_config=args.cluster_config,
         racs_all_options=racs_all_options,
-        pol_field_options=pol_field_options,
     )
 
 

--- a/flint/prefect/flows/racs_all_continuum_selfcal.py
+++ b/flint/prefect/flows/racs_all_continuum_selfcal.py
@@ -647,13 +647,15 @@ def process_racs_all_field(
             # sub-flows do no inherit the task runner, they use the specified
             # running in their decorator flow argument. Overwrite it here with
             # the current runner
-            from prefect_dask import DaskTaskRunner
+            # from prefect_dask import DaskTaskRunner
 
-            sub_flow_runner = DaskTaskRunner(
-                cluster_class=run_context.task_runner.cluster_class,
-                cluster_kwargs=run_context.task_runner.cluster_kwargs,
-                adapt_kwargs=run_context.task_runner.adapt_kwargs,
-            )
+            sub_flow_runner = run_context.task_runner.duplicate()
+
+            # sub_flow_runner = DaskTaskRunner(
+            #     cluster_class=run_context.task_runner.cluster_class,
+            #     cluster_kwargs=run_context.task_runner.cluster_kwargs,
+            #     adapt_kwargs=run_context.task_runner.adapt_kwargs,
+            # )
 
             pol_futures = process_science_fields_pol.with_options(
                 task_runner=sub_flow_runner,

--- a/flint/prefect/flows/racs_all_continuum_selfcal.py
+++ b/flint/prefect/flows/racs_all_continuum_selfcal.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, TypeAlias
+from typing import Any
 
 from capn_crunch import (
     add_options_to_parser,
@@ -33,7 +33,7 @@ from flint.imager.channel_division import (
 )
 from flint.imager.wsclean import WSCleanResult
 from flint.logging import logger
-from flint.ms import MS, MSSummary, find_mss
+from flint.ms import MS, MSsByBeam, MSSummary, find_mss
 from flint.naming import (
     CASDANameComponents,
     add_timestamp_to_path,
@@ -71,8 +71,6 @@ from flint.prefect.common.utils import (
 )
 from flint.prefect.flows.polarisation_pipeline import process_science_fields_pol
 from flint.summary import BeamSummary
-
-MSsByBeam: TypeAlias = tuple[tuple[MS, ...], ...]
 
 
 @dataclass
@@ -619,10 +617,19 @@ def process_racs_all_field(
                 if pol_field_options is not None
                 else racs_all_options_to_pol_field_options(racs_all_options)
             )
+            # Hand down the final round's per-beam self-calibrated MSs directly, rather
+            # than having the polarisation flow rediscover MSs by globbing the output
+            # directory. These are still Prefect futures - passing them here is what
+            # makes prefect wait for the self-cal loop to finish before imaging starts.
+            final_round_mss_by_beam: MSsByBeam = tuple(
+                tuple(beam_result.mss)
+                for beam_result in imaging_results[racs_all_options.rounds]
+            )
             pol_futures = process_science_fields_pol(
                 flint_ms_directory=output_science_path,
                 pol_field_options=resolved_pol_field_options,
                 cube_division=pol_cube_division,
+                mss_by_beam=final_round_mss_by_beam,
             )
             terminal_futures.extend(pol_futures)
 

--- a/flint/prefect/flows/racs_all_continuum_selfcal.py
+++ b/flint/prefect/flows/racs_all_continuum_selfcal.py
@@ -25,7 +25,11 @@ from flint.configuration import (
     get_options_from_strategy,
     load_and_copy_strategy,
 )
-from flint.imager.channel_division import ChannelDivision, channel_division_for_beams
+from flint.imager.channel_division import (
+    ChannelDivision,
+    apply_cube_division,
+    channel_division_for_beams,
+)
 from flint.imager.wsclean import WSCleanResult
 from flint.logging import logger
 from flint.ms import MS, MSSummary, find_mss
@@ -38,6 +42,7 @@ from flint.naming import (
 from flint.options import (
     RACSAllOptions,
     dump_field_options_to_yaml,
+    racs_all_options_to_pol_field_options,
 )
 from flint.prefect.clusters import get_dask_runner
 from flint.prefect.common.imaging import (
@@ -60,6 +65,7 @@ from flint.prefect.common.utils import (
     task_update_field_summary,
     task_update_with_options,
 )
+from flint.prefect.flows.polarisation_pipeline import process_science_fields_pol
 from flint.summary import BeamSummary
 
 MSsByBeam: TypeAlias = tuple[tuple[MS, ...], ...]
@@ -115,6 +121,11 @@ def _check_racs_all_options(racs_all_options: RACSAllOptions) -> None:
         ):
             raise ValueError(
                 "Unable to create linmos cubes without a yandasoft container"
+            )
+    if racs_all_options.run_polarisation:
+        if not racs_all_options.yandasoft_container:
+            raise ValueError(
+                "Unable to run polarisation imaging without a yandasoft container"
             )
 
     # For the moment we make sure that this is provided. Can consider moving to mandatory argument in
@@ -267,27 +278,6 @@ def all_holography_available(
     return holo_output_path
 
 
-def _apply_cube_division(
-    update_wsclean_options: dict[Any, Any], cube_division: ChannelDivision
-) -> dict[Any, Any]:
-    """Replace the strategy channel division with a solved one. A division set
-    explicitly in the strategy wins, so a known good grid can be pinned."""
-    if update_wsclean_options.get("channel_division_frequencies") is not None:
-        logger.info(
-            "Strategy specifies channel_division_frequencies, not using the solved division"
-        )
-        return update_wsclean_options
-
-    logger.info(
-        f"Imaging with the solved channel division, {cube_division.channels_out=}"
-    )
-    return {
-        **update_wsclean_options,
-        "channels_out": cube_division.channels_out,
-        "channel_division_frequencies": cube_division.channel_division_frequencies,
-    }
-
-
 @flow
 def process_racs_all_field(
     racs_all_options: RACSAllOptions,
@@ -327,6 +317,15 @@ def process_racs_all_field(
         cube_division = channel_division_for_beams(
             mss_by_beam=science_mss_by_beam,
             target_width=racs_all_options.cube_channel_width,
+        )
+
+    # Polarisation may use a different channelisation to the self-cal cube, so it
+    # is solved independently from the same beam frequency lists
+    pol_cube_division: ChannelDivision | None = None
+    if racs_all_options.run_polarisation and racs_all_options.pol_cube_channel_width:
+        pol_cube_division = channel_division_for_beams(
+            mss_by_beam=science_mss_by_beam,
+            target_width=racs_all_options.pol_cube_channel_width,
         )
 
     dump_field_options_to_yaml(
@@ -492,7 +491,7 @@ def process_racs_all_field(
                     operation="selfcal",
                 )
                 if final_round and cube_division is not None:
-                    update_wsclean_options = _apply_cube_division(
+                    update_wsclean_options = apply_cube_division(
                         update_wsclean_options=update_wsclean_options,
                         cube_division=cube_division,
                     )
@@ -572,6 +571,17 @@ def process_racs_all_field(
                     )
                     if val_results:
                         terminal_futures.extend(val_results)
+
+    if racs_all_options.run_polarisation:
+        with tags("polarisation"):
+            pol_futures = process_science_fields_pol(
+                flint_ms_directory=output_science_path,
+                pol_field_options=racs_all_options_to_pol_field_options(
+                    racs_all_options
+                ),
+                cube_division=pol_cube_division,
+            )
+            terminal_futures.extend(pol_futures)
 
     terminal_futures.append(field_summary)
 

--- a/flint/prefect/flows/racs_all_continuum_selfcal.py
+++ b/flint/prefect/flows/racs_all_continuum_selfcal.py
@@ -632,7 +632,7 @@ def process_racs_all_field(
             # directory. These are still Prefect futures - passing them here is what
             # makes prefect wait for the self-cal loop to finish before imaging starts.
             final_round_mss_by_beam: MSsByBeam = tuple(
-                tuple(beam_result.mss)
+                tuple([ms.result() for ms in beam_result.mss])
                 for beam_result in imaging_results[racs_all_options.rounds]
             )
             low_sbid = get_sbid_from_path(path=racs_all_options.low_data)

--- a/flint/prefect/flows/racs_all_pipeline.py
+++ b/flint/prefect/flows/racs_all_pipeline.py
@@ -9,11 +9,10 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from capn_crunch import BaseOptions, add_options_to_parser, create_options_from_parser
+from capn_crunch import add_options_to_parser, create_options_from_parser
 from configargparse import ArgumentParser
 from fitscube.combine_fits import compress_cube
 from prefect import flow
-from pydantic import create_model
 
 from flint.configuration import (
     POLARISATION_MAPPING,
@@ -33,6 +32,7 @@ from flint.options import (
     RMSynthFieldOptions,
     SpiceFieldOptions,
     WeightCubesForRMSynth,
+    exclude_fields_cli_class,
     pol_field_options_cli_class,
 )
 from flint.prefect.clusters import get_dask_runner
@@ -40,13 +40,6 @@ from flint.prefect.flows.polarisation_pipeline import process_science_fields_pol
 from flint.prefect.flows.racs_all_continuum_selfcal import process_racs_all_continuum
 from flint.prefect.flows.rmsynth_pipeline import process_rmsynth
 from flint.prefect.flows.spice_compression_pipeline import process_spice_compression
-
-STAGE_CLUSTER_CONFIG_ATTRS = (
-    "imaging_cluster_config",
-    "polarisation_cluster_config",
-    "rmsynth_cluster_config",
-    "spice_cluster_config",
-)
 
 # Fields on the rm-synth/spice options classes that process_racs_all always recomputes
 # from the polarisation stage's output. Excluded from the combined CLI.
@@ -192,29 +185,6 @@ def _check_spice_mfs_dependency(
             "(needed as the aegean source-finding reference image). Pass "
             "--skip-spice to disable the stage."
         )
-
-
-def _exclude_fields_cli_class(
-    options_class: type[BaseOptions], exclude_fields: set[str]
-) -> type[BaseOptions]:
-    """Build a sibling of ``options_class`` exposing only the fields not in
-    ``exclude_fields``, so it can be added to a parser that already exposes
-    those fields via another options class without a duplicate-flag error.
-
-    The result derives from ``options_class.__base__``, so it is a sibling rather
-    than a subclass. Generalises ``pol_field_options_cli_class`` to an arbitrary,
-    accumulated set of already-registered field names.
-    """
-    unique_fields = {
-        name: (field.annotation, field)
-        for name, field in options_class.model_fields.items()
-        if name not in exclude_fields
-    }
-    return create_model(
-        f"{options_class.__name__}CLI",
-        __base__=options_class.__base__,
-        **unique_fields,
-    )
 
 
 @flow(name="Flint RACS-All Pipeline")
@@ -417,14 +387,14 @@ def get_parser() -> ArgumentParser:
 
     parser = add_options_to_parser(
         parser=parser,
-        options_class=_exclude_fields_cli_class(RMSynthFieldOptions, seen_fields),
+        options_class=exclude_fields_cli_class(RMSynthFieldOptions, seen_fields),
         description="RM-synthesis processing options",
     )
     seen_fields |= set(RMSynthFieldOptions.model_fields)
 
     parser = add_options_to_parser(
         parser=parser,
-        options_class=_exclude_fields_cli_class(SpiceFieldOptions, seen_fields),
+        options_class=exclude_fields_cli_class(SpiceFieldOptions, seen_fields),
         description="SPICE compression processing options",
     )
 
@@ -457,7 +427,12 @@ def cli() -> None:
         parser_namespace=args, options_class=SpiceFieldOptions
     )
 
-    for cluster_config_attr in STAGE_CLUSTER_CONFIG_ATTRS:
+    for cluster_config_attr in (
+        "imaging_cluster_config",
+        "polarisation_cluster_config",
+        "rmsynth_cluster_config",
+        "spice_cluster_config",
+    ):
         if getattr(pipeline_options, cluster_config_attr) is None:
             pipeline_options = pipeline_options.with_options(
                 **{cluster_config_attr: args.cluster_config}

--- a/flint/prefect/flows/racs_all_pipeline.py
+++ b/flint/prefect/flows/racs_all_pipeline.py
@@ -248,6 +248,7 @@ def process_racs_all(
     # One root for every downstream stage, split into a subdirectory per stage.
     output_root = pipeline_options.output_path or continuum_result.output_science_path
 
+    rmsynth_convolved_cubes: list[Path] = []
     if not pipeline_options.skip_rmsynth:
         resolved_rmsynth_field_options = rmsynth_field_options.with_options(
             stokes_q_cube=pol_result.stokes_cubes["q"],
@@ -259,13 +260,14 @@ def process_racs_all(
             output_path=rmsynth_field_options.output_path or output_root / "rmsynth",
         )
         assert pipeline_options.rmsynth_cluster_config is not None
-        rmsynth_results = process_rmsynth.with_options(
+        rmsynth_result = process_rmsynth.with_options(
             task_runner=get_dask_runner(
                 cluster=pipeline_options.rmsynth_cluster_config
             ),
             name="RACS All -- rm-synthesis",
         )(rmsynth_field_options=resolved_rmsynth_field_options)
-        terminal_results.extend(rmsynth_results)
+        terminal_results.extend(rmsynth_result.written_paths)
+        rmsynth_convolved_cubes = rmsynth_result.convolved_cubes
 
     if not pipeline_options.skip_spice:
         resolved_reference_image = (
@@ -273,8 +275,11 @@ def process_racs_all(
             if spice_field_options.catalogue is not None
             else pol_result.mfs_products.get("i", {}).get("image")
         )
+        # The common-resolution cubes rm-synth wrote are trimmed alongside the
+        # cubes they came from; they share the pixel grid, so one set of boxes
+        # covers both. Empty unless rm-synth actually had to convolve.
         resolved_spice_field_options = spice_field_options.with_options(
-            cubes=list(pol_result.stokes_cubes.values()),
+            cubes=[*pol_result.stokes_cubes.values(), *rmsynth_convolved_cubes],
             weight_cubes=list(pol_result.weight_cubes.values()),
             reference_image=resolved_reference_image,
             output_path=spice_field_options.output_path or output_root / "spice",
@@ -298,6 +303,7 @@ def process_racs_all(
             for cube in (
                 *pol_result.stokes_cubes.values(),
                 *pol_result.weight_cubes.values(),
+                *rmsynth_convolved_cubes,
             )
         )
 

--- a/flint/prefect/flows/racs_all_pipeline.py
+++ b/flint/prefect/flows/racs_all_pipeline.py
@@ -15,16 +15,24 @@ from fitscube.combine_fits import compress_cube
 from prefect import flow
 from pydantic import create_model
 
-from flint.configuration import get_options_from_strategy, load_strategy_yaml
+from flint.configuration import (
+    POLARISATION_MAPPING,
+    get_options_from_strategy,
+    load_strategy_yaml,
+)
 from flint.logging import logger
 from flint.naming import get_sbid_from_path
 from flint.options import (
+    CubesForRMSynth,
+    ErrorCubesForRMSynth,
     FitsCubeOptions,
+    NoiseCubesForRMSynth,
     PolFieldOptions,
     RACSAllOptions,
     RACSAllPipelineOptions,
     RMSynthFieldOptions,
     SpiceFieldOptions,
+    WeightCubesForRMSynth,
     pol_field_options_cli_class,
 )
 from flint.prefect.clusters import get_dask_runner
@@ -42,7 +50,7 @@ STAGE_CLUSTER_CONFIG_ATTRS = (
 
 # Fields on the rm-synth/spice options classes that process_racs_all always recomputes
 # from the polarisation stage's output. Excluded from the combined CLI.
-COMPUTED_FIELDS = {"stokes_q_cube", "stokes_u_cube", "cubes", "weight_cubes"}
+COMPUTED_FIELDS = {"stokes_cubes", "error_cubes", "cubes", "weight_cubes"}
 
 
 def _check_stage_prerequisites(
@@ -116,6 +124,41 @@ def _check_racs_all_pipeline_options(pipeline_options: RACSAllPipelineOptions) -
             "spice stage requires the polarisation stage (cannot set "
             "skip_polarisation without skip_spice). To run spice on its own, use "
             "flint_flow_spice_compression_pipeline."
+        )
+
+
+def _check_rmsynth_has_linear_stokes(
+    pipeline_options: RACSAllPipelineOptions,
+    pol_field_options: PolFieldOptions,
+) -> None:
+    """RM-synthesis builds its FDF from Q+iU, so a polarisation strategy that
+    names its Stokes has to include the linear ones. A circular-only strategy
+    would otherwise fail once imaging had already run.
+
+    Only checked when the strategy says: without one the polarisation stage has
+    its own say, and guessing here would refuse runs it would have served.
+    """
+    if pipeline_options.skip_rmsynth or pipeline_options.skip_polarisation:
+        return
+    if pol_field_options.imaging_strategy is None:
+        return
+
+    strategy = load_strategy_yaml(input_yaml=pol_field_options.imaging_strategy)
+    polarisations = strategy.get("polarisation")
+    if not polarisations:
+        return
+
+    imaged = {
+        stokes
+        for mode in polarisations
+        for stokes in POLARISATION_MAPPING.get(mode, "")
+    }
+    missing = {"q", "u"} - imaged
+    if missing:
+        raise ValueError(
+            f"rm-synthesis needs Stokes {sorted(missing)}, which the polarisation "
+            f"strategy does not image (modes: {sorted(polarisations)}). Add the "
+            "'linear' polarisation, or pass --skip-rmsynth."
         )
 
 
@@ -194,6 +237,9 @@ def process_racs_all(
         pol_field_options=pol_field_options,
         spice_field_options=spice_field_options,
     )
+    _check_rmsynth_has_linear_stokes(
+        pipeline_options=pipeline_options, pol_field_options=pol_field_options
+    )
 
     terminal_results: list[Any] = []
 
@@ -249,14 +295,18 @@ def process_racs_all(
     output_root = pipeline_options.output_path or continuum_result.output_science_path
 
     rmsynth_convolved_cubes: list[Path] = []
+    rmsynth_noise_cubes: list[Path] = []
     if not pipeline_options.skip_rmsynth:
+        # BANE RMS if the polarisation stage measured it, else the linmos
+        # weights. rm-synth supersedes both once it convolves to a common beam.
+        error_cubes: ErrorCubesForRMSynth = (
+            NoiseCubesForRMSynth.from_mapping(pol_result.rms_cubes)
+            if pol_result.rms_cubes
+            else WeightCubesForRMSynth.from_mapping(pol_result.weight_cubes)
+        )
         resolved_rmsynth_field_options = rmsynth_field_options.with_options(
-            stokes_q_cube=pol_result.stokes_cubes["q"],
-            stokes_u_cube=pol_result.stokes_cubes["u"],
-            stokes_i_cube=pol_result.stokes_cubes.get("i"),
-            stokes_i_weight_cube=pol_result.weight_cubes.get("i"),
-            stokes_q_weight_cube=pol_result.weight_cubes["q"],
-            stokes_u_weight_cube=pol_result.weight_cubes["u"],
+            stokes_cubes=CubesForRMSynth.from_mapping(pol_result.stokes_cubes),
+            error_cubes=error_cubes,
             output_path=rmsynth_field_options.output_path or output_root / "rmsynth",
         )
         assert pipeline_options.rmsynth_cluster_config is not None
@@ -268,6 +318,7 @@ def process_racs_all(
         )(rmsynth_field_options=resolved_rmsynth_field_options)
         terminal_results.extend(rmsynth_result.written_paths)
         rmsynth_convolved_cubes = rmsynth_result.convolved_cubes
+        rmsynth_noise_cubes = rmsynth_result.convolved_noise_cubes
 
     if not pipeline_options.skip_spice:
         resolved_reference_image = (
@@ -280,7 +331,12 @@ def process_racs_all(
         # covers both. Empty unless rm-synth actually had to convolve.
         resolved_spice_field_options = spice_field_options.with_options(
             cubes=[*pol_result.stokes_cubes.values(), *rmsynth_convolved_cubes],
-            weight_cubes=list(pol_result.weight_cubes.values()),
+            weight_cubes=[
+                *pol_result.weight_cubes.values(),
+                *pol_result.bkg_cubes.values(),
+                *pol_result.rms_cubes.values(),
+                *rmsynth_noise_cubes,
+            ],
             reference_image=resolved_reference_image,
             output_path=spice_field_options.output_path or output_root / "spice",
         )
@@ -303,7 +359,10 @@ def process_racs_all(
             for cube in (
                 *pol_result.stokes_cubes.values(),
                 *pol_result.weight_cubes.values(),
+                *pol_result.bkg_cubes.values(),
+                *pol_result.rms_cubes.values(),
                 *rmsynth_convolved_cubes,
+                *rmsynth_noise_cubes,
             )
         )
 

--- a/flint/prefect/flows/racs_all_pipeline.py
+++ b/flint/prefect/flows/racs_all_pipeline.py
@@ -253,6 +253,9 @@ def process_racs_all(
             stokes_q_cube=pol_result.stokes_cubes["q"],
             stokes_u_cube=pol_result.stokes_cubes["u"],
             stokes_i_cube=pol_result.stokes_cubes.get("i"),
+            stokes_i_weight_cube=pol_result.weight_cubes.get("i"),
+            stokes_q_weight_cube=pol_result.weight_cubes["q"],
+            stokes_u_weight_cube=pol_result.weight_cubes["u"],
             output_path=rmsynth_field_options.output_path or output_root / "rmsynth",
         )
         assert pipeline_options.rmsynth_cluster_config is not None

--- a/flint/prefect/flows/racs_all_pipeline.py
+++ b/flint/prefect/flows/racs_all_pipeline.py
@@ -1,0 +1,404 @@
+"""The RACS-All flow-of-flows: chains continuum imaging/self-cal,
+polarisation imaging, RM-synthesis/RM-CLEAN and SPICE compression together,
+each stage individually skippable and dask-cluster-configurable. Data is
+handed from one stage to the next in-memory rather than rediscovered on disk.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from capn_crunch import BaseOptions, add_options_to_parser, create_options_from_parser
+from configargparse import ArgumentParser
+from fitscube.combine_fits import compress_cube
+from prefect import flow
+from pydantic import create_model
+
+from flint.configuration import get_options_from_strategy, load_strategy_yaml
+from flint.logging import logger
+from flint.naming import get_sbid_from_path
+from flint.options import (
+    FitsCubeOptions,
+    PolFieldOptions,
+    RACSAllOptions,
+    RACSAllPipelineOptions,
+    RMSynthFieldOptions,
+    SpiceFieldOptions,
+    pol_field_options_cli_class,
+)
+from flint.prefect.clusters import get_dask_runner
+from flint.prefect.flows.polarisation_pipeline import process_science_fields_pol
+from flint.prefect.flows.racs_all_continuum_selfcal import process_racs_all_continuum
+from flint.prefect.flows.rmsynth_pipeline import process_rmsynth
+from flint.prefect.flows.spice_compression_pipeline import process_spice_compression
+
+STAGE_CLUSTER_CONFIG_ATTRS = (
+    "imaging_cluster_config",
+    "polarisation_cluster_config",
+    "rmsynth_cluster_config",
+    "spice_cluster_config",
+)
+
+# Fields on the rm-synth/spice options classes that process_racs_all always recomputes
+# from the polarisation stage's output. Excluded from the combined CLI.
+COMPUTED_FIELDS = {"stokes_q_cube", "stokes_u_cube", "cubes"}
+
+
+def _check_stage_prerequisites(
+    pipeline_options: RACSAllPipelineOptions,
+    racs_all_options: RACSAllOptions,
+    pol_field_options: PolFieldOptions,
+    spice_field_options: SpiceFieldOptions,
+) -> None:
+    """Prerequisites of every enabled stage, checked before the first stage runs.
+
+    The stage flows keep their own checks so they stay independently runnable.
+    Repeating the checks here turns a missing container into a failure in seconds
+    rather than one after imaging and polarisation have already completed.
+
+    Raises:
+        ValueError: A required option is unset, or a supplied path does not exist
+    """
+    paths: dict[str, Path | None] = {}
+
+    if not pipeline_options.skip_imaging:
+        paths |= {
+            "flagger_container": racs_all_options.flagger_container,
+            "casa_container": racs_all_options.casa_container,
+            "wsclean_container": racs_all_options.wsclean_container,
+            "yandasoft_container": racs_all_options.yandasoft_container,
+            "potato_container": racs_all_options.potato_container,
+        }
+
+    if not pipeline_options.skip_polarisation:
+        for name in ("wsclean_container", "yandasoft_container"):
+            if getattr(pol_field_options, name) is None:
+                raise ValueError(f"polarisation stage requires {name}")
+            paths[f"polarisation {name}"] = getattr(pol_field_options, name)
+
+    if not pipeline_options.skip_spice:
+        if spice_field_options.catalogue is None:
+            if spice_field_options.aegean_container is None:
+                raise ValueError(
+                    "spice stage without a catalogue requires aegean_container for "
+                    "source finding. Pass --skip-spice to disable the stage."
+                )
+            paths["aegean_container"] = spice_field_options.aegean_container
+        else:
+            paths["spice catalogue"] = spice_field_options.catalogue
+
+    for name, path in paths.items():
+        if path is not None and not path.exists():
+            raise ValueError(f"{name} is set to {path}, which does not exist")
+
+
+def _check_racs_all_pipeline_options(pipeline_options: RACSAllPipelineOptions) -> None:
+    """Enforce the fixed stage order for RACS-all
+
+    A downstream stage may not be enabled while the upstream stage it depends on
+    (for its in-memory input) is skipped.
+    """
+    if not pipeline_options.skip_polarisation and pipeline_options.skip_imaging:
+        raise ValueError(
+            "polarisation stage requires the imaging stage (cannot set skip_imaging "
+            "without skip_polarisation). To run polarisation on its own, use "
+            "flint_flow_polarisation_pipeline."
+        )
+    if not pipeline_options.skip_rmsynth and pipeline_options.skip_polarisation:
+        raise ValueError(
+            "rm-synth stage requires the polarisation stage (cannot set "
+            "skip_polarisation without skip_rmsynth). To run rm-synth on its own, "
+            "use flint_flow_rmsynth_pipeline."
+        )
+    if not pipeline_options.skip_spice and pipeline_options.skip_polarisation:
+        raise ValueError(
+            "spice stage requires the polarisation stage (cannot set "
+            "skip_polarisation without skip_spice). To run spice on its own, use "
+            "flint_flow_spice_compression_pipeline."
+        )
+
+
+def _check_spice_mfs_dependency(
+    pipeline_options: RACSAllPipelineOptions,
+    racs_all_options: RACSAllOptions,
+    spice_field_options: SpiceFieldOptions,
+) -> None:
+    """Aegean source finding (no user catalogue) needs a Stokes I MFS reference image,
+    which only exists if the 'total' polarisation strategy sets
+    ``flint_save_mfs_products``.
+    """
+    if pipeline_options.skip_spice or spice_field_options.catalogue is not None:
+        return
+
+    strategy = (
+        load_strategy_yaml(input_yaml=racs_all_options.imaging_strategy)
+        if racs_all_options.imaging_strategy is not None
+        else None
+    )
+    save_mfs_products = get_options_from_strategy(
+        strategy=strategy,
+        operation="polarisation",
+        mode="wsclean",
+        polarisation="total",
+    ).get("flint_save_mfs_products", False)
+    if not save_mfs_products:
+        raise ValueError(
+            "spice stage with no spice_field_options.catalogue requires the "
+            "'total' polarisation strategy to set flint_save_mfs_products=True "
+            "(needed as the aegean source-finding reference image). Pass "
+            "--skip-spice to disable the stage."
+        )
+
+
+def _exclude_fields_cli_class(
+    options_class: type[BaseOptions], exclude_fields: set[str]
+) -> type[BaseOptions]:
+    """Build a sibling of ``options_class`` exposing only the fields not in
+    ``exclude_fields``, so it can be added to a parser that already exposes
+    those fields via another options class without a duplicate-flag error.
+
+    The result derives from ``options_class.__base__``, so it is a sibling rather
+    than a subclass. Generalises ``pol_field_options_cli_class`` to an arbitrary,
+    accumulated set of already-registered field names.
+    """
+    unique_fields = {
+        name: (field.annotation, field)
+        for name, field in options_class.model_fields.items()
+        if name not in exclude_fields
+    }
+    return create_model(
+        f"{options_class.__name__}CLI",
+        __base__=options_class.__base__,
+        **unique_fields,
+    )
+
+
+@flow(name="Flint RACS-All Pipeline")
+def process_racs_all(
+    pipeline_options: RACSAllPipelineOptions,
+    racs_all_options: RACSAllOptions,
+    pol_field_options: PolFieldOptions,
+    rmsynth_field_options: RMSynthFieldOptions,
+    spice_field_options: SpiceFieldOptions,
+) -> list[Any]:
+    _check_racs_all_pipeline_options(pipeline_options=pipeline_options)
+    _check_spice_mfs_dependency(
+        pipeline_options=pipeline_options,
+        racs_all_options=racs_all_options,
+        spice_field_options=spice_field_options,
+    )
+    _check_stage_prerequisites(
+        pipeline_options=pipeline_options,
+        racs_all_options=racs_all_options,
+        pol_field_options=pol_field_options,
+        spice_field_options=spice_field_options,
+    )
+
+    terminal_results: list[Any] = []
+
+    if not pipeline_options.skip_imaging:
+        assert pipeline_options.imaging_cluster_config is not None
+        continuum_result = process_racs_all_continuum.with_options(
+            task_runner=get_dask_runner(
+                cluster=pipeline_options.imaging_cluster_config
+            ),
+            name="RACS All -- continuum imaging",
+        )(racs_all_options=racs_all_options)
+        terminal_results.extend(continuum_result.terminal_futures)
+
+    if pipeline_options.skip_polarisation:
+        return terminal_results
+
+    resolved_pol_field_options = pol_field_options.with_options(
+        holofile=continuum_result.holography_path
+    )
+
+    # Compression comes last: the rm-synth and spice stages both read the Stokes
+    # cubes chunk-by-chunk, and astropy cannot memmap a gzip file, so each read
+    # would decompress the whole cube into memory. Spice compresses whatever it
+    # trims, so the pol cubes are only compressed below when spice is skipped.
+    pol_fitscube_options = FitsCubeOptions().with_options(
+        **get_options_from_strategy(
+            strategy=load_strategy_yaml(input_yaml=racs_all_options.imaging_strategy)
+            if racs_all_options.imaging_strategy is not None
+            else None,
+            operation="polarisation",
+            mode="fitscube",
+        )
+    )
+    defer_compression = not (
+        pipeline_options.skip_rmsynth and pipeline_options.skip_spice
+    )
+
+    assert pipeline_options.polarisation_cluster_config is not None
+    pol_result = process_science_fields_pol.with_options(
+        task_runner=get_dask_runner(
+            cluster=pipeline_options.polarisation_cluster_config
+        ),
+        name="RACS All -- polarisation imaging",
+    )(
+        flint_ms_directory=continuum_result.output_science_path,
+        pol_field_options=resolved_pol_field_options,
+        mss_by_beam=continuum_result.mss_by_beam,
+        compress_cubes=False if defer_compression else None,
+    )
+    terminal_results.extend(pol_result.terminal_futures)
+
+    # One root for every downstream stage, split into a subdirectory per stage.
+    output_root = pipeline_options.output_path or continuum_result.output_science_path
+
+    if not pipeline_options.skip_rmsynth:
+        resolved_rmsynth_field_options = rmsynth_field_options.with_options(
+            stokes_q_cube=pol_result.stokes_cubes["q"],
+            stokes_u_cube=pol_result.stokes_cubes["u"],
+            stokes_i_cube=pol_result.stokes_cubes.get("i"),
+            output_path=rmsynth_field_options.output_path or output_root / "rmsynth",
+        )
+        assert pipeline_options.rmsynth_cluster_config is not None
+        rmsynth_results = process_rmsynth.with_options(
+            task_runner=get_dask_runner(
+                cluster=pipeline_options.rmsynth_cluster_config
+            ),
+            name="RACS All -- rm-synthesis",
+        )(rmsynth_field_options=resolved_rmsynth_field_options)
+        terminal_results.extend(rmsynth_results)
+
+    if not pipeline_options.skip_spice:
+        resolved_reference_image = (
+            spice_field_options.reference_image
+            if spice_field_options.catalogue is not None
+            else pol_result.mfs_products.get("i", {}).get("image")
+        )
+        resolved_spice_field_options = spice_field_options.with_options(
+            cubes=list(pol_result.stokes_cubes.values()),
+            reference_image=resolved_reference_image,
+            output_path=spice_field_options.output_path or output_root / "spice",
+        )
+        assert pipeline_options.spice_cluster_config is not None
+        spice_results = process_spice_compression.with_options(
+            task_runner=get_dask_runner(cluster=pipeline_options.spice_cluster_config),
+            name="RACS All -- spice compression",
+        )(spice_field_options=resolved_spice_field_options)
+        terminal_results.extend(spice_results)
+    elif defer_compression and pol_fitscube_options.compress:
+        logger.info(
+            "Compressing the polarisation cubes, now that rm-synth has read them"
+        )
+        terminal_results.extend(
+            compress_cube(
+                stokes_cube,
+                method=pol_fitscube_options.compress_method,
+                max_workers=pol_fitscube_options.max_workers,
+            )
+            for stokes_cube in pol_result.stokes_cubes.values()
+        )
+
+    return terminal_results
+
+
+def setup_run_racs_all(
+    pipeline_options: RACSAllPipelineOptions,
+    racs_all_options: RACSAllOptions,
+    pol_field_options: PolFieldOptions,
+    rmsynth_field_options: RMSynthFieldOptions,
+    spice_field_options: SpiceFieldOptions,
+) -> None:
+    low_sbid = get_sbid_from_path(path=racs_all_options.low_data)
+
+    process_racs_all.with_options(name=f"RACS All Pipeline -- {low_sbid}")(
+        pipeline_options=pipeline_options,
+        racs_all_options=racs_all_options,
+        pol_field_options=pol_field_options,
+        rmsynth_field_options=rmsynth_field_options,
+        spice_field_options=spice_field_options,
+    )
+
+
+def get_parser() -> ArgumentParser:
+    parser = ArgumentParser(description=__doc__)
+
+    parser.add_argument(
+        "--cli-config", is_config_file=True, help="Path to configuration file"
+    )
+    parser.add_argument(
+        "--cluster-config",
+        type=str,
+        default="petrichor",
+        help="Path to a cluster configuration file, or a known cluster name. ",
+    )
+
+    parser = add_options_to_parser(parser=parser, options_class=RACSAllPipelineOptions)
+    parser = add_options_to_parser(parser=parser, options_class=RACSAllOptions)
+    seen_fields = (
+        set(RACSAllPipelineOptions.model_fields)
+        | set(RACSAllOptions.model_fields)
+        | COMPUTED_FIELDS
+    )
+
+    parser = add_options_to_parser(
+        parser=parser,
+        options_class=pol_field_options_cli_class(RACSAllOptions),
+        description="Polarisation processing options",
+    )
+    seen_fields |= set(PolFieldOptions.model_fields)
+
+    parser = add_options_to_parser(
+        parser=parser,
+        options_class=_exclude_fields_cli_class(RMSynthFieldOptions, seen_fields),
+        description="RM-synthesis processing options",
+    )
+    seen_fields |= set(RMSynthFieldOptions.model_fields)
+
+    parser = add_options_to_parser(
+        parser=parser,
+        options_class=_exclude_fields_cli_class(SpiceFieldOptions, seen_fields),
+        description="SPICE compression processing options",
+    )
+
+    return parser
+
+
+def cli() -> None:
+    parser = get_parser()
+
+    args = parser.parse_args()
+
+    # Excluded from the parser (COMPUTED_FIELDS), but create_options_from_parser
+    # reads every field off the namespace. process_racs_all sets the real values.
+    for field in COMPUTED_FIELDS:
+        setattr(args, field, [] if field == "cubes" else None)
+
+    pipeline_options = create_options_from_parser(
+        parser_namespace=args, options_class=RACSAllPipelineOptions
+    )
+    racs_all_options = create_options_from_parser(
+        parser_namespace=args, options_class=RACSAllOptions
+    )
+    pol_field_options = create_options_from_parser(
+        parser_namespace=args, options_class=PolFieldOptions
+    )
+    rmsynth_field_options = create_options_from_parser(
+        parser_namespace=args, options_class=RMSynthFieldOptions
+    )
+    spice_field_options = create_options_from_parser(
+        parser_namespace=args, options_class=SpiceFieldOptions
+    )
+
+    for cluster_config_attr in STAGE_CLUSTER_CONFIG_ATTRS:
+        if getattr(pipeline_options, cluster_config_attr) is None:
+            pipeline_options = pipeline_options.with_options(
+                **{cluster_config_attr: args.cluster_config}
+            )
+
+    setup_run_racs_all(
+        pipeline_options=pipeline_options,
+        racs_all_options=racs_all_options,
+        pol_field_options=pol_field_options,
+        rmsynth_field_options=rmsynth_field_options,
+        spice_field_options=spice_field_options,
+    )
+
+
+if __name__ == "__main__":
+    cli()

--- a/flint/prefect/flows/racs_all_pipeline.py
+++ b/flint/prefect/flows/racs_all_pipeline.py
@@ -42,7 +42,7 @@ STAGE_CLUSTER_CONFIG_ATTRS = (
 
 # Fields on the rm-synth/spice options classes that process_racs_all always recomputes
 # from the polarisation stage's output. Excluded from the combined CLI.
-COMPUTED_FIELDS = {"stokes_q_cube", "stokes_u_cube", "cubes"}
+COMPUTED_FIELDS = {"stokes_q_cube", "stokes_u_cube", "cubes", "weight_cubes"}
 
 
 def _check_stage_prerequisites(
@@ -275,6 +275,7 @@ def process_racs_all(
         )
         resolved_spice_field_options = spice_field_options.with_options(
             cubes=list(pol_result.stokes_cubes.values()),
+            weight_cubes=list(pol_result.weight_cubes.values()),
             reference_image=resolved_reference_image,
             output_path=spice_field_options.output_path or output_root / "spice",
         )
@@ -290,11 +291,14 @@ def process_racs_all(
         )
         terminal_results.extend(
             compress_cube(
-                stokes_cube,
+                cube,
                 method=pol_fitscube_options.compress_method,
                 max_workers=pol_fitscube_options.max_workers,
             )
-            for stokes_cube in pol_result.stokes_cubes.values()
+            for cube in (
+                *pol_result.stokes_cubes.values(),
+                *pol_result.weight_cubes.values(),
+            )
         )
 
     return terminal_results
@@ -370,7 +374,7 @@ def cli() -> None:
     # Excluded from the parser (COMPUTED_FIELDS), but create_options_from_parser
     # reads every field off the namespace. process_racs_all sets the real values.
     for field in COMPUTED_FIELDS:
-        setattr(args, field, [] if field == "cubes" else None)
+        setattr(args, field, [] if field in ("cubes", "weight_cubes") else None)
 
     pipeline_options = create_options_from_parser(
         parser_namespace=args, options_class=RACSAllPipelineOptions

--- a/flint/prefect/flows/rmsynth_pipeline.py
+++ b/flint/prefect/flows/rmsynth_pipeline.py
@@ -13,11 +13,18 @@ from configargparse import ArgumentParser
 from prefect import flow
 
 from flint.configuration import get_options_from_strategy, load_and_copy_strategy
+from flint.convol import cubes_share_common_beam
 from flint.logging import logger
 from flint.naming import create_name_from_common_fields, get_sbid_from_path
-from flint.options import RMCleanOptions, RMSynthFieldOptions, RMSynthOptions
+from flint.options import (
+    BaseOptions,
+    RMCleanOptions,
+    RMSynthFieldOptions,
+    RMSynthOptions,
+)
 from flint.prefect.clusters import get_dask_runner
 from flint.prefect.common.rmsynth import (
+    task_convolve_cubes_to_common_beam,
     task_rmclean,
     task_rmsynth,
     task_write_rm_products,
@@ -26,8 +33,50 @@ from flint.prefect.common.utils import task_archive_sbid
 from flint.rmsynth import needs_rmclean
 
 
+class RMSynthPipelineResult(BaseOptions):
+    """Return value of ``process_rmsynth``, handed in-memory to the
+    spice-compression stage of the ``racs-all`` flow-of-flows."""
+
+    written_paths: list[Path]
+    """The RM-synthesis and RM-CLEAN products written"""
+    convolved_cubes: list[Path]
+    """Any new Stokes cubes written to bring the inputs to a common resolution. Empty when the inputs already shared one and were used as they are, so a caller may concatenate these with the input cubes without ever repeating a path"""
+
+
+def _resolve_common_resolution_cubes(
+    stokes_cubes: dict[str, Path],
+    output_path: Path | None = None,
+    beam_cutoff: float | None = None,
+) -> tuple[dict[str, Path], list[Path]]:
+    """RM-synthesis is only meaningful when every channel of every Stokes shares
+    one resolution. Cubes that already do are used as they are; otherwise they
+    are convolved to a common beam and written as new cubes, leaving the inputs
+    alone. The weight cubes are untouched, as convolution preserves the pixel grid.
+
+    Args:
+        stokes_cubes (dict[str, Path]): The input cube of each Stokes to run against
+        output_path (Path | None, optional): Directory any new cubes are written into. Defaults to alongside the inputs.
+        beam_cutoff (float | None, optional): Channels coarser than this, in arcsec, are blanked rather than dragging the common beam out to their resolution. Defaults to no cutoff.
+
+    Returns:
+        tuple[dict[str, Path], list[Path]]: The cube to use for each Stokes, and the new cubes written (empty when the inputs were used as they are)
+    """
+    cube_paths = list(stokes_cubes.values())
+    if cubes_share_common_beam(cube_paths=cube_paths):
+        logger.info("Stokes cubes already share a common resolution")
+        return stokes_cubes, []
+
+    convolved_cubes = task_convolve_cubes_to_common_beam.submit(
+        cube_paths=cube_paths, output_path=output_path, cutoff=beam_cutoff
+    ).result()
+
+    return dict(zip(stokes_cubes, convolved_cubes)), convolved_cubes
+
+
 @flow(name="Flint RM-Synthesis Pipeline")
-def process_rmsynth(rmsynth_field_options: RMSynthFieldOptions) -> list[Path]:
+def process_rmsynth(
+    rmsynth_field_options: RMSynthFieldOptions,
+) -> RMSynthPipelineResult:
     if (
         rmsynth_field_options.stokes_q_cube is None
         or rmsynth_field_options.stokes_u_cube is None
@@ -36,6 +85,12 @@ def process_rmsynth(rmsynth_field_options: RMSynthFieldOptions) -> list[Path]:
             "stokes_q_cube and stokes_u_cube are required. The racs-all flow sets "
             "them from the polarisation stage."
         )
+    stokes_cubes = {
+        "q": rmsynth_field_options.stokes_q_cube,
+        "u": rmsynth_field_options.stokes_u_cube,
+    }
+    if rmsynth_field_options.stokes_i_cube is not None:
+        stokes_cubes["i"] = rmsynth_field_options.stokes_i_cube
 
     strategy = load_and_copy_strategy(
         output_split_science_path=rmsynth_field_options.stokes_q_cube.parent,
@@ -61,13 +116,19 @@ def process_rmsynth(rmsynth_field_options: RMSynthFieldOptions) -> list[Path]:
         and not rmclean_options.peak_products
     ):
         logger.info("No RM-synthesis products requested, skipping.")
-        return []
+        return RMSynthPipelineResult(written_paths=[], convolved_cubes=[])
+
+    stokes_cubes, convolved_cubes = _resolve_common_resolution_cubes(
+        stokes_cubes=stokes_cubes,
+        output_path=rmsynth_field_options.output_path,
+        beam_cutoff=rmsynth_field_options.beam_cutoff,
+    )
 
     synth_result = task_rmsynth.submit(
-        stokes_q_cube=rmsynth_field_options.stokes_q_cube,
-        stokes_u_cube=rmsynth_field_options.stokes_u_cube,
+        stokes_q_cube=stokes_cubes["q"],
+        stokes_u_cube=stokes_cubes["u"],
         rmsynth_options=rmsynth_options,
-        stokes_i_cube=rmsynth_field_options.stokes_i_cube,
+        stokes_i_cube=stokes_cubes.get("i"),
         stokes_i_weight_cube=rmsynth_field_options.stokes_i_weight_cube,
         stokes_q_weight_cube=rmsynth_field_options.stokes_q_weight_cube,
         stokes_u_weight_cube=rmsynth_field_options.stokes_u_weight_cube,
@@ -87,10 +148,7 @@ def process_rmsynth(rmsynth_field_options: RMSynthFieldOptions) -> list[Path]:
     )
 
     output_prefix = create_name_from_common_fields(
-        in_paths=(
-            rmsynth_field_options.stokes_q_cube,
-            rmsynth_field_options.stokes_u_cube,
-        )
+        in_paths=(stokes_cubes["q"], stokes_cubes["u"])
     )
     if rmsynth_field_options.output_path is not None:
         rmsynth_field_options.output_path.mkdir(parents=True, exist_ok=True)
@@ -99,7 +157,7 @@ def process_rmsynth(rmsynth_field_options: RMSynthFieldOptions) -> list[Path]:
     output_paths = task_write_rm_products.submit(
         synth_results=synth_result,
         clean_results=clean_result,
-        stokes_q_cube=rmsynth_field_options.stokes_q_cube,
+        stokes_q_cube=stokes_cubes["q"],
         rmsynth_options=rmsynth_options,
         rmclean_options=rmclean_options,
         cube_products=rmsynth_field_options.cube_products,
@@ -116,7 +174,9 @@ def process_rmsynth(rmsynth_field_options: RMSynthFieldOptions) -> list[Path]:
             copy_path=rmsynth_field_options.sbid_copy_path,
         ).result()
 
-    return written_paths
+    return RMSynthPipelineResult(
+        written_paths=written_paths, convolved_cubes=convolved_cubes
+    )
 
 
 def setup_run_rmsynth(

--- a/flint/prefect/flows/rmsynth_pipeline.py
+++ b/flint/prefect/flows/rmsynth_pipeline.py
@@ -13,7 +13,7 @@ from configargparse import ArgumentParser
 from prefect import flow
 
 from flint.configuration import get_options_from_strategy, load_and_copy_strategy
-from flint.convol import cubes_share_common_beam
+from flint.convol import BeamShape, common_beam_from_cubes, cubes_share_common_beam
 from flint.logging import logger
 from flint.naming import create_name_from_common_fields, get_sbid_from_path
 from flint.options import (
@@ -24,7 +24,7 @@ from flint.options import (
 )
 from flint.prefect.clusters import get_dask_runner
 from flint.prefect.common.rmsynth import (
-    task_convolve_cubes_to_common_beam,
+    convolve_cubes_to_common_resolution,
     task_rmclean,
     task_rmsynth,
     task_write_rm_products,
@@ -53,6 +53,10 @@ def _resolve_common_resolution_cubes(
     are convolved to a common beam and written as new cubes, leaving the inputs
     alone. The weight cubes are untouched, as convolution preserves the pixel grid.
 
+    The convolution runs plane by plane (see
+    ``convolve_cubes_to_common_resolution``), so every channel of every Stokes
+    is smoothed at once across the cluster.
+
     Args:
         stokes_cubes (dict[str, Path]): The input cube of each Stokes to run against
         output_path (Path | None, optional): Directory any new cubes are written into. Defaults to alongside the inputs.
@@ -62,15 +66,28 @@ def _resolve_common_resolution_cubes(
         tuple[dict[str, Path], list[Path]]: The cube to use for each Stokes, and the new cubes written (empty when the inputs were used as they are)
     """
     cube_paths = list(stokes_cubes.values())
-    if cubes_share_common_beam(cube_paths=cube_paths):
+    common_beam = common_beam_from_cubes(cube_paths=cube_paths, cutoff=beam_cutoff)
+    if common_beam is None:
+        logger.warning(
+            "No usable restoring beam among the Stokes cubes, so there is no "
+            "resolution to make common. Using them as they are."
+        )
+        return stokes_cubes, []
+
+    if cubes_share_common_beam(cube_paths=cube_paths, cutoff=beam_cutoff):
         logger.info("Stokes cubes already share a common resolution")
         return stokes_cubes, []
 
-    convolved_cubes = task_convolve_cubes_to_common_beam.submit(
-        cube_paths=cube_paths, output_path=output_path, cutoff=beam_cutoff
-    ).result()
+    beam_shape = BeamShape.from_radio_beam(radio_beam=common_beam)
+    logger.info(f"Bringing the Stokes cubes to {beam_shape=}")
+    convolved_cubes = convolve_cubes_to_common_resolution(
+        cubes=stokes_cubes,
+        beam_shape=beam_shape,
+        output_path=output_path,
+        beam_cutoff=beam_cutoff,
+    )
 
-    return dict(zip(stokes_cubes, convolved_cubes)), convolved_cubes
+    return convolved_cubes, list(convolved_cubes.values())
 
 
 @flow(name="Flint RM-Synthesis Pipeline")

--- a/flint/prefect/flows/rmsynth_pipeline.py
+++ b/flint/prefect/flows/rmsynth_pipeline.py
@@ -25,6 +25,8 @@ from flint.options import (
     RMCleanOptions,
     RMSynthFieldOptions,
     RMSynthOptions,
+    WeightCubesForRMSynth,
+    exclude_fields_cli_class,
 )
 from flint.prefect.clusters import get_dask_runner
 from flint.prefect.common.rmsynth import (
@@ -262,10 +264,46 @@ def get_parser() -> ArgumentParser:
         help="Path to a cluster configuration file, or a known cluster name. ",
     )
 
+    # stokes_cubes/error_cubes are nested Options classes, which
+    # add_options_to_parser can only render as a single-value flag that no CLI or
+    # config string can fill. Set up by hand below and assembled in cli().
     parser = add_options_to_parser(
         parser=parser,
-        options_class=RMSynthFieldOptions,
+        options_class=exclude_fields_cli_class(
+            RMSynthFieldOptions, {"stokes_cubes", "error_cubes"}
+        ),
         description="RM-synthesis processing options",
+    )
+
+    group = parser.add_argument_group(title="Input cubes")
+    group.add_argument(
+        "--stokes-cubes",
+        type=Path,
+        nargs="+",
+        default=None,
+        metavar="CUBE",
+        help="The Stokes cubes to synthesise, one per Stokes. Q and U are required, "
+        "I is optional and fits the fractional-polarisation correction. Which Stokes "
+        "each cube is comes from its filename.",
+    )
+    group.add_argument(
+        "--error-cubes",
+        type=Path,
+        nargs="+",
+        default=None,
+        metavar="CUBE",
+        help="Cubes describing the error on --stokes-cubes, matched to a Stokes the "
+        "same way. Requires --error-cube-kind. Omit to let rm-lite estimate the noise "
+        "from Q/U itself.",
+    )
+    group.add_argument(
+        "--error-cube-kind",
+        type=str,
+        choices=("weight", "noise"),
+        default=None,
+        help="Whether --error-cubes are linmos weights (an inverse variance) or a "
+        "noise (a sigma). Required with --error-cubes: reading one as the other "
+        "inverts the error by 1/sigma**2.",
     )
 
     return parser
@@ -276,8 +314,27 @@ def cli() -> None:
 
     args = parser.parse_args()
 
+    if args.error_cubes and args.error_cube_kind is None:
+        parser.error("--error-cubes requires --error-cube-kind")
+
+    error_cubes_class = {
+        "weight": WeightCubesForRMSynth,
+        "noise": NoiseCubesForRMSynth,
+    }.get(args.error_cube_kind)
+
+    # The cube fields are off the parser, so their values are substituted rather
+    # than read straight off the namespace.
+    namespace = vars(args) | {
+        "stokes_cubes": CubesForRMSynth.from_paths(paths=args.stokes_cubes)
+        if args.stokes_cubes
+        else None,
+        "error_cubes": error_cubes_class.from_paths(paths=args.error_cubes)
+        if args.error_cubes and error_cubes_class is not None
+        else None,
+    }
+
     rmsynth_field_options = create_options_from_parser(
-        parser_namespace=args, options_class=RMSynthFieldOptions
+        parser_namespace=namespace, options_class=RMSynthFieldOptions
     )
 
     setup_run_rmsynth(

--- a/flint/prefect/flows/rmsynth_pipeline.py
+++ b/flint/prefect/flows/rmsynth_pipeline.py
@@ -42,13 +42,6 @@ def process_rmsynth(rmsynth_field_options: RMSynthFieldOptions) -> list[Path]:
         imaging_strategy=rmsynth_field_options.imaging_strategy,
     )
 
-    if (
-        not rmsynth_field_options.cube_products
-        and not rmsynth_field_options.moment_products
-    ):
-        logger.info("No RM-synthesis products requested, skipping.")
-        return []
-
     rmsynth_options = RMSynthOptions(
         **get_options_from_strategy(
             strategy=strategy, operation="rmsynth", mode="rmsynth"
@@ -59,6 +52,16 @@ def process_rmsynth(rmsynth_field_options: RMSynthFieldOptions) -> list[Path]:
             strategy=strategy, operation="rmsynth", mode="rmclean"
         )
     )
+
+    # After the options are built, not before: peak_products is a product
+    # request like the other two, but it comes from the strategy, not the CLI
+    if (
+        not rmsynth_field_options.cube_products
+        and not rmsynth_field_options.moment_products
+        and not rmclean_options.peak_products
+    ):
+        logger.info("No RM-synthesis products requested, skipping.")
+        return []
 
     synth_result = task_rmsynth.submit(
         stokes_q_cube=rmsynth_field_options.stokes_q_cube,
@@ -73,6 +76,7 @@ def process_rmsynth(rmsynth_field_options: RMSynthFieldOptions) -> list[Path]:
     run_clean = needs_rmclean(
         cube_products=rmsynth_field_options.cube_products,
         moment_products=rmsynth_field_options.moment_products,
+        peak_products=rmclean_options.peak_products,
     )
     clean_result = (
         task_rmclean.submit(
@@ -101,6 +105,7 @@ def process_rmsynth(rmsynth_field_options: RMSynthFieldOptions) -> list[Path]:
         cube_products=rmsynth_field_options.cube_products,
         moment_products=rmsynth_field_options.moment_products,
         output_prefix=output_prefix,
+        peak_products=rmclean_options.peak_products,
     )
 
     written_paths = output_paths.result()

--- a/flint/prefect/flows/rmsynth_pipeline.py
+++ b/flint/prefect/flows/rmsynth_pipeline.py
@@ -18,12 +18,17 @@ from flint.logging import logger
 from flint.naming import create_name_from_common_fields, get_sbid_from_path
 from flint.options import (
     BaseOptions,
+    CubesForRMSynth,
+    ErrorCubesForRMSynth,
+    FFTBANEOptions,
+    NoiseCubesForRMSynth,
     RMCleanOptions,
     RMSynthFieldOptions,
     RMSynthOptions,
 )
 from flint.prefect.clusters import get_dask_runner
 from flint.prefect.common.rmsynth import (
+    CommonResolutionCubes,
     convolve_cubes_to_common_resolution,
     task_rmclean,
     task_rmsynth,
@@ -41,13 +46,16 @@ class RMSynthPipelineResult(BaseOptions):
     """The RM-synthesis and RM-CLEAN products written"""
     convolved_cubes: list[Path]
     """Any new Stokes cubes written to bring the inputs to a common resolution. Empty when the inputs already shared one and were used as they are, so a caller may concatenate these with the input cubes without ever repeating a path"""
+    convolved_noise_cubes: list[Path] = []
+    """The BANE background and RMS cubes measured on those convolved cubes. Frequency cubes like the rest, so they are trimmed and compressed alongside them. Empty whenever ``convolved_cubes`` is, or when BANE was not asked for"""
 
 
 def _resolve_common_resolution_cubes(
     stokes_cubes: dict[str, Path],
     output_path: Path | None = None,
     beam_cutoff: float | None = None,
-) -> tuple[dict[str, Path], list[Path]]:
+    fft_bane_options: FFTBANEOptions | None = None,
+) -> CommonResolutionCubes:
     """RM-synthesis is only meaningful when every channel of every Stokes shares
     one resolution, the 'total' mode of racs_tools. Cubes that already do are
     used as they are; otherwise they are convolved to a common beam and written
@@ -65,9 +73,10 @@ def _resolve_common_resolution_cubes(
         stokes_cubes (dict[str, Path]): The input cube of each Stokes to run against
         output_path (Path | None, optional): Directory any new cubes are written into. Defaults to alongside the inputs.
         beam_cutoff (float | None, optional): Channels coarser than this, in arcsec, are blanked rather than dragging the common beam out to their resolution. Defaults to no cutoff.
+        fft_bane_options (FFTBANEOptions | None, optional): When given, the convolved planes also get BANE background and RMS cubes, measured at the resolution the FDF is built at. Defaults to None.
 
     Returns:
-        tuple[dict[str, Path], list[Path]]: The cube to use for each Stokes, and the new cubes written (empty when the inputs were used as they are)
+        CommonResolutionCubes: The cube to use for each Stokes, and any BANE cubes. ``cubes`` is the input dict unchanged when no convolution was needed.
     """
     cube_paths = list(stokes_cubes.values())
     common_beam = common_beam_from_cubes(cube_paths=cube_paths, cutoff=beam_cutoff)
@@ -76,35 +85,31 @@ def _resolve_common_resolution_cubes(
             "No usable restoring beam among the Stokes cubes, so there is no "
             "resolution to make common. Using them as they are."
         )
-        return stokes_cubes, []
+        return CommonResolutionCubes(cubes=stokes_cubes)
 
     if cubes_share_common_beam(cube_paths=cube_paths, cutoff=beam_cutoff):
         logger.info("Stokes cubes already share a common resolution")
-        return stokes_cubes, []
+        return CommonResolutionCubes(cubes=stokes_cubes)
 
     beam_shape = BeamShape.from_radio_beam(radio_beam=common_beam)
     logger.info(f"Bringing the Stokes cubes to {beam_shape=}")
-    convolved_cubes = convolve_cubes_to_common_resolution(
+    return convolve_cubes_to_common_resolution(
         cubes=stokes_cubes,
         beam_shape=beam_shape,
         output_path=output_path,
         beam_cutoff=beam_cutoff,
+        fft_bane_options=fft_bane_options,
     )
-
-    return convolved_cubes, list(convolved_cubes.values())
 
 
 @flow(name="Flint RM-Synthesis Pipeline")
 def process_rmsynth(
     rmsynth_field_options: RMSynthFieldOptions,
 ) -> RMSynthPipelineResult:
-    if (
-        rmsynth_field_options.stokes_q_cube is None
-        or rmsynth_field_options.stokes_u_cube is None
-    ):
+    if rmsynth_field_options.stokes_cubes is None:
         raise ValueError(
-            "stokes_q_cube and stokes_u_cube are required. The racs-all flow sets "
-            "them from the polarisation stage."
+            "stokes_cubes is required. The racs-all flow sets it from the "
+            "polarisation stage."
         )
     if (
         not rmsynth_field_options.cube_products
@@ -114,15 +119,18 @@ def process_rmsynth(
         logger.info("No RM-synthesis products requested, skipping.")
         return RMSynthPipelineResult(written_paths=[], convolved_cubes=[])
 
-    stokes_cubes = {
-        "q": rmsynth_field_options.stokes_q_cube,
-        "u": rmsynth_field_options.stokes_u_cube,
+    stokes_cube_paths = {
+        stokes: cube
+        for stokes, cube in (
+            ("q", rmsynth_field_options.stokes_cubes.q_path),
+            ("u", rmsynth_field_options.stokes_cubes.u_path),
+            ("i", rmsynth_field_options.stokes_cubes.i_path),
+        )
+        if cube is not None
     }
-    if rmsynth_field_options.stokes_i_cube is not None:
-        stokes_cubes["i"] = rmsynth_field_options.stokes_i_cube
 
     strategy = load_and_copy_strategy(
-        output_split_science_path=rmsynth_field_options.stokes_q_cube.parent,
+        output_split_science_path=rmsynth_field_options.stokes_cubes.q_path.parent,
         imaging_strategy=rmsynth_field_options.imaging_strategy,
     )
 
@@ -137,20 +145,33 @@ def process_rmsynth(
         )
     )
 
-    stokes_cubes, convolved_cubes = _resolve_common_resolution_cubes(
-        stokes_cubes=stokes_cubes,
+    common_resolution = _resolve_common_resolution_cubes(
+        stokes_cubes=stokes_cube_paths,
         output_path=rmsynth_field_options.output_path,
         beam_cutoff=rmsynth_field_options.beam_cutoff,
+        fft_bane_options=FFTBANEOptions(
+            **get_options_from_strategy(
+                strategy=strategy, operation="rmsynth", mode="fftbane"
+            )
+        )
+        if rmsynth_field_options.bane_noise
+        else None,
+    )
+    stokes_cubes = CubesForRMSynth.from_mapping(common_resolution.cubes)
+
+    # A noise cube only describes the cubes it was measured on, so the BANE
+    # cubes made just above supersede the caller's. The caller's are right only
+    # when nothing was convolved and they describe these same cubes.
+    error_cubes: ErrorCubesForRMSynth | None = (
+        NoiseCubesForRMSynth.from_mapping(common_resolution.rms_cubes)
+        if common_resolution.rms_cubes
+        else rmsynth_field_options.error_cubes
     )
 
     synth_result = task_rmsynth.submit(
-        stokes_q_cube=stokes_cubes["q"],
-        stokes_u_cube=stokes_cubes["u"],
+        stokes_cubes=stokes_cubes,
         rmsynth_options=rmsynth_options,
-        stokes_i_cube=stokes_cubes.get("i"),
-        stokes_i_weight_cube=rmsynth_field_options.stokes_i_weight_cube,
-        stokes_q_weight_cube=rmsynth_field_options.stokes_q_weight_cube,
-        stokes_u_weight_cube=rmsynth_field_options.stokes_u_weight_cube,
+        error_cubes=error_cubes,
     )
 
     run_clean = needs_rmclean(
@@ -167,7 +188,7 @@ def process_rmsynth(
     )
 
     output_prefix = create_name_from_common_fields(
-        in_paths=(stokes_cubes["q"], stokes_cubes["u"])
+        in_paths=(stokes_cubes.q_path, stokes_cubes.u_path)
     )
     if rmsynth_field_options.output_path is not None:
         rmsynth_field_options.output_path.mkdir(parents=True, exist_ok=True)
@@ -176,13 +197,15 @@ def process_rmsynth(
     output_paths = task_write_rm_products.submit(
         synth_results=synth_result,
         clean_results=clean_result,
-        stokes_q_cube=stokes_cubes["q"],
+        stokes_q_cube=stokes_cubes.q_path,
         rmsynth_options=rmsynth_options,
         rmclean_options=rmclean_options,
         cube_products=rmsynth_field_options.cube_products,
         moment_products=rmsynth_field_options.moment_products,
         peak_products=rmsynth_field_options.peak_products,
         output_prefix=output_prefix,
+        moment_threshold_snr=rmsynth_field_options.moment_threshold_snr,
+        peak_threshold_snr=rmsynth_field_options.peak_threshold_snr,
     )
 
     written_paths = output_paths.result()
@@ -194,7 +217,14 @@ def process_rmsynth(
         ).result()
 
     return RMSynthPipelineResult(
-        written_paths=written_paths, convolved_cubes=convolved_cubes
+        written_paths=written_paths,
+        convolved_cubes=list(common_resolution.cubes.values())
+        if common_resolution.convolved
+        else [],
+        convolved_noise_cubes=[
+            *common_resolution.bkg_cubes.values(),
+            *common_resolution.rms_cubes.values(),
+        ],
     )
 
 
@@ -203,9 +233,11 @@ def setup_run_rmsynth(
 ) -> None:
     if (
         rmsynth_field_options.sbid_copy_path
-        and rmsynth_field_options.stokes_q_cube is not None
+        and rmsynth_field_options.stokes_cubes is not None
     ):
-        science_sbid = get_sbid_from_path(path=rmsynth_field_options.stokes_q_cube)
+        science_sbid = get_sbid_from_path(
+            path=rmsynth_field_options.stokes_cubes.q_path
+        )
         rmsynth_field_options = rmsynth_field_options.with_options(
             sbid_copy_path=rmsynth_field_options.sbid_copy_path / f"{science_sbid}"
         )

--- a/flint/prefect/flows/rmsynth_pipeline.py
+++ b/flint/prefect/flows/rmsynth_pipeline.py
@@ -85,6 +85,14 @@ def process_rmsynth(
             "stokes_q_cube and stokes_u_cube are required. The racs-all flow sets "
             "them from the polarisation stage."
         )
+    if (
+        not rmsynth_field_options.cube_products
+        and not rmsynth_field_options.moment_products
+        and not rmsynth_field_options.peak_products
+    ):
+        logger.info("No RM-synthesis products requested, skipping.")
+        return RMSynthPipelineResult(written_paths=[], convolved_cubes=[])
+
     stokes_cubes = {
         "q": rmsynth_field_options.stokes_q_cube,
         "u": rmsynth_field_options.stokes_u_cube,
@@ -108,16 +116,6 @@ def process_rmsynth(
         )
     )
 
-    # After the options are built, not before: peak_products is a product
-    # request like the other two, but it comes from the strategy, not the CLI
-    if (
-        not rmsynth_field_options.cube_products
-        and not rmsynth_field_options.moment_products
-        and not rmclean_options.peak_products
-    ):
-        logger.info("No RM-synthesis products requested, skipping.")
-        return RMSynthPipelineResult(written_paths=[], convolved_cubes=[])
-
     stokes_cubes, convolved_cubes = _resolve_common_resolution_cubes(
         stokes_cubes=stokes_cubes,
         output_path=rmsynth_field_options.output_path,
@@ -137,7 +135,7 @@ def process_rmsynth(
     run_clean = needs_rmclean(
         cube_products=rmsynth_field_options.cube_products,
         moment_products=rmsynth_field_options.moment_products,
-        peak_products=rmclean_options.peak_products,
+        peak_products=rmsynth_field_options.peak_products,
     )
     clean_result = (
         task_rmclean.submit(
@@ -162,8 +160,8 @@ def process_rmsynth(
         rmclean_options=rmclean_options,
         cube_products=rmsynth_field_options.cube_products,
         moment_products=rmsynth_field_options.moment_products,
+        peak_products=rmsynth_field_options.peak_products,
         output_prefix=output_prefix,
-        peak_products=rmclean_options.peak_products,
     )
 
     written_paths = output_paths.result()

--- a/flint/prefect/flows/rmsynth_pipeline.py
+++ b/flint/prefect/flows/rmsynth_pipeline.py
@@ -1,0 +1,171 @@
+"""Standalone RM-synthesis (and, if requested, RM-CLEAN) pipeline: given
+already-imaged Stokes Q/U (and optionally I) FITS cubes, write the requested
+Faraday dispersion function (FDF) cube and moment map products. See
+``flint.rmsynth``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from capn_crunch import add_options_to_parser, create_options_from_parser
+from configargparse import ArgumentParser
+from prefect import flow
+
+from flint.configuration import get_options_from_strategy, load_and_copy_strategy
+from flint.logging import logger
+from flint.naming import create_name_from_common_fields, get_sbid_from_path
+from flint.options import RMCleanOptions, RMSynthFieldOptions, RMSynthOptions
+from flint.prefect.clusters import get_dask_runner
+from flint.prefect.common.rmsynth import (
+    task_rmclean,
+    task_rmsynth,
+    task_write_rm_products,
+)
+from flint.prefect.common.utils import task_archive_sbid
+from flint.rmsynth import needs_rmclean
+
+
+@flow(name="Flint RM-Synthesis Pipeline")
+def process_rmsynth(rmsynth_field_options: RMSynthFieldOptions) -> list[Path]:
+    if (
+        rmsynth_field_options.stokes_q_cube is None
+        or rmsynth_field_options.stokes_u_cube is None
+    ):
+        raise ValueError(
+            "stokes_q_cube and stokes_u_cube are required. The racs-all flow sets "
+            "them from the polarisation stage."
+        )
+
+    strategy = load_and_copy_strategy(
+        output_split_science_path=rmsynth_field_options.stokes_q_cube.parent,
+        imaging_strategy=rmsynth_field_options.imaging_strategy,
+    )
+
+    if (
+        not rmsynth_field_options.cube_products
+        and not rmsynth_field_options.moment_products
+    ):
+        logger.info("No RM-synthesis products requested, skipping.")
+        return []
+
+    rmsynth_options = RMSynthOptions(
+        **get_options_from_strategy(
+            strategy=strategy, operation="rmsynth", mode="rmsynth"
+        )
+    )
+    rmclean_options = RMCleanOptions(
+        **get_options_from_strategy(
+            strategy=strategy, operation="rmsynth", mode="rmclean"
+        )
+    )
+
+    synth_result = task_rmsynth.submit(
+        stokes_q_cube=rmsynth_field_options.stokes_q_cube,
+        stokes_u_cube=rmsynth_field_options.stokes_u_cube,
+        rmsynth_options=rmsynth_options,
+        stokes_i_cube=rmsynth_field_options.stokes_i_cube,
+    )
+
+    run_clean = needs_rmclean(
+        cube_products=rmsynth_field_options.cube_products,
+        moment_products=rmsynth_field_options.moment_products,
+    )
+    clean_result = (
+        task_rmclean.submit(
+            rm_synth_results=synth_result, rmclean_options=rmclean_options
+        )
+        if run_clean
+        else None
+    )
+
+    output_prefix = create_name_from_common_fields(
+        in_paths=(
+            rmsynth_field_options.stokes_q_cube,
+            rmsynth_field_options.stokes_u_cube,
+        )
+    )
+    if rmsynth_field_options.output_path is not None:
+        rmsynth_field_options.output_path.mkdir(parents=True, exist_ok=True)
+        output_prefix = rmsynth_field_options.output_path / output_prefix.name
+
+    output_paths = task_write_rm_products.submit(
+        synth_results=synth_result,
+        clean_results=clean_result,
+        stokes_q_cube=rmsynth_field_options.stokes_q_cube,
+        rmsynth_options=rmsynth_options,
+        rmclean_options=rmclean_options,
+        cube_products=rmsynth_field_options.cube_products,
+        moment_products=rmsynth_field_options.moment_products,
+        output_prefix=output_prefix,
+    )
+
+    written_paths = output_paths.result()
+
+    if rmsynth_field_options.sbid_copy_path:
+        task_archive_sbid.submit(
+            science_folder_path=output_prefix.parent,
+            copy_path=rmsynth_field_options.sbid_copy_path,
+        ).result()
+
+    return written_paths
+
+
+def setup_run_rmsynth(
+    cluster_config: str | Path, rmsynth_field_options: RMSynthFieldOptions
+) -> None:
+    if (
+        rmsynth_field_options.sbid_copy_path
+        and rmsynth_field_options.stokes_q_cube is not None
+    ):
+        science_sbid = get_sbid_from_path(path=rmsynth_field_options.stokes_q_cube)
+        rmsynth_field_options = rmsynth_field_options.with_options(
+            sbid_copy_path=rmsynth_field_options.sbid_copy_path / f"{science_sbid}"
+        )
+
+    dask_task_runner = get_dask_runner(cluster=cluster_config)
+
+    process_rmsynth.with_options(task_runner=dask_task_runner)(
+        rmsynth_field_options=rmsynth_field_options
+    )
+
+
+def get_parser() -> ArgumentParser:
+    parser = ArgumentParser(description=__doc__)
+
+    parser.add_argument(
+        "--cli-config", is_config_file=True, help="Path to configuration file"
+    )
+    parser.add_argument(
+        "--cluster-config",
+        type=str,
+        default="petrichor",
+        help="Path to a cluster configuration file, or a known cluster name. ",
+    )
+
+    parser = add_options_to_parser(
+        parser=parser,
+        options_class=RMSynthFieldOptions,
+        description="RM-synthesis processing options",
+    )
+
+    return parser
+
+
+def cli() -> None:
+    parser = get_parser()
+
+    args = parser.parse_args()
+
+    rmsynth_field_options = create_options_from_parser(
+        parser_namespace=args, options_class=RMSynthFieldOptions
+    )
+
+    setup_run_rmsynth(
+        cluster_config=args.cluster_config,
+        rmsynth_field_options=rmsynth_field_options,
+    )
+
+
+if __name__ == "__main__":
+    cli()

--- a/flint/prefect/flows/rmsynth_pipeline.py
+++ b/flint/prefect/flows/rmsynth_pipeline.py
@@ -49,9 +49,13 @@ def _resolve_common_resolution_cubes(
     beam_cutoff: float | None = None,
 ) -> tuple[dict[str, Path], list[Path]]:
     """RM-synthesis is only meaningful when every channel of every Stokes shares
-    one resolution. Cubes that already do are used as they are; otherwise they
-    are convolved to a common beam and written as new cubes, leaving the inputs
-    alone. The weight cubes are untouched, as convolution preserves the pixel grid.
+    one resolution, the 'total' mode of racs_tools. Cubes that already do are
+    used as they are; otherwise they are convolved to a common beam and written
+    as new cubes, leaving the inputs alone. The polarisation stage hands over
+    cubes at a 'natural' resolution, one beam per channel, so in the racs-all
+    flow this is the pass that makes them synthesisable while the cubes to
+    archive keep their frequency-dependent resolution. The weight cubes are
+    untouched, as convolution preserves the pixel grid.
 
     The convolution runs plane by plane (see
     ``convolve_cubes_to_common_resolution``), so every channel of every Stokes

--- a/flint/prefect/flows/rmsynth_pipeline.py
+++ b/flint/prefect/flows/rmsynth_pipeline.py
@@ -65,6 +65,9 @@ def process_rmsynth(rmsynth_field_options: RMSynthFieldOptions) -> list[Path]:
         stokes_u_cube=rmsynth_field_options.stokes_u_cube,
         rmsynth_options=rmsynth_options,
         stokes_i_cube=rmsynth_field_options.stokes_i_cube,
+        stokes_i_weight_cube=rmsynth_field_options.stokes_i_weight_cube,
+        stokes_q_weight_cube=rmsynth_field_options.stokes_q_weight_cube,
+        stokes_u_weight_cube=rmsynth_field_options.stokes_u_weight_cube,
     )
 
     run_clean = needs_rmclean(

--- a/flint/prefect/flows/rmsynth_pipeline.py
+++ b/flint/prefect/flows/rmsynth_pipeline.py
@@ -207,7 +207,6 @@ def process_rmsynth(
         peak_products=rmsynth_field_options.peak_products,
         output_prefix=output_prefix,
         moment_threshold_snr=rmsynth_field_options.moment_threshold_snr,
-        peak_threshold_snr=rmsynth_field_options.peak_threshold_snr,
     )
 
     written_paths = output_paths.result()

--- a/flint/prefect/flows/spice_compression_pipeline.py
+++ b/flint/prefect/flows/spice_compression_pipeline.py
@@ -1,6 +1,7 @@
 """Standalone SPICE-style cube compression pipeline: trim already-imaged
-Stokes cubes down to small boxes around catalogued sources, crop to their
-union, and compress. See ``flint.spice``.
+Stokes image and weight cubes down to small boxes around catalogued sources,
+crop to their union, and compress. Every cube is trimmed with the same boxes,
+so they all land on a common grid. See ``flint.spice``.
 """
 
 from __future__ import annotations
@@ -27,7 +28,7 @@ from flint.prefect.common.spice import (
 )
 from flint.prefect.common.utils import task_archive_sbid, task_getattr
 from flint.source_finding.aegean import run_bane_and_aegean
-from flint.spice import any_box_overlaps
+from flint.spice import check_cubes_share_shape, shared_pixel_boxes
 
 task_run_bane_and_aegean = task(run_bane_and_aegean)
 
@@ -38,6 +39,8 @@ def process_spice_compression(spice_field_options: SpiceFieldOptions) -> list[Pa
         raise ValueError(
             "``cubes`` is required. The racs-all flow sets it from the polarisation stage."
         )
+
+    cubes = [*spice_field_options.cubes, *spice_field_options.weight_cubes]
 
     strategy = load_and_copy_strategy(
         output_split_science_path=spice_field_options.cubes[0].parent,
@@ -89,37 +92,29 @@ def process_spice_compression(spice_field_options: SpiceFieldOptions) -> list[Pa
         is_user_catalogue=is_user_catalogue,
     )
 
-    resolved_sky_boxes = island_sky_boxes.result()
-    overlapping = [
-        cube
-        for cube in spice_field_options.cubes
-        if any_box_overlaps(fits_path=cube, sky_boxes=resolved_sky_boxes)
-    ]
-    if not overlapping:
-        raise ValueError(
-            f"No island overlaps any of the {len(spice_field_options.cubes)} supplied "
-            "cubes. Check the catalogue and reference image match the field."
-        )
-    if len(overlapping) != len(spice_field_options.cubes):
-        logger.warning(
-            f"{len(spice_field_options.cubes) - len(overlapping)} cube(s) have no "
-            "islands and will be compressed without spicing"
-        )
-
-    spiced_cubes = task_spice_fits.map(
-        fits_path=spice_field_options.cubes,
-        sky_boxes=unmapped(resolved_sky_boxes),
-        output_path=unmapped(spice_field_options.output_path),
+    # One set of boxes for every image and weight cube, so they all come out of
+    # the spicing on the same pixel grid.
+    pixel_boxes = shared_pixel_boxes(
+        fits_paths=cubes, sky_boxes=island_sky_boxes.result()
     )
 
+    spiced_cubes = task_spice_fits.map(
+        fits_path=cubes,
+        pixel_boxes=unmapped(pixel_boxes),
+        output_path=unmapped(spice_field_options.output_path),
+    )
+    spiced_paths = spiced_cubes.result()
+    spiced_shape = check_cubes_share_shape(fits_paths=spiced_paths)
+    logger.info(f"Spiced {len(spiced_paths)} cubes, all of shape {spiced_shape}")
+
     compressed_cubes = task_compress_cube.map(
-        out_cube=spiced_cubes,
+        out_cube=spiced_paths,
         method=unmapped(spice_options.compress_method),
         max_workers=unmapped(spice_options.compress_max_workers),
     )
 
-    logger.info(f"Compressed {len(compressed_cubes)} cubes")
     written_paths = compressed_cubes.result()
+    logger.info(f"Compressed {len(written_paths)} cubes")
 
     if spice_field_options.sbid_copy_path:
         task_archive_sbid.submit(

--- a/flint/prefect/flows/spice_compression_pipeline.py
+++ b/flint/prefect/flows/spice_compression_pipeline.py
@@ -1,0 +1,186 @@
+"""Standalone SPICE-style cube compression pipeline: trim already-imaged
+Stokes cubes down to small boxes around catalogued sources, crop to their
+union, and compress. See ``flint.spice``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from astropy.io import fits
+from capn_crunch import add_options_to_parser, create_options_from_parser
+from configargparse import ArgumentParser
+from prefect import flow, unmapped
+from radio_beam import Beam
+
+from flint.configuration import get_options_from_strategy, load_and_copy_strategy
+from flint.convol import BeamShape
+from flint.logging import logger
+from flint.naming import get_sbid_from_path
+from flint.options import SpiceFieldOptions, SpiceOptions
+from flint.prefect.caching import task
+from flint.prefect.clusters import get_dask_runner
+from flint.prefect.common.spice import (
+    task_compress_cube,
+    task_get_spice_boxes,
+    task_spice_fits,
+)
+from flint.prefect.common.utils import task_archive_sbid, task_getattr
+from flint.source_finding.aegean import run_bane_and_aegean
+from flint.spice import any_box_overlaps
+
+task_run_bane_and_aegean = task(run_bane_and_aegean)
+
+
+@flow(name="Flint SPICE Compression Pipeline")
+def process_spice_compression(spice_field_options: SpiceFieldOptions) -> list[Path]:
+    if not spice_field_options.cubes:
+        raise ValueError(
+            "``cubes`` is required. The racs-all flow sets it from the polarisation stage."
+        )
+
+    strategy = load_and_copy_strategy(
+        output_split_science_path=spice_field_options.cubes[0].parent,
+        imaging_strategy=spice_field_options.imaging_strategy,
+    )
+
+    is_user_catalogue = spice_field_options.catalogue is not None
+    if is_user_catalogue:
+        catalogue_path = spice_field_options.catalogue
+        reference_image = spice_field_options.cubes[0]
+    else:
+        assert spice_field_options.reference_image is not None, (
+            "reference_image is required when no catalogue is supplied "
+            "(built-in aegean source finding)"
+        )
+        assert spice_field_options.aegean_container is not None, (
+            "aegean_container is required when no catalogue is supplied"
+        )
+        reference_image = spice_field_options.reference_image
+        aegean_outputs = task_run_bane_and_aegean.submit(
+            image=reference_image,
+            aegean_container=spice_field_options.aegean_container,
+            update_bane_options=get_options_from_strategy(
+                strategy=strategy, operation="polarisation", mode="bane"
+            ),
+            update_aegean_options=get_options_from_strategy(
+                strategy=strategy, operation="polarisation", mode="aegean"
+            ),
+        )
+        catalogue_path = task_getattr.submit(aegean_outputs, "comp")
+
+    spice_options = SpiceOptions(
+        **get_options_from_strategy(
+            strategy=strategy, operation="polarisation", mode="spice"
+        )
+    )
+
+    beam_shape = BeamShape.from_radio_beam(
+        Beam.from_fits_header(fits.getheader(reference_image))
+    )
+
+    island_sky_boxes = task_get_spice_boxes.submit(
+        reference_image=reference_image,
+        catalogue=catalogue_path,
+        spice_options=spice_options,
+        beam_shape=beam_shape,
+        is_user_catalogue=is_user_catalogue,
+    )
+
+    resolved_sky_boxes = island_sky_boxes.result()
+    overlapping = [
+        cube
+        for cube in spice_field_options.cubes
+        if any_box_overlaps(fits_path=cube, sky_boxes=resolved_sky_boxes)
+    ]
+    if not overlapping:
+        raise ValueError(
+            f"No island overlaps any of the {len(spice_field_options.cubes)} supplied "
+            "cubes. Check the catalogue and reference image match the field."
+        )
+    if len(overlapping) != len(spice_field_options.cubes):
+        logger.warning(
+            f"{len(spice_field_options.cubes) - len(overlapping)} cube(s) have no "
+            "islands and will be compressed without spicing"
+        )
+
+    spiced_cubes = task_spice_fits.map(
+        fits_path=spice_field_options.cubes,
+        sky_boxes=unmapped(resolved_sky_boxes),
+        output_path=unmapped(spice_field_options.output_path),
+    )
+
+    compressed_cubes = task_compress_cube.map(
+        out_cube=spiced_cubes,
+        method=unmapped(spice_options.compress_method),
+        max_workers=unmapped(spice_options.compress_max_workers),
+    )
+
+    logger.info(f"Compressed {len(compressed_cubes)} cubes")
+    written_paths = compressed_cubes.result()
+
+    if spice_field_options.sbid_copy_path:
+        task_archive_sbid.submit(
+            science_folder_path=spice_field_options.output_path
+            or spice_field_options.cubes[0].parent,
+            copy_path=spice_field_options.sbid_copy_path,
+        ).result()
+
+    return written_paths
+
+
+def setup_run_spice_compression(
+    cluster_config: str | Path, spice_field_options: SpiceFieldOptions
+) -> None:
+    if spice_field_options.sbid_copy_path and spice_field_options.cubes:
+        science_sbid = get_sbid_from_path(path=spice_field_options.cubes[0])
+        spice_field_options = spice_field_options.with_options(
+            sbid_copy_path=spice_field_options.sbid_copy_path / f"{science_sbid}"
+        )
+
+    dask_task_runner = get_dask_runner(cluster=cluster_config)
+
+    process_spice_compression.with_options(task_runner=dask_task_runner)(
+        spice_field_options=spice_field_options
+    )
+
+
+def get_parser() -> ArgumentParser:
+    parser = ArgumentParser(description=__doc__)
+
+    parser.add_argument(
+        "--cli-config", is_config_file=True, help="Path to configuration file"
+    )
+    parser.add_argument(
+        "--cluster-config",
+        type=str,
+        default="petrichor",
+        help="Path to a cluster configuration file, or a known cluster name. ",
+    )
+
+    parser = add_options_to_parser(
+        parser=parser,
+        options_class=SpiceFieldOptions,
+        description="SPICE compression processing options",
+    )
+
+    return parser
+
+
+def cli() -> None:
+    parser = get_parser()
+
+    args = parser.parse_args()
+
+    spice_field_options = create_options_from_parser(
+        parser_namespace=args, options_class=SpiceFieldOptions
+    )
+
+    setup_run_spice_compression(
+        cluster_config=args.cluster_config,
+        spice_field_options=spice_field_options,
+    )
+
+
+if __name__ == "__main__":
+    cli()

--- a/flint/prefect/flows/spice_compression_pipeline.py
+++ b/flint/prefect/flows/spice_compression_pipeline.py
@@ -8,14 +8,12 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from astropy.io import fits
 from capn_crunch import add_options_to_parser, create_options_from_parser
 from configargparse import ArgumentParser
 from prefect import flow, unmapped
-from radio_beam import Beam
 
 from flint.configuration import get_options_from_strategy, load_and_copy_strategy
-from flint.convol import BeamShape
+from flint.convol import BeamShape, common_beam_from_cubes
 from flint.logging import logger
 from flint.naming import get_sbid_from_path
 from flint.options import SpiceFieldOptions, SpiceOptions
@@ -79,10 +77,12 @@ def process_spice_compression(spice_field_options: SpiceFieldOptions) -> list[Pa
         )
     )
 
-    logger.info(f"Getting Beam information from {reference_image=}")
+    # Sized on the coarsest resolution among the cubes being trimmed, not on the
+    # finer reference image, so a box holds its island in every one of them
     beam_shape = BeamShape.from_radio_beam(
-        Beam.from_fits_header(fits.getheader(reference_image))
+        common_beam_from_cubes(cube_paths=spice_field_options.cubes)
     )
+    logger.info(f"Sizing the island boxes on {beam_shape=}")
 
     island_sky_boxes = task_get_spice_boxes.submit(
         reference_image=reference_image,

--- a/flint/prefect/flows/spice_compression_pipeline.py
+++ b/flint/prefect/flows/spice_compression_pipeline.py
@@ -13,7 +13,7 @@ from configargparse import ArgumentParser
 from prefect import flow, unmapped
 
 from flint.configuration import get_options_from_strategy, load_and_copy_strategy
-from flint.convol import BeamShape, common_beam_from_cubes
+from flint.convol import common_beam_shape_from_cubes
 from flint.logging import logger
 from flint.naming import get_sbid_from_path
 from flint.options import SpiceFieldOptions, SpiceOptions
@@ -79,9 +79,9 @@ def process_spice_compression(spice_field_options: SpiceFieldOptions) -> list[Pa
 
     # Sized on the coarsest resolution among the cubes being trimmed, not on the
     # finer reference image, so a box holds its island in every one of them
-    beam_shape = BeamShape.from_radio_beam(
-        common_beam_from_cubes(cube_paths=spice_field_options.cubes)
-    )
+    # Raises when no cube carries a usable beam, as there is then no island box
+    # to size
+    beam_shape = common_beam_shape_from_cubes(cube_paths=spice_field_options.cubes)
     logger.info(f"Sizing the island boxes on {beam_shape=}")
 
     island_sky_boxes = task_get_spice_boxes.submit(

--- a/flint/prefect/flows/spice_compression_pipeline.py
+++ b/flint/prefect/flows/spice_compression_pipeline.py
@@ -57,6 +57,7 @@ def process_spice_compression(spice_field_options: SpiceFieldOptions) -> list[Pa
             "aegean_container is required when no catalogue is supplied"
         )
         reference_image = spice_field_options.reference_image
+        logger.info(f"Running source finder against {reference_image=}")
         aegean_outputs = task_run_bane_and_aegean.submit(
             image=reference_image,
             aegean_container=spice_field_options.aegean_container,
@@ -75,6 +76,7 @@ def process_spice_compression(spice_field_options: SpiceFieldOptions) -> list[Pa
         )
     )
 
+    logger.info(f"Getting Beam information from {reference_image=}")
     beam_shape = BeamShape.from_radio_beam(
         Beam.from_fits_header(fits.getheader(reference_image))
     )

--- a/flint/prefect/flows/subtract_cube_pipeline.py
+++ b/flint/prefect/flows/subtract_cube_pipeline.py
@@ -251,6 +251,7 @@ def task_combine_all_linmos_images(
         time_domain_mode=time_domain,
         bounding_box=fits_cube_options.bounding_box,
         invalidate_zeros=fits_cube_options.invalidate_zeros,
+        create_blanks=fits_cube_options.create_blanks,
     )
 
     if fits_cube_options.remove_original_images:

--- a/flint/rmsynth.py
+++ b/flint/rmsynth.py
@@ -98,7 +98,13 @@ def run_rmsynth_3d(
         RMSynth3DResults: Lazy dirty FDF cube, the RMSF spectrum every pixel
         shares, and associated parameters
     """
-    _check_cubes_memmappable(stokes_q_cube, stokes_u_cube, stokes_i_cube,stokes_q_weight_cube, stokes_u_weight_cube)
+    _check_cubes_memmappable(
+        stokes_q_cube,
+        stokes_u_cube,
+        stokes_i_cube,
+        stokes_q_weight_cube,
+        stokes_u_weight_cube,
+    )
     stokes_i_kwargs = (
         {
             "stokes_i_file": stokes_i_cube,

--- a/flint/rmsynth.py
+++ b/flint/rmsynth.py
@@ -10,9 +10,10 @@ import time
 from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Literal, TypeAlias
 
 import dask
+import dask.array as da
 import numpy as np
 import zarr
 from astropy.io import fits
@@ -46,7 +47,8 @@ from flint.exceptions import NotSupportedError
 from flint.logging import logger
 from flint.options import RMCleanOptions, RMSynthOptions
 
-FDFLabel = Literal["dirty", "clean", "model"]
+FDFLabel: TypeAlias = Literal["dirty", "clean", "model"]
+FDFThreshold: TypeAlias = float | np.ndarray | da.Array | None
 _MOMENT_NAMES = ("mom0", "mom1", "mom2")
 
 # The FDF peak statistics, as {FaradayPeaks field: (file suffix, BUNIT, comment)}.
@@ -411,10 +413,27 @@ def write_stokes_i_coeff_maps_to_fits(
     return output_paths
 
 
+def _snr_threshold(snr: float, fdf_error_noise: FDFThreshold) -> FDFThreshold:
+    """An FDF amplitude cut ``snr`` times the theoretical noise, or None for no cut.
+
+    Zero means no cut, and has to short-circuit rather than multiply through:
+    the theoretical noise is ``inf`` wherever a pixel carries no weight at all
+    (linmos blanks the mosaic edge), and ``0 * inf`` is NaN, which blanks every
+    comparison against it instead of passing everything.
+
+    The noise is a scalar for per-channel weights and a lazy (ny, nx) map for
+    the per-pixel ones the linmos cubes give, so the cut comes back in whichever
+    form it arrived in.
+    """
+    if snr == 0 or fdf_error_noise is None:
+        return None
+    return snr * fdf_error_noise
+
+
 def _lazy_faraday_moments(
     fdf_cube: dask.array.Array,
     synth_results: RMSynth3DResults,
-    threshold: float | None,
+    threshold: FDFThreshold,
     debias: bool = False,
     debias_filter_size: int = 5,
 ) -> FaradayMoments:
@@ -735,9 +754,9 @@ def write_rm_products(
     # (mom1/mom2 are then weighted by that noise and mean nothing). rm-lite
     # applies this same cut inside RM-CLEAN to its own moment maps, which flint
     # does not use, so it is rederived here from the shared theoretical noise.
-    moment_threshold = (
-        rmclean_options.moment_threshold_snr
-        * synth_results.theoretical_noise.fdf_error_noise
+    moment_threshold = _snr_threshold(
+        rmclean_options.moment_threshold_snr,
+        synth_results.theoretical_noise.fdf_error_noise,
     )
     for label in moment_products:
         moments = _lazy_faraday_moments(
@@ -766,7 +785,16 @@ def write_rm_products(
     # rm-lite returns peaks of its own on RMClean3DResults, but only for the
     # clean FDF and only under its own threshold. Deriving them here is what
     # lets any requested FDF have them -- the dirty one included, which needs no
-    # RM-CLEAN at all -- under the same cut flint gives its moments.
+    # RM-CLEAN at all -- under a cut flint chooses.
+    #
+    # A separate cut from the moments, and off by default. The moment cut exists
+    # because mom0 integrates the whole Faraday depth axis; a peak is one sample
+    # and has no such floor, so blanking it discards a real measurement whose
+    # error (peak_pi_error) is written beside it.
+    peak_threshold = _snr_threshold(
+        rmclean_options.peak_threshold_snr,
+        synth_results.theoretical_noise.fdf_error_noise,
+    )
     for label in peak_products:
         peaks = calc_faraday_peaks(
             fdf_sources[label],
@@ -775,7 +803,7 @@ def write_rm_products(
             fdf_error=synth_results.theoretical_noise.fdf_error_noise,
             lam_sq_0_m2=synth_results.lam_sq_0_m2,
             lambda_sq_arr_m2=synth_results.lambda_sq_arr_m2,
-            threshold=moment_threshold,
+            threshold=peak_threshold,
         )
         for field in _PEAK_MAPS:
             compute_targets[f"peak.{label}.{field}"] = getattr(peaks, field).astype(

--- a/flint/rmsynth.py
+++ b/flint/rmsynth.py
@@ -6,6 +6,9 @@ from __future__ import annotations
 
 import logging
 import os
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Literal
 
@@ -14,7 +17,7 @@ import numpy as np
 import zarr
 from astropy.io import fits
 from astropy.wcs import WCS
-from dask.distributed import Client
+from dask.distributed import Client, as_completed, get_worker, rejoin, secede
 
 # finufft's PyPI wheel vendors its own libomp.dylib (macOS) rather than
 # linking the environment's shared one; having both loaded aborts the
@@ -412,6 +415,138 @@ def _lazy_faraday_moments(
     )
 
 
+def _elapsed(start: float) -> str:
+    """Wall time since ``start``, as a compact human-readable string."""
+    seconds = time.time() - start
+    if seconds < 60:
+        return f"{seconds:.1f}s"
+    minutes, seconds = divmod(int(seconds), 60)
+    hours, minutes = divmod(minutes, 60)
+    return f"{hours}h{minutes:02d}m" if hours else f"{minutes}m{seconds:02d}s"
+
+
+def _describe_rm_workload(
+    synth_results: RMSynth3DResults, compute_keys: list[str]
+) -> str:
+    """One line saying what the coming compute is actually going to chew through.
+
+    Everything here is known before any of it runs, and none of it is otherwise
+    reported: the FDF's shape, how many spatial chunks it is cut into, and
+    whether rm-lite decided every pixel needs its own RMSF (roughly doubling the
+    footprint, and not something flint asked for -- see
+    ``RMSynthOptions.per_pixel_rmsf``).
+    """
+    fdf_cube = synth_results.fdf_dirty_cube
+    n_phi, n_y, n_x = fdf_cube.shape
+    n_chunks = int(np.prod([len(chunk) for chunk in fdf_cube.chunks]))
+    per_pixel_rmsf = synth_results.rmsf_cube is not None
+    return (
+        f"{len(compute_keys)} products over {n_y}x{n_x} pixels and {n_phi} "
+        f"Faraday depths, in {n_chunks} chunks; "
+        f"per-pixel RMSF {'on' if per_pixel_rmsf else 'off'}"
+    )
+
+
+@contextmanager
+def _seceded_if_on_a_worker() -> Iterator[None]:
+    """Give this worker's compute slot back for the duration of a blocking wait.
+
+    ``task_write_rm_products`` is a prefect task, so under ``DaskTaskRunner`` it
+    runs *on a worker*, and ``prefect_dask.get_dask_client`` hands back a plain
+    ``Client`` rather than a ``worker_client`` -- it does not secede. Waiting on
+    futures from there holds the worker's thread while the tasks being waited on
+    need worker threads to run, and with one thread per worker that deadlocks the
+    cluster outright.
+
+    ``dask.compute(scheduler=client)`` never showed this because ``Client.get``
+    secedes for you when it is called inside a worker. Draining the futures by
+    hand is what makes it ours to do.
+
+    A no-op off a worker, which is the local-scheduler and standalone case.
+    """
+    try:
+        get_worker()
+    except ValueError:
+        # Not on a worker, so there is no slot to give back
+        yield
+        return
+
+    secede()
+    try:
+        yield
+    finally:
+        rejoin()
+
+
+def _compute_rm_products(
+    compute_targets: dict[str, Any],
+    fuse_config: dict[str, Any],
+    scheduler: Client | str,
+    workload: str,
+) -> dict[str, Any]:
+    """Compute every product in one shared pass, reporting each as it lands.
+
+    The whole RM-synthesis stage is one ``compute`` over a lazy graph, so
+    without this it is a single silent wait -- hours on a mosaic, with no way to
+    tell a slow run from a stuck one. Submitting the targets together (rather
+    than one compute per product) is what keeps the synthesis and RM-CLEAN graph
+    shared, so it still runs once no matter how many products are asked for --
+    getting that wrong is invisible in the output and simply multiplies the
+    runtime, so ``test_rmclean_runs_once_per_chunk_on_a_distributed_client``
+    holds it for this path.
+
+    Progress needs a distributed ``Client`` to report against futures. The local
+    schedulers take the plain ``dask.compute`` path and are logged start-to-end
+    only -- that is the unit tests and standalone use, not a pipeline run.
+
+    Args:
+        compute_targets (dict[str, Any]): Lazy arrays/delayed writes, keyed by product name
+        fuse_config (dict[str, Any]): Dask fusion settings the submission must be made under
+        scheduler (Client | str): A distributed Client, or a local scheduler name
+        workload (str): Description of the work, logged up front. See ``_describe_rm_workload``
+
+    Returns:
+        dict[str, Any]: The computed value for each key in ``compute_targets``
+    """
+    compute_keys = list(compute_targets.keys())
+    start = time.time()
+
+    if not isinstance(scheduler, Client):
+        logger.info(f"Computing RM products ({workload}), scheduler={scheduler!r}")
+        with dask.config.set(fuse_config):
+            computed_values = dask.compute(
+                *(compute_targets[key] for key in compute_keys), scheduler=scheduler
+            )
+        logger.info(f"Computed {len(compute_keys)} RM products in {_elapsed(start)}")
+        return dict(zip(compute_keys, computed_values))
+
+    logger.info(f"Computing RM products ({workload})")
+    with dask.config.set(fuse_config):
+        # One submission for the whole batch: `client.compute` on a list keeps
+        # the shared graph, where a compute per product would rebuild it each time
+        futures = scheduler.compute(
+            [compute_targets[key] for key in compute_keys], sync=False
+        )
+    future_to_key = dict(zip(futures, compute_keys))
+
+    computed: dict[str, Any] = {}
+    with _seceded_if_on_a_worker():
+        for future in as_completed(futures):
+            key = future_to_key[future]
+            # `.result()` re-raises whatever the worker raised, so a failed
+            # product still surfaces here rather than being dropped
+            computed[key] = future.result()
+            # Elapsed since submission, not this product's own runtime: they
+            # share one graph, so "how far into the run are we" is the
+            # answerable question
+            logger.info(
+                f"[{len(computed):>2}/{len(compute_keys)}] {key} at {_elapsed(start)}"
+            )
+
+    logger.info(f"Computed {len(compute_keys)} RM products in {_elapsed(start)}")
+    return computed
+
+
 def write_rm_products(
     synth_results: RMSynth3DResults,
     clean_results: RMClean3DResults | None,
@@ -584,16 +719,13 @@ def write_rm_products(
         if dask_client is not None
         else ("processes" if run_clean else "threads")
     )
-    compute_keys = list(compute_targets.keys())
-    with dask.config.set(fuse_config):
-        computed_values = dask.compute(
-            *(compute_targets[key] for key in compute_keys), scheduler=scheduler
-        )
-    computed = dict(
-        zip(
-            compute_keys,
-            computed_values,
-        )
+    computed = _compute_rm_products(
+        compute_targets=compute_targets,
+        fuse_config=fuse_config,
+        scheduler=scheduler,
+        workload=_describe_rm_workload(
+            synth_results=synth_results, compute_keys=list(compute_targets)
+        ),
     )
 
     reference_header = fits.getheader(stokes_q_cube)

--- a/flint/rmsynth.py
+++ b/flint/rmsynth.py
@@ -1,0 +1,258 @@
+"""RM-synthesis and RM-CLEAN of Stokes Q/U cubes using the external
+``rm-lite`` package (an optional dependency, see the ``rmsynth`` extra).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Literal
+
+import dask
+import numpy as np
+from astropy.io import fits
+from astropy.wcs import WCS
+from rm_lite.tools_3d.rmclean import RMClean3DResults, run_rmclean_from_synth
+from rm_lite.tools_3d.rmsynth import RMSynth3DResults, rmsynth_3d_from_fits
+from rm_lite.utils.synthesis import calc_faraday_moments
+
+from flint.logging import logger
+from flint.naming import create_image_cube_name
+from flint.options import RMCleanOptions, RMSynthOptions
+
+FDFLabel = Literal["dirty", "clean", "model"]
+
+
+def run_rmsynth_3d(
+    stokes_q_cube: Path,
+    stokes_u_cube: Path,
+    rmsynth_options: RMSynthOptions,
+    stokes_i_cube: Path | None = None,
+) -> RMSynth3DResults:
+    """Run 3D RM-synthesis on Stokes Q/U FITS cubes.
+
+    Args:
+        stokes_q_cube (Path): Path to the Stokes Q FITS cube
+        stokes_u_cube (Path): Path to the Stokes U FITS cube
+        rmsynth_options (RMSynthOptions): Options controlling the synthesis
+        stokes_i_cube (Path | None, optional): Path to a Stokes I FITS cube, used to fit a per-pixel fractional-polarisation correction. FDF stays in Q/U flux if not given. Defaults to None.
+
+    Returns:
+        RMSynth3DResults: Lazy dirty FDF cube, RMSF cube, and associated parameters
+    """
+    stokes_i_kwargs = (
+        {
+            "stokes_i_file": stokes_i_cube,
+            "fit_order": rmsynth_options.fit_order,
+            "fit_function": rmsynth_options.fit_function,
+            "stokes_i_snr_cut": rmsynth_options.stokes_i_snr_cut,
+            "estimate_stokes_i_noise": rmsynth_options.estimate_stokes_i_noise,
+        }
+        if stokes_i_cube is not None
+        else {}
+    )
+    return rmsynth_3d_from_fits(
+        stokes_q_file=stokes_q_cube,
+        stokes_u_file=stokes_u_cube,
+        phi_max_radm2=rmsynth_options.phi_max_radm2,
+        d_phi_radm2=rmsynth_options.d_phi_radm2,
+        n_samples=rmsynth_options.n_samples,
+        weight_type=rmsynth_options.weight_type,
+        robust=rmsynth_options.robust,
+        nufft_nthreads=rmsynth_options.nufft_nthreads,
+        target_chunk_mb=rmsynth_options.target_chunk_mb,
+        **stokes_i_kwargs,
+    )
+
+
+def run_rmclean_3d(
+    rm_synth_results: RMSynth3DResults, rmclean_options: RMCleanOptions
+) -> RMClean3DResults:
+    """Run 3D RM-CLEAN on the results of ``run_rmsynth_3d``.
+
+    Args:
+        rm_synth_results (RMSynth3DResults): Results from ``run_rmsynth_3d``
+        rmclean_options (RMCleanOptions): Options controlling RM-CLEAN
+
+    Returns:
+        RMClean3DResults: Lazy clean/model/residual FDF cubes and moment maps
+    """
+    return run_rmclean_from_synth(
+        rm_synth_3d_results=rm_synth_results,
+        auto_mask=rmclean_options.auto_mask,
+        auto_threshold=rmclean_options.auto_threshold,
+        max_iter=rmclean_options.max_iter,
+        gain=rmclean_options.gain,
+        moment_threshold_snr=rmclean_options.moment_threshold_snr,
+        multiscale=rmclean_options.multiscale,
+    )
+
+
+def _phi_header(reference_header: fits.Header, phi_arr_radm2: np.ndarray) -> fits.Header:
+    """Build a FDF cube header: the reference header's spatial WCS with the
+    spectral axis replaced by a linear Faraday-depth axis."""
+    header = WCS(reference_header).celestial.to_header()
+    header["NAXIS"] = 3
+    header["CTYPE3"] = "FDEPTH"
+    header["CUNIT3"] = "rad/m2"
+    header["CRPIX3"] = 1
+    header["CRVAL3"] = float(phi_arr_radm2[0])
+    header["CDELT3"] = float(phi_arr_radm2[1] - phi_arr_radm2[0])
+    return header
+
+
+def write_fdf_cube_to_fits(
+    fdf_cube: np.ndarray,
+    phi_arr_radm2: np.ndarray,
+    reference_header: fits.Header,
+    output_path: Path,
+) -> Path:
+    """Write a (already computed) FDF cube to FITS as amplitude, matching the
+    RM-Tools ``_FDFdirty.fits``/``_FDFclean.fits`` convention. Phase is dropped.
+
+    Args:
+        fdf_cube (np.ndarray): Complex FDF cube, shape (n_phi, ny, nx)
+        phi_arr_radm2 (np.ndarray): Faraday depth values, rad/m^2
+        reference_header (fits.Header): Header to derive the spatial WCS from (e.g. the Stokes Q cube header)
+        output_path (Path): Output FITS path
+
+    Returns:
+        Path: ``output_path``
+    """
+    header = _phi_header(reference_header=reference_header, phi_arr_radm2=phi_arr_radm2)
+    fits.writeto(output_path, np.abs(fdf_cube).astype(np.float32), header, overwrite=True)
+    return output_path
+
+
+def write_moment_maps_to_fits(
+    fdf_cube: np.ndarray,
+    phi_arr_radm2: np.ndarray,
+    fwhm_rmsf_radm2: float,
+    reference_header: fits.Header,
+    output_prefix: Path,
+    label: FDFLabel,
+    threshold: float | None = None,
+) -> list[Path]:
+    """Compute and write the mom0/mom1/mom2 Faraday moment maps of an FDF cube.
+
+    Args:
+        fdf_cube (np.ndarray): Complex FDF cube, shape (n_phi, ny, nx)
+        phi_arr_radm2 (np.ndarray): Faraday depth values, rad/m^2
+        fwhm_rmsf_radm2 (float): RMSF FWHM, rad/m^2
+        reference_header (fits.Header): Header to derive the spatial WCS from (e.g. the Stokes Q cube header)
+        output_prefix (Path): Common prefix for the output files
+        label (FDFLabel): Which FDF ``fdf_cube`` is ('dirty', 'clean', or 'model'), used to name the outputs
+        threshold (float | None, optional): Amplitude cut applied before computing the moments. Defaults to None.
+
+    Returns:
+        list[Path]: The three written moment-map paths (mom0, mom1, mom2)
+    """
+    moments = calc_faraday_moments(
+        fdf_cube,
+        phi_arr_radm2=phi_arr_radm2,
+        fwhm_rmsf_radm2=fwhm_rmsf_radm2,
+        threshold=threshold,
+    )
+    header = WCS(reference_header).celestial.to_header()
+    output_paths = []
+    for moment_name, moment_map in zip(
+        ("mom0", "mom1", "mom2"), (moments.mom0, moments.mom1, moments.mom2)
+    ):
+        output_path = Path(f"{output_prefix}.fdf.{label}.{moment_name}.fits")
+        fits.writeto(output_path, np.asarray(moment_map, dtype=np.float32), header, overwrite=True)
+        output_paths.append(output_path)
+    return output_paths
+
+
+def rmsynth_and_write_products(
+    stokes_q_cube: Path,
+    stokes_u_cube: Path,
+    rmsynth_options: RMSynthOptions,
+    rmclean_options: RMCleanOptions,
+    cube_products: list[FDFLabel],
+    moment_products: list[FDFLabel],
+    output_prefix: Path,
+    stokes_i_cube: Path | None = None,
+) -> list[Path]:
+    """Run RM-synthesis (and RM-CLEAN if needed) and write the requested output products.
+
+    Args:
+        stokes_q_cube (Path): Path to the Stokes Q FITS cube
+        stokes_u_cube (Path): Path to the Stokes U FITS cube
+        rmsynth_options (RMSynthOptions): Options controlling RM-synthesis
+        rmclean_options (RMCleanOptions): Options controlling RM-CLEAN
+        cube_products (list[FDFLabel]): Which FDF cube(s) to write ('dirty', 'clean', 'model')
+        moment_products (list[FDFLabel]): Which FDF(s) to compute Faraday moment maps from
+        output_prefix (Path): Common prefix for the output files
+        stokes_i_cube (Path | None, optional): Path to a Stokes I FITS cube for the fractional-polarisation correction. Defaults to None.
+
+    Returns:
+        list[Path]: Every FITS path written
+    """
+    if not cube_products and not moment_products:
+        logger.info("No RM-synthesis products requested, skipping.")
+        return []
+
+    synth_results = run_rmsynth_3d(
+        stokes_q_cube=stokes_q_cube,
+        stokes_u_cube=stokes_u_cube,
+        rmsynth_options=rmsynth_options,
+        stokes_i_cube=stokes_i_cube,
+    )
+
+    run_clean = any(label in ("clean", "model") for label in (*cube_products, *moment_products))
+    clean_results = (
+        run_rmclean_3d(rm_synth_results=synth_results, rmclean_options=rmclean_options)
+        if run_clean
+        else None
+    )
+
+    fdf_sources = {"dirty": synth_results.fdf_dirty_cube}
+    if clean_results is not None:
+        fdf_sources["clean"] = clean_results.clean_fdf_cube
+        fdf_sources["model"] = clean_results.model_fdf_cube
+
+    # Batch every lazy array needed by the requested products into a single
+    # dask.compute call: computing per-product in a loop would redo the shared
+    # synthesis/RM-CLEAN graph once per product instead of once total.
+    needed_labels = {*cube_products, *moment_products}
+    computed = dict(
+        zip(needed_labels, dask.compute(*(fdf_sources[label] for label in needed_labels)))
+    )
+
+    reference_header = fits.getheader(stokes_q_cube)
+    clean_moment_threshold = (
+        rmclean_options.moment_threshold_snr * synth_results.theoretical_noise.fdf_error_noise
+    )
+    moment_thresholds: dict[FDFLabel, float | None] = {
+        "dirty": None,
+        "clean": clean_moment_threshold,
+        "model": clean_moment_threshold,
+    }
+
+    output_paths: list[Path] = []
+    for label in cube_products:
+        output_path = create_image_cube_name(
+            image_prefix=output_prefix, mode="fdf", suffix=label
+        )
+        output_paths.append(
+            write_fdf_cube_to_fits(
+                fdf_cube=computed[label],
+                phi_arr_radm2=synth_results.phi_arr_radm2,
+                reference_header=reference_header,
+                output_path=output_path,
+            )
+        )
+    for label in moment_products:
+        output_paths.extend(
+            write_moment_maps_to_fits(
+                fdf_cube=computed[label],
+                phi_arr_radm2=synth_results.phi_arr_radm2,
+                fwhm_rmsf_radm2=synth_results.fwhm_rmsf_radm2,
+                reference_header=reference_header,
+                output_prefix=output_prefix,
+                label=label,
+                threshold=moment_thresholds[label],
+            )
+        )
+
+    return output_paths

--- a/flint/rmsynth.py
+++ b/flint/rmsynth.py
@@ -45,7 +45,13 @@ from rm_lite.utils.synthesis import (  # noqa: E402
 
 from flint.exceptions import NotSupportedError
 from flint.logging import logger
-from flint.options import RMCleanOptions, RMSynthOptions
+from flint.options import (
+    CubesForRMSynth,
+    ErrorCubesForRMSynth,
+    RMCleanOptions,
+    RMSynthOptions,
+    WeightCubesForRMSynth,
+)
 
 FDFLabel: TypeAlias = Literal["dirty", "clean", "model"]
 FDFThreshold: TypeAlias = float | np.ndarray | da.Array | None
@@ -104,24 +110,16 @@ def _check_cubes_memmappable(*cubes: Path | None) -> None:
 
 
 def run_rmsynth_3d(
-    stokes_q_cube: Path,
-    stokes_u_cube: Path,
+    stokes_cubes: CubesForRMSynth,
     rmsynth_options: RMSynthOptions,
-    stokes_i_cube: Path | None = None,
-    stokes_q_weight_cube: Path | None = None,
-    stokes_u_weight_cube: Path | None = None,
-    stokes_i_weight_cube: Path | None = None,
+    error_cubes: ErrorCubesForRMSynth | None = None,
 ) -> RMSynth3DResults:
     """Run 3D RM-synthesis on Stokes Q/U FITS cubes.
 
     Args:
-        stokes_q_cube (Path): Path to the Stokes Q FITS cube
-        stokes_u_cube (Path): Path to the Stokes U FITS cube
+        stokes_cubes (CubesForRMSynth): The Stokes Q/U cubes, and optionally I to fit a per-pixel fractional-polarisation correction against
         rmsynth_options (RMSynthOptions): Options controlling the synthesis
-        stokes_i_cube (Path | None, optional): Path to a Stokes I FITS cube, used to fit a per-pixel fractional-polarisation correction. FDF stays in Q/U flux if not given. Defaults to None.
-        stokes_q_weight_cube (Path | None, optional): Path to the linmos Stokes Q weight cube, giving each pixel its own channel weights rather than one spectrum estimated from the Q/U cubes. rm-lite requires both Q and U, or neither. Defaults to None.
-        stokes_u_weight_cube (Path | None, optional): Path to the linmos Stokes U weight cube. See ``stokes_q_weight_cube``. Defaults to None.
-        stokes_i_weight_cube (Path | None, optional): Path to the linmos Stokes I weight cube, used to weight the per-pixel Stokes I fit and to score it against ``stokes_i_snr_cut``. Falls back to ``RMSynthOptions.estimate_stokes_i_noise`` if not given. Defaults to None.
+        error_cubes (ErrorCubesForRMSynth | None, optional): Either the linmos weight cubes (an inverse variance) or a set of noise cubes (a sigma), which the type says which of. None leaves rm-lite to estimate a per-channel noise from Q/U itself. Defaults to None.
 
     Returns:
         RMSynth3DResults: Lazy dirty FDF cube, the RMSF, and associated
@@ -130,37 +128,33 @@ def run_rmsynth_3d(
         itself; see ``RMSynthOptions.per_pixel_rmsf`` for what that costs
     """
     _check_cubes_memmappable(
-        stokes_q_cube,
-        stokes_u_cube,
-        stokes_i_cube,
-        stokes_q_weight_cube,
-        stokes_u_weight_cube,
-        stokes_i_weight_cube,
+        *stokes_cubes.paths, *(error_cubes.paths if error_cubes else ())
     )
     stokes_i_kwargs = (
         {
-            "stokes_i_file": stokes_i_cube,
-            "stokes_i_error_file": stokes_i_weight_cube,
+            "stokes_i_file": stokes_cubes.i_path,
+            "stokes_i_error_file": error_cubes.i_path if error_cubes else None,
             "fit_order": rmsynth_options.fit_order,
             "fit_function": rmsynth_options.fit_function,
             "stokes_i_snr_cut": rmsynth_options.stokes_i_snr_cut,
-            # Only consulted when no Stokes I weight cube is given: rm-lite
+            # Only consulted when no Stokes I error cube is given: rm-lite
             # refuses a stokes_i_snr_cut it has no error to measure against.
             "estimate_stokes_i_noise": rmsynth_options.estimate_stokes_i_noise,
             "compute_model_error": rmsynth_options.compute_model_error,
             "n_error_samples": rmsynth_options.n_error_samples,
         }
-        if stokes_i_cube is not None
+        if stokes_cubes.i_path is not None
         else {}
     )
     return rmsynth_3d_from_fits(
-        stokes_q_file=stokes_q_cube,
-        stokes_u_file=stokes_u_cube,
-        stokes_q_error_file=stokes_q_weight_cube,
-        stokes_u_error_file=stokes_u_weight_cube,
+        stokes_q_file=stokes_cubes.q_path,
+        stokes_u_file=stokes_cubes.u_path,
+        stokes_q_error_file=error_cubes.q_path if error_cubes else None,
+        stokes_u_error_file=error_cubes.u_path if error_cubes else None,
         # linmos writes 1/sigma**2 directly, so rm-lite must not invert and
-        # square these again. Applies to the Stokes I error cube as well
-        noise_files_are_weight=True,
+        # square those. A noise cube is a sigma and must be inverted. Applies to
+        # the Stokes I error cube as well
+        noise_files_are_weight=isinstance(error_cubes, WeightCubesForRMSynth),
         phi_max_radm2=rmsynth_options.phi_max_radm2,
         d_phi_radm2=rmsynth_options.d_phi_radm2,
         n_samples=rmsynth_options.n_samples,
@@ -193,7 +187,8 @@ def run_rmclean_3d(
         auto_threshold=rmclean_options.auto_threshold,
         max_iter=rmclean_options.max_iter,
         gain=rmclean_options.gain,
-        moment_threshold_snr=rmclean_options.moment_threshold_snr,
+        # rm-lite's own moment and peak maps go unused, so its cut is left at
+        # whatever it defaults to; flint derives its own in write_rm_products
         log_level=logging.INFO,
     )
 
@@ -416,14 +411,9 @@ def write_stokes_i_coeff_maps_to_fits(
 def _snr_threshold(snr: float, fdf_error_noise: FDFThreshold) -> FDFThreshold:
     """An FDF amplitude cut ``snr`` times the theoretical noise, or None for no cut.
 
-    Zero means no cut, and has to short-circuit rather than multiply through:
-    the theoretical noise is ``inf`` wherever a pixel carries no weight at all
-    (linmos blanks the mosaic edge), and ``0 * inf`` is NaN, which blanks every
-    comparison against it instead of passing everything.
-
-    The noise is a scalar for per-channel weights and a lazy (ny, nx) map for
-    the per-pixel ones the linmos cubes give, so the cut comes back in whichever
-    form it arrived in.
+    Zero short-circuits rather than multiplying through: the noise is ``inf``
+    where a pixel carries no weight, and ``0 * inf`` is NaN, which would blank
+    every comparison instead of passing everything.
     """
     if snr == 0 or fdf_error_noise is None:
         return None
@@ -661,6 +651,8 @@ def write_rm_products(
     moment_products: list[FDFLabel],
     peak_products: list[FDFLabel],
     output_prefix: Path,
+    moment_threshold_snr: float = 5.0,
+    peak_threshold_snr: float = 0.0,
     dask_client: Client | None = None,
 ) -> list[Path]:
     """Batch-compute and write the requested RM-synthesis/RM-CLEAN output products.
@@ -674,6 +666,8 @@ def write_rm_products(
         cube_products (list[FDFLabel]): Which FDF cube(s) to write ('dirty', 'clean', 'model')
         moment_products (list[FDFLabel]): Which FDF(s) to compute Faraday moment maps from
         peak_products (list[FDFLabel]): Which FDF(s) to write peak-statistic maps from, nine per entry
+        moment_threshold_snr (float, optional): SNR cut applied before the moment maps. Defaults to 5.0.
+        peak_threshold_snr (float, optional): SNR cut below which peaks are blanked. Zero applies no cut. Defaults to 0.0.
         output_prefix (Path): Common prefix for the output files
         dask_client (Client | None, optional): A distributed Client (e.g. the one backing a Prefect ``DaskTaskRunner``) to compute across, rather than just the local worker. Defaults to None.
 
@@ -755,7 +749,7 @@ def write_rm_products(
     # applies this same cut inside RM-CLEAN to its own moment maps, which flint
     # does not use, so it is rederived here from the shared theoretical noise.
     moment_threshold = _snr_threshold(
-        rmclean_options.moment_threshold_snr,
+        moment_threshold_snr,
         synth_results.theoretical_noise.fdf_error_noise,
     )
     for label in moment_products:
@@ -782,17 +776,13 @@ def write_rm_products(
         assert clean_results is not None  # run_clean is `clean_results is not None`
         compute_targets["rmclean_niter"] = clean_results.iter_count_map
 
-    # rm-lite returns peaks of its own on RMClean3DResults, but only for the
-    # clean FDF and only under its own threshold. Deriving them here is what
-    # lets any requested FDF have them -- the dirty one included, which needs no
-    # RM-CLEAN at all -- under a cut flint chooses.
-    #
-    # A separate cut from the moments, and off by default. The moment cut exists
-    # because mom0 integrates the whole Faraday depth axis; a peak is one sample
-    # and has no such floor, so blanking it discards a real measurement whose
-    # error (peak_pi_error) is written beside it.
+    # rm-lite's own peaks cover only the clean FDF under its own threshold;
+    # deriving them here lets any requested FDF have them, the dirty one
+    # included. Cut separately from the moments and off by default: mom0
+    # integrates the whole Faraday depth axis, a peak is one sample with no such
+    # floor, and peak_pi_error is written beside it to judge significance.
     peak_threshold = _snr_threshold(
-        rmclean_options.peak_threshold_snr,
+        peak_threshold_snr,
         synth_results.theoretical_noise.fdf_error_noise,
     )
     for label in peak_products:

--- a/flint/rmsynth.py
+++ b/flint/rmsynth.py
@@ -68,21 +68,21 @@ _PEAK_MAPS = {
 def needs_rmclean(
     cube_products: list[FDFLabel],
     moment_products: list[FDFLabel],
-    peak_products: list[FDFLabel] | None = None,
+    peak_products: list[FDFLabel],
 ) -> bool:
     """Whether any requested product requires RM-CLEAN to be run.
 
     Args:
         cube_products (list[FDFLabel]): Requested FDF cubes
         moment_products (list[FDFLabel]): Requested Faraday moment maps
-        peak_products (list[FDFLabel] | None, optional): Requested FDF peak-statistic maps. Defaults to None.
+        peak_products (list[FDFLabel]): Requested FDF peak-statistic maps
 
     Returns:
         bool: True if RM-CLEAN is needed
     """
     return any(
         label in ("clean", "model")
-        for label in (*cube_products, *moment_products, *(peak_products or ()))
+        for label in (*cube_products, *moment_products, *peak_products)
     )
 
 
@@ -640,9 +640,9 @@ def write_rm_products(
     rmclean_options: RMCleanOptions,
     cube_products: list[FDFLabel],
     moment_products: list[FDFLabel],
+    peak_products: list[FDFLabel],
     output_prefix: Path,
     dask_client: Client | None = None,
-    peak_products: list[FDFLabel] | None = None,
 ) -> list[Path]:
     """Batch-compute and write the requested RM-synthesis/RM-CLEAN output products.
 
@@ -654,7 +654,7 @@ def write_rm_products(
         rmclean_options (RMCleanOptions): Options controlling RM-CLEAN
         cube_products (list[FDFLabel]): Which FDF cube(s) to write ('dirty', 'clean', 'model')
         moment_products (list[FDFLabel]): Which FDF(s) to compute Faraday moment maps from
-        peak_products (list[FDFLabel] | None, optional): Which FDF(s) to write peak-statistic maps from, nine per entry. Defaults to None.
+        peak_products (list[FDFLabel]): Which FDF(s) to write peak-statistic maps from, nine per entry
         output_prefix (Path): Common prefix for the output files
         dask_client (Client | None, optional): A distributed Client (e.g. the one backing a Prefect ``DaskTaskRunner``) to compute across, rather than just the local worker. Defaults to None.
 
@@ -767,7 +767,7 @@ def write_rm_products(
     # clean FDF and only under its own threshold. Deriving them here is what
     # lets any requested FDF have them -- the dirty one included, which needs no
     # RM-CLEAN at all -- under the same cut flint gives its moments.
-    for label in peak_products or ():
+    for label in peak_products:
         peaks = calc_faraday_peaks(
             fdf_sources[label],
             phi_arr_radm2=synth_results.phi_arr_radm2,
@@ -871,7 +871,7 @@ def write_rm_products(
             )
         )
 
-    for label in peak_products or ():
+    for label in peak_products:
         output_paths.extend(
             write_peak_maps_to_fits(
                 peaks=FaradayPeaks(

--- a/flint/rmsynth.py
+++ b/flint/rmsynth.py
@@ -91,7 +91,9 @@ def run_rmclean_3d(
     )
 
 
-def _phi_header(reference_header: fits.Header, phi_arr_radm2: np.ndarray) -> fits.Header:
+def _phi_header(
+    reference_header: fits.Header, phi_arr_radm2: np.ndarray
+) -> fits.Header:
     """Build a FDF cube header: the reference header's spatial WCS with the
     spectral axis replaced by a linear Faraday-depth axis."""
     header = WCS(reference_header).celestial.to_header()
@@ -123,7 +125,9 @@ def write_fdf_cube_to_fits(
         Path: ``output_path``
     """
     header = _phi_header(reference_header=reference_header, phi_arr_radm2=phi_arr_radm2)
-    fits.writeto(output_path, np.abs(fdf_cube).astype(np.float32), header, overwrite=True)
+    fits.writeto(
+        output_path, np.abs(fdf_cube).astype(np.float32), header, overwrite=True
+    )
     return output_path
 
 
@@ -140,6 +144,9 @@ def write_moment_maps_to_fits(
     debias_filter_size: int = 5,
 ) -> list[Path]:
     """Compute and write the mom0/mom1/mom2 Faraday moment maps of an FDF cube.
+    If ``debias`` is True, an additional debiased mom0/mom1/mom2 set (via
+    rm_lite's ``debias_fdf``) is written alongside the usual thresholded set,
+    suffixed ``.debiased`` -- not a replacement for it.
 
     Args:
         fdf_cube (np.ndarray): Complex FDF cube, shape (n_phi, ny, nx)
@@ -148,31 +155,54 @@ def write_moment_maps_to_fits(
         reference_header (fits.Header): Header to derive the spatial WCS from (e.g. the Stokes Q cube header)
         output_prefix (Path): Common prefix for the output files
         label (FDFLabel): Which FDF ``fdf_cube`` is ('dirty', 'clean', or 'model'), used to name the outputs
-        threshold (float | None, optional): Amplitude cut applied before computing the moments. Ignored if debias is True. Defaults to None.
-        debias (bool, optional): Debias mom0 via rm_lite's debias_fdf instead of thresholding. Requires lam_sq_0_m2. Defaults to False.
+        threshold (float | None, optional): Amplitude cut applied before computing the moments. Defaults to None.
+        debias (bool, optional): Also write a debiased mom0/mom1/mom2 set. Requires lam_sq_0_m2. Defaults to False.
         lam_sq_0_m2 (float | None, optional): Reference wavelength^2, required if debias is True. Defaults to None.
         debias_filter_size (int, optional): Median filter size (pixels) used by debiasing. Defaults to 5.
 
     Returns:
-        list[Path]: The three written moment-map paths (mom0, mom1, mom2)
+        list[Path]: The written moment-map paths: three (mom0, mom1, mom2), plus
+        three more (mom0.debiased, mom1.debiased, mom2.debiased) if debias is True
     """
+    header = WCS(reference_header).celestial.to_header()
+
+    def _write(moments, suffix: str) -> list[Path]:
+        written = []
+        for moment_name, moment_map in zip(
+            ("mom0", "mom1", "mom2"), (moments.mom0, moments.mom1, moments.mom2)
+        ):
+            output_path = Path(
+                f"{output_prefix}.fdf.{label}.{moment_name}{suffix}.fits"
+            )
+            fits.writeto(
+                output_path,
+                np.asarray(moment_map, dtype=np.float32),
+                header,
+                overwrite=True,
+            )
+            written.append(output_path)
+        return written
+
     moments = calc_faraday_moments(
         fdf_cube,
         phi_arr_radm2=phi_arr_radm2,
         fwhm_rmsf_radm2=fwhm_rmsf_radm2,
-        threshold=None if debias else threshold,
-        debias=debias,
-        lam_sq_0_m2=lam_sq_0_m2,
-        debias_filter_size=debias_filter_size,
+        threshold=threshold,
     )
-    header = WCS(reference_header).celestial.to_header()
-    output_paths = []
-    for moment_name, moment_map in zip(
-        ("mom0", "mom1", "mom2"), (moments.mom0, moments.mom1, moments.mom2)
-    ):
-        output_path = Path(f"{output_prefix}.fdf.{label}.{moment_name}.fits")
-        fits.writeto(output_path, np.asarray(moment_map, dtype=np.float32), header, overwrite=True)
-        output_paths.append(output_path)
+    output_paths = _write(moments, suffix="")
+
+    if debias:
+        debiased_moments = calc_faraday_moments(
+            fdf_cube,
+            phi_arr_radm2=phi_arr_radm2,
+            fwhm_rmsf_radm2=fwhm_rmsf_radm2,
+            threshold=None,
+            debias=True,
+            lam_sq_0_m2=lam_sq_0_m2,
+            debias_filter_size=debias_filter_size,
+        )
+        output_paths.extend(_write(debiased_moments, suffix=".debiased"))
+
     return output_paths
 
 
@@ -206,7 +236,9 @@ def write_stokes_i_fit_maps_to_fits(
     output_paths = []
     for key, data in stokes_i_maps.items():
         output_path = Path(f"{output_prefix}.{_STOKES_I_MAP_SUFFIXES[key]}.fits")
-        fits.writeto(output_path, np.asarray(data, dtype=np.float32), header, overwrite=True)
+        fits.writeto(
+            output_path, np.asarray(data, dtype=np.float32), header, overwrite=True
+        )
         output_paths.append(output_path)
     return output_paths
 
@@ -255,7 +287,9 @@ def rmsynth_and_write_products(
         stokes_i_cube=stokes_i_cube,
     )
 
-    run_clean = any(label in ("clean", "model") for label in (*cube_products, *moment_products))
+    run_clean = any(
+        label in ("clean", "model") for label in (*cube_products, *moment_products)
+    )
     clean_results = (
         run_rmclean_3d(rm_synth_results=synth_results, rmclean_options=rmclean_options)
         if run_clean
@@ -267,10 +301,23 @@ def rmsynth_and_write_products(
         fdf_sources["clean"] = clean_results.clean_fdf_cube
         fdf_sources["model"] = clean_results.model_fdf_cube
 
-    needed_labels = {*cube_products, *moment_products}
+    # Cubes written to zarr are stored chunk-by-chunk (one worker writing its
+    # own chunk directly) and so must NOT also be gathered to numpy here --
+    # only labels also needed for moments (small, cheap to gather) go through
+    # the numpy path below.
+    write_cubes_as_zarr = rmsynth_options.write_fdfs_to_zarr and bool(cube_products)
+    zarr_store_path = Path(f"{output_prefix}.fdf.zarr") if write_cubes_as_zarr else None
+    numpy_cube_labels = set() if write_cubes_as_zarr else set(cube_products)
+
+    needed_labels = numpy_cube_labels | set(moment_products)
     compute_targets: dict[str, dask.array.Array] = {
         label: fdf_sources[label] for label in needed_labels
     }
+    if write_cubes_as_zarr:
+        for label in cube_products:
+            compute_targets[f"zarr_{label}"] = fdf_sources[label].to_zarr(
+                str(zarr_store_path), component=label, overwrite=True, compute=False
+            )
     # stokes_i_alpha_error_map is None unless estimate_stokes_i_noise (or a
     # supplied Stokes I error) gives the fit something to propagate; the other
     # maps are None only if the Stokes I fit didn't run at all. Skip whichever
@@ -284,25 +331,33 @@ def rmsynth_and_write_products(
     stokes_i_maps = {k: v for k, v in stokes_i_maps.items() if v is not None}
     compute_targets.update(stokes_i_maps)
 
-    # Batch every lazy array needed by the requested products into a single
-    # dask.compute call: computing per-product in a loop would redo the shared
-    # synthesis/RM-CLEAN graph once per product instead of once total. Per
-    # rm-lite's dask parallelisation guide: the threaded scheduler suits the
-    # GIL-releasing NUFFT (dirty-only), but RM-CLEAN/Stokes-I fitting are
-    # GIL-bound Python loops that need the process scheduler -- unless a
-    # distributed Client is given, in which case it takes over entirely.
-    scheduler = dask_client if dask_client is not None else ("processes" if run_clean else "threads")
+    # Batch every lazy array/delayed write needed by the requested products
+    # into a single dask.compute call, including the zarr writes above:
+    # computing per-product in a loop would redo the shared synthesis/RM-CLEAN
+    # graph once per product instead of once total. Per rm-lite's dask
+    # parallelisation guide: the threaded scheduler suits the GIL-releasing
+    # NUFFT (dirty-only), but RM-CLEAN/Stokes-I fitting are GIL-bound Python
+    # loops that need the process scheduler -- unless a distributed Client is
+    # given, in which case it takes over entirely.
+    scheduler = (
+        dask_client
+        if dask_client is not None
+        else ("processes" if run_clean else "threads")
+    )
     compute_keys = list(compute_targets.keys())
     computed = dict(
         zip(
             compute_keys,
-            dask.compute(*(compute_targets[key] for key in compute_keys), scheduler=scheduler),
+            dask.compute(
+                *(compute_targets[key] for key in compute_keys), scheduler=scheduler
+            ),
         )
     )
 
     reference_header = fits.getheader(stokes_q_cube)
     clean_moment_threshold = (
-        rmclean_options.moment_threshold_snr * synth_results.theoretical_noise.fdf_error_noise
+        rmclean_options.moment_threshold_snr
+        * synth_results.theoretical_noise.fdf_error_noise
     )
     moment_thresholds: dict[FDFLabel, float | None] = {
         "dirty": None,
@@ -311,18 +366,22 @@ def rmsynth_and_write_products(
     }
 
     output_paths: list[Path] = []
-    for label in cube_products:
-        output_path = create_image_cube_name(
-            image_prefix=output_prefix, mode="fdf", suffix=label
-        )
-        output_paths.append(
-            write_fdf_cube_to_fits(
-                fdf_cube=computed[label],
-                phi_arr_radm2=synth_results.phi_arr_radm2,
-                reference_header=reference_header,
-                output_path=output_path,
+    if write_cubes_as_zarr:
+        assert zarr_store_path is not None
+        output_paths.append(zarr_store_path)
+    else:
+        for label in cube_products:
+            output_path = create_image_cube_name(
+                image_prefix=output_prefix, mode="fdf", suffix=label
             )
-        )
+            output_paths.append(
+                write_fdf_cube_to_fits(
+                    fdf_cube=computed[label],
+                    phi_arr_radm2=synth_results.phi_arr_radm2,
+                    reference_header=reference_header,
+                    output_path=output_path,
+                )
+            )
     for label in moment_products:
         output_paths.extend(
             write_moment_maps_to_fits(

--- a/flint/rmsynth.py
+++ b/flint/rmsynth.py
@@ -13,9 +13,25 @@ import numpy as np
 from astropy.io import fits
 from astropy.wcs import WCS
 from dask.distributed import Client
-from rm_lite.tools_3d.rmclean import RMClean3DResults, run_rmclean_from_synth
-from rm_lite.tools_3d.rmsynth import RMSynth3DResults, rmsynth_3d_from_fits
-from rm_lite.utils.synthesis import calc_faraday_moments
+
+# finufft's PyPI wheel vendors its own libomp.dylib (macOS) rather than
+# linking the environment's shared one; having both loaded aborts the
+# process with "OMP: Error #15: Initializing libomp.dylib, but found
+# libomp.dylib already initialized." as soon as anything else (e.g.
+# casacore) has already initialised an OpenMP runtime in the process. Must
+# be set before finufft/rm_lite are imported -- this module is the first
+# place in flint-pol that imports them.
+os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "TRUE")
+
+from rm_lite.tools_3d.rmclean import (  # noqa: E402
+    RMClean3DResults,
+    run_rmclean_from_synth,
+)
+from rm_lite.tools_3d.rmsynth import (  # noqa: E402
+    RMSynth3DResults,
+    rmsynth_3d_from_fits,
+)
+from rm_lite.utils.synthesis import calc_faraday_moments  # noqa: E402
 
 from flint.logging import logger
 from flint.naming import create_image_cube_name
@@ -334,11 +350,12 @@ def rmsynth_and_write_products(
     # Batch every lazy array/delayed write needed by the requested products
     # into a single dask.compute call, including the zarr writes above:
     # computing per-product in a loop would redo the shared synthesis/RM-CLEAN
-    # graph once per product instead of once total. Per rm-lite's dask
-    # parallelisation guide: the threaded scheduler suits the GIL-releasing
-    # NUFFT (dirty-only), but RM-CLEAN/Stokes-I fitting are GIL-bound Python
-    # loops that need the process scheduler -- unless a distributed Client is
-    # given, in which case it takes over entirely.
+    # graph once per product instead of once total.
+    #
+    # Per rm-lite's dask parallelisation guide: the threaded scheduler suits
+    # the GIL-releasing NUFFT (dirty-only), but RM-CLEAN/Stokes-I fitting are
+    # GIL-bound Python loops that need the process scheduler -- unless a
+    # distributed Client is given, in which case it takes over entirely.
     scheduler = (
         dask_client
         if dask_client is not None

--- a/flint/rmsynth.py
+++ b/flint/rmsynth.py
@@ -82,6 +82,9 @@ def run_rmsynth_3d(
     stokes_u_cube: Path,
     rmsynth_options: RMSynthOptions,
     stokes_i_cube: Path | None = None,
+    stokes_q_weight_cube: Path | None = None,
+    stokes_u_weight_cube: Path | None = None,
+    stokes_i_weight_cube: Path | None = None,
 ) -> RMSynth3DResults:
     """Run 3D RM-synthesis on Stokes Q/U FITS cubes.
 
@@ -95,15 +98,14 @@ def run_rmsynth_3d(
         RMSynth3DResults: Lazy dirty FDF cube, the RMSF spectrum every pixel
         shares, and associated parameters
     """
-    _check_cubes_memmappable(stokes_q_cube, stokes_u_cube, stokes_i_cube)
-
+    _check_cubes_memmappable(stokes_q_cube, stokes_u_cube, stokes_i_cube,stokes_q_weight_cube, stokes_u_weight_cube)
     stokes_i_kwargs = (
         {
             "stokes_i_file": stokes_i_cube,
+            "stokes_i_error_file": stokes_i_weight_cube,
             "fit_order": rmsynth_options.fit_order,
             "fit_function": rmsynth_options.fit_function,
             "stokes_i_snr_cut": rmsynth_options.stokes_i_snr_cut,
-            "estimate_stokes_i_noise": rmsynth_options.estimate_stokes_i_noise,
             "compute_model_error": rmsynth_options.compute_model_error,
             "n_error_samples": rmsynth_options.n_error_samples,
         }
@@ -113,6 +115,9 @@ def run_rmsynth_3d(
     return rmsynth_3d_from_fits(
         stokes_q_file=stokes_q_cube,
         stokes_u_file=stokes_u_cube,
+        stokes_q_error_file=stokes_q_weight_cube,
+        stokes_u_error_file=stokes_u_weight_cube,
+        noise_files_are_weight=True,
         phi_max_radm2=rmsynth_options.phi_max_radm2,
         d_phi_radm2=rmsynth_options.d_phi_radm2,
         n_samples=rmsynth_options.n_samples,
@@ -121,12 +126,6 @@ def run_rmsynth_3d(
         nufft_nthreads=rmsynth_options.nufft_nthreads,
         target_chunk_mb=rmsynth_options.target_chunk_mb,
         log_level=logging.INFO,
-        # `per_pixel_rmsf` is deliberately left off. A pixel's RMSF depends only
-        # on which channels it has flagged, and flint flags per channel, so the
-        # single `rmsf_arr` spectrum rm-lite returns describes the whole cube. The
-        # per-pixel cube is ~2x the FDF's size and would hold that one spectrum in
-        # every pixel. Only worth turning on for per-pixel blanking that the
-        # channel weights do not carry, which flint does not produce.
         **stokes_i_kwargs,
     )
 

--- a/flint/rmsynth.py
+++ b/flint/rmsynth.py
@@ -6,10 +6,11 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-from typing import Literal
+from typing import Any, Literal
 
 import dask
 import numpy as np
+import zarr
 from astropy.io import fits
 from astropy.wcs import WCS
 from dask.distributed import Client
@@ -19,8 +20,7 @@ from dask.distributed import Client
 # process with "OMP: Error #15: Initializing libomp.dylib, but found
 # libomp.dylib already initialized." as soon as anything else (e.g.
 # casacore) has already initialised an OpenMP runtime in the process. Must
-# be set before finufft/rm_lite are imported -- this module is the first
-# place in flint-pol that imports them.
+# be set before finufft/rm_lite are imported.
 os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "TRUE")
 
 from rm_lite.tools_3d.rmclean import (  # noqa: E402
@@ -31,13 +31,49 @@ from rm_lite.tools_3d.rmsynth import (  # noqa: E402
     RMSynth3DResults,
     rmsynth_3d_from_fits,
 )
-from rm_lite.utils.synthesis import calc_faraday_moments  # noqa: E402
+from rm_lite.utils.synthesis import (  # noqa: E402
+    FaradayMoments,
+    calc_faraday_moments,
+)
 
+from flint.exceptions import NotSupportedError
 from flint.logging import logger
-from flint.naming import create_image_cube_name
 from flint.options import RMCleanOptions, RMSynthOptions
 
 FDFLabel = Literal["dirty", "clean", "model"]
+_MOMENT_NAMES = ("mom0", "mom1", "mom2")
+
+
+def needs_rmclean(
+    cube_products: list[FDFLabel], moment_products: list[FDFLabel]
+) -> bool:
+    """Whether any requested product requires RM-CLEAN to be run.
+
+    Args:
+        cube_products (list[FDFLabel]): Requested FDF cubes
+        moment_products (list[FDFLabel]): Requested Faraday moment maps
+
+    Returns:
+        bool: True if RM-CLEAN is needed
+    """
+    return any(
+        label in ("clean", "model") for label in (*cube_products, *moment_products)
+    )
+
+
+def _check_cubes_memmappable(*cubes: Path | None) -> None:
+    """rm-lite reads each spatial block by reopening the cube with ``memmap=True``.
+    astropy cannot memmap a gzip file, so every block read decompresses the whole
+    cube into memory. Compress after RM-synthesis, not before."""
+    compressed = [cube for cube in cubes if cube is not None and cube.suffix == ".gz"]
+    if compressed:
+        msg = (
+            f"{compressed} are gzip-compressed and cannot be used for RM-synthesis: "
+            "astropy cannot memmap a compressed FITS file, so each of the chunked "
+            "reads would decompress the entire cube into memory. Run RM-synthesis "
+            "on the uncompressed cubes."
+        )
+        raise NotSupportedError(msg)
 
 
 def run_rmsynth_3d(
@@ -55,8 +91,11 @@ def run_rmsynth_3d(
         stokes_i_cube (Path | None, optional): Path to a Stokes I FITS cube, used to fit a per-pixel fractional-polarisation correction. FDF stays in Q/U flux if not given. Defaults to None.
 
     Returns:
-        RMSynth3DResults: Lazy dirty FDF cube, RMSF cube, and associated parameters
+        RMSynth3DResults: Lazy dirty FDF cube, the RMSF spectrum every pixel
+        shares, and associated parameters
     """
+    _check_cubes_memmappable(stokes_q_cube, stokes_u_cube, stokes_i_cube)
+
     stokes_i_kwargs = (
         {
             "stokes_i_file": stokes_i_cube,
@@ -80,6 +119,12 @@ def run_rmsynth_3d(
         robust=rmsynth_options.robust,
         nufft_nthreads=rmsynth_options.nufft_nthreads,
         target_chunk_mb=rmsynth_options.target_chunk_mb,
+        # `per_pixel_rmsf` is deliberately left off. A pixel's RMSF depends only
+        # on which channels it has flagged, and flint flags per channel, so the
+        # single `rmsf_arr` spectrum rm-lite returns describes the whole cube. The
+        # per-pixel cube is ~2x the FDF's size and would hold that one spectrum in
+        # every pixel. Only worth turning on for per-pixel blanking that the
+        # channel weights do not carry, which flint does not produce.
         **stokes_i_kwargs,
     )
 
@@ -103,89 +148,40 @@ def run_rmclean_3d(
         max_iter=rmclean_options.max_iter,
         gain=rmclean_options.gain,
         moment_threshold_snr=rmclean_options.moment_threshold_snr,
-        multiscale=rmclean_options.multiscale,
     )
-
-
-def _phi_header(
-    reference_header: fits.Header, phi_arr_radm2: np.ndarray
-) -> fits.Header:
-    """Build a FDF cube header: the reference header's spatial WCS with the
-    spectral axis replaced by a linear Faraday-depth axis."""
-    header = WCS(reference_header).celestial.to_header()
-    header["NAXIS"] = 3
-    header["CTYPE3"] = "FDEPTH"
-    header["CUNIT3"] = "rad/m2"
-    header["CRPIX3"] = 1
-    header["CRVAL3"] = float(phi_arr_radm2[0])
-    header["CDELT3"] = float(phi_arr_radm2[1] - phi_arr_radm2[0])
-    return header
-
-
-def write_fdf_cube_to_fits(
-    fdf_cube: np.ndarray,
-    phi_arr_radm2: np.ndarray,
-    reference_header: fits.Header,
-    output_path: Path,
-) -> Path:
-    """Write a (already computed) FDF cube to FITS as amplitude, matching the
-    RM-Tools ``_FDFdirty.fits``/``_FDFclean.fits`` convention. Phase is dropped.
-
-    Args:
-        fdf_cube (np.ndarray): Complex FDF cube, shape (n_phi, ny, nx)
-        phi_arr_radm2 (np.ndarray): Faraday depth values, rad/m^2
-        reference_header (fits.Header): Header to derive the spatial WCS from (e.g. the Stokes Q cube header)
-        output_path (Path): Output FITS path
-
-    Returns:
-        Path: ``output_path``
-    """
-    header = _phi_header(reference_header=reference_header, phi_arr_radm2=phi_arr_radm2)
-    fits.writeto(
-        output_path, np.abs(fdf_cube).astype(np.float32), header, overwrite=True
-    )
-    return output_path
 
 
 def write_moment_maps_to_fits(
-    fdf_cube: np.ndarray,
-    phi_arr_radm2: np.ndarray,
-    fwhm_rmsf_radm2: float,
+    moments: FaradayMoments,
     reference_header: fits.Header,
     output_prefix: Path,
     label: FDFLabel,
-    threshold: float | None = None,
-    debias: bool = False,
-    lam_sq_0_m2: float | None = None,
-    debias_filter_size: int = 5,
+    debiased_moments: FaradayMoments | None = None,
 ) -> list[Path]:
-    """Compute and write the mom0/mom1/mom2 Faraday moment maps of an FDF cube.
-    If ``debias`` is True, an additional debiased mom0/mom1/mom2 set (via
-    rm_lite's ``debias_fdf``) is written alongside the usual thresholded set,
-    suffixed ``.debiased`` -- not a replacement for it.
+    """Write already-computed mom0/mom1/mom2 Faraday moment maps to FITS.
+
+    The moments are built lazily and computed by ``write_rm_products``, which
+    keeps the (n_phi, ny, nx) FDF cube they reduce out of this process; only the
+    (ny, nx) maps arrive here. See ``_lazy_faraday_moments``.
 
     Args:
-        fdf_cube (np.ndarray): Complex FDF cube, shape (n_phi, ny, nx)
-        phi_arr_radm2 (np.ndarray): Faraday depth values, rad/m^2
-        fwhm_rmsf_radm2 (float): RMSF FWHM, rad/m^2
+        moments (FaradayMoments): Computed mom0/mom1/mom2 maps, each (ny, nx)
         reference_header (fits.Header): Header to derive the spatial WCS from (e.g. the Stokes Q cube header)
         output_prefix (Path): Common prefix for the output files
-        label (FDFLabel): Which FDF ``fdf_cube`` is ('dirty', 'clean', or 'model'), used to name the outputs
-        threshold (float | None, optional): Amplitude cut applied before computing the moments. Defaults to None.
-        debias (bool, optional): Also write a debiased mom0/mom1/mom2 set. Requires lam_sq_0_m2. Defaults to False.
-        lam_sq_0_m2 (float | None, optional): Reference wavelength^2, required if debias is True. Defaults to None.
-        debias_filter_size (int, optional): Median filter size (pixels) used by debiasing. Defaults to 5.
+        label (FDFLabel): Which FDF the moments came from ('dirty', 'clean', or 'model'), used to name the outputs
+        debiased_moments (FaradayMoments | None, optional): Debiased moment set, written alongside with a ``.debiased`` suffix. Defaults to None.
 
     Returns:
         list[Path]: The written moment-map paths: three (mom0, mom1, mom2), plus
-        three more (mom0.debiased, mom1.debiased, mom2.debiased) if debias is True
+        three more (mom0.debiased, mom1.debiased, mom2.debiased) if debiased_moments is given
     """
     header = WCS(reference_header).celestial.to_header()
 
-    def _write(moments, suffix: str) -> list[Path]:
+    def _write(moment_set: FaradayMoments, suffix: str) -> list[Path]:
         written = []
         for moment_name, moment_map in zip(
-            ("mom0", "mom1", "mom2"), (moments.mom0, moments.mom1, moments.mom2)
+            _MOMENT_NAMES,
+            (moment_set.mom0, moment_set.mom1, moment_set.mom2),
         ):
             output_path = Path(
                 f"{output_prefix}.fdf.{label}.{moment_name}{suffix}.fits"
@@ -199,59 +195,89 @@ def write_moment_maps_to_fits(
             written.append(output_path)
         return written
 
-    moments = calc_faraday_moments(
-        fdf_cube,
-        phi_arr_radm2=phi_arr_radm2,
-        fwhm_rmsf_radm2=fwhm_rmsf_radm2,
-        threshold=threshold,
-    )
     output_paths = _write(moments, suffix="")
-
-    if debias:
-        debiased_moments = calc_faraday_moments(
-            fdf_cube,
-            phi_arr_radm2=phi_arr_radm2,
-            fwhm_rmsf_radm2=fwhm_rmsf_radm2,
-            threshold=None,
-            debias=True,
-            lam_sq_0_m2=lam_sq_0_m2,
-            debias_filter_size=debias_filter_size,
-        )
+    if debiased_moments is not None:
         output_paths.extend(_write(debiased_moments, suffix=".debiased"))
 
     return output_paths
 
 
-_STOKES_I_MAP_SUFFIXES = {
-    "stokes_i_ref_flux": "stokesi.ref_flux",
-    "stokes_i_alpha": "stokesi.alpha",
-    "stokes_i_alpha_error": "stokesi.alpha_error",
-    "stokes_i_model_order": "stokesi.model_order",
-}
+def _stokes_i_fit_header(
+    reference_header: fits.Header,
+    ref_freq_hz: float | None,
+    fit_function: str | None,
+    coeff: tuple[int, str] | None = None,
+) -> fits.Header:
+    """Build the celestial-WCS header for a Stokes I fit map, stamped with what
+    is needed to read it. A spectral index or a reference flux means nothing
+    without the frequency it is defined at and the functional form it belongs to,
+    so those travel in the header rather than only in flint's file naming.
+
+    Args:
+        reference_header (fits.Header): Header to derive the spatial WCS from
+        ref_freq_hz (float | None): Frequency the model terms are defined at, omitted from the header if rm-lite did not report one
+        fit_function (str | None): The Stokes I fit function the terms belong to ('log' or 'linear'), omitted from the header if not known
+        coeff (tuple[int, str] | None, optional): The (popt index, name) of the model term this map holds, for the per-term maps. Defaults to None.
+
+    Returns:
+        fits.Header: The header to write the map with
+    """
+    header = WCS(reference_header).celestial.to_header()
+    if ref_freq_hz is not None:
+        header["REFFREQ"] = (
+            float(ref_freq_hz),
+            "Stokes I model reference frequency [Hz]",
+        )
+    if fit_function is not None:
+        header["FITFUNC"] = (fit_function, "Stokes I fit function")
+    if coeff is not None:
+        index, name = coeff
+        header["SICOEFF"] = (name, "Stokes I model term in this map")
+        header["SICOEFFI"] = (index, "Index of this term in the fitted popt")
+        header.add_comment("0 means the AIC dropped this term: it contributes nothing.")
+        header.add_comment("NaN means the pixel was never fitted (below the SNR cut).")
+    return header
 
 
 def write_stokes_i_fit_maps_to_fits(
     stokes_i_maps: dict[str, np.ndarray],
     reference_header: fits.Header,
     output_prefix: Path,
+    ref_freq_hz: float | None = None,
+    fit_function: str | None = None,
 ) -> list[Path]:
     """Write the per-pixel Stokes I fractional-polarisation fit maps: the fitted
     reference flux, spectral index (alpha) and its error, and the fitted
     polynomial order. Cheap 2D maps, always written when a Stokes I cube is used
     and rm-lite actually returned that particular map (e.g. ``alpha_error`` is
-    only produced if a Stokes I noise estimate was available).
+    only produced if the model error was computed).
 
     Args:
         stokes_i_maps (dict[str, np.ndarray]): Already-computed maps, keyed by
-            one of ``_STOKES_I_MAP_SUFFIXES``'s keys.
+            one of ``stokes_i_ref_flux``, ``stokes_i_alpha``,
+            ``stokes_i_alpha_error`` or ``stokes_i_model_order``.
+        reference_header (fits.Header): Header to derive the spatial WCS from
+        output_prefix (Path): Common prefix for the output files
+        ref_freq_hz (float | None, optional): Frequency the fit is referenced to, recorded in each header. Defaults to None.
+        fit_function (str | None, optional): The Stokes I fit function, recorded in each header. Defaults to None.
 
     Returns:
         list[Path]: The written map paths, one per entry in ``stokes_i_maps``
     """
-    header = WCS(reference_header).celestial.to_header()
+    suffixes = {
+        "stokes_i_ref_flux": "stokesi.ref_flux",
+        "stokes_i_alpha": "stokesi.alpha",
+        "stokes_i_alpha_error": "stokesi.alpha_error",
+        "stokes_i_model_order": "stokesi.model_order",
+    }
+    header = _stokes_i_fit_header(
+        reference_header=reference_header,
+        ref_freq_hz=ref_freq_hz,
+        fit_function=fit_function,
+    )
     output_paths = []
     for key, data in stokes_i_maps.items():
-        output_path = Path(f"{output_prefix}.{_STOKES_I_MAP_SUFFIXES[key]}.fits")
+        output_path = Path(f"{output_prefix}.{suffixes[key]}.fits")
         fits.writeto(
             output_path, np.asarray(data, dtype=np.float32), header, overwrite=True
         )
@@ -259,93 +285,270 @@ def write_stokes_i_fit_maps_to_fits(
     return output_paths
 
 
-def rmsynth_and_write_products(
+def write_stokes_i_coeff_maps_to_fits(
+    coeff_cube: np.ndarray,
+    coeff_names: tuple[str, ...],
+    reference_header: fits.Header,
+    output_prefix: Path,
+    ref_freq_hz: float | None = None,
+    fit_function: str | None = None,
+    coeff_error_cube: np.ndarray | None = None,
+) -> list[Path]:
+    """Write the fitted Stokes I model terms.
+
+    The terms plus the reference frequency and the fit function *are* the whole
+    Stokes I model, so anything downstream can evaluate Stokes I at any frequency
+    from these maps alone without carrying the model cube -- but only if it knows
+    which plane holds which term, which is why each gets its own named file and
+    its ``REFFREQ``/``FITFUNC`` header.
+
+    Two values are meaningful rather than missing, and are recorded in the header
+    as well: a zero is the actual value of a term the AIC dropped (it contributes
+    nothing to the model, and ``stokesi.model_order`` says how many terms were
+    really fitted), while a NaN is a pixel that was never fitted at all.
+
+    Args:
+        coeff_cube (np.ndarray): Already-computed model terms, shape (n_coeff, ny, nx) in popt order
+        coeff_names (tuple[str, ...]): Name of each plane of ``coeff_cube``, e.g. ('flux', 'alpha', 'beta')
+        reference_header (fits.Header): Header to derive the spatial WCS from
+        output_prefix (Path): Common prefix for the output files
+        ref_freq_hz (float | None, optional): Frequency the terms are defined at, recorded in each header. Defaults to None.
+        fit_function (str | None, optional): The Stokes I fit function the terms belong to, recorded in each header. Defaults to None.
+        coeff_error_cube (np.ndarray | None, optional): 1-sigma marginal error on each term, shaped like ``coeff_cube``, written alongside with an ``_error`` suffix. Defaults to None.
+
+    Returns:
+        list[Path]: The written map paths, one per term, plus one more per term if
+        ``coeff_error_cube`` is given
+    """
+    if len(coeff_names) != coeff_cube.shape[0]:
+        msg = (
+            f"rm-lite named {len(coeff_names)} Stokes I model terms {coeff_names} "
+            f"but returned {coeff_cube.shape[0]} planes, so the maps cannot be "
+            "named. This is an rm-lite API mismatch, not a configuration error."
+        )
+        raise ValueError(msg)
+
+    suffix = "stokesi.coeff"
+    output_paths = []
+    for index, name in enumerate(coeff_names):
+        header = _stokes_i_fit_header(
+            reference_header=reference_header,
+            ref_freq_hz=ref_freq_hz,
+            fit_function=fit_function,
+            coeff=(index, name),
+        )
+        output_path = Path(f"{output_prefix}.{suffix}.{name}.fits")
+        fits.writeto(
+            output_path,
+            np.asarray(coeff_cube[index], dtype=np.float32),
+            header,
+            overwrite=True,
+        )
+        output_paths.append(output_path)
+
+        if coeff_error_cube is None:
+            continue
+        # Marginal, i.e. sqrt(diag(pcov)): it ignores the strong correlations
+        # between the terms, so it is not the error on the model itself.
+        error_header = header.copy()
+        error_header.add_comment(
+            "1-sigma marginal error; ignores inter-term correlation."
+        )
+        error_path = Path(f"{output_prefix}.{suffix}.{name}_error.fits")
+        fits.writeto(
+            error_path,
+            np.asarray(coeff_error_cube[index], dtype=np.float32),
+            error_header,
+            overwrite=True,
+        )
+        output_paths.append(error_path)
+
+    return output_paths
+
+
+def _lazy_faraday_moments(
+    fdf_cube: dask.array.Array,
+    synth_results: RMSynth3DResults,
+    threshold: float | None,
+    debias: bool = False,
+    debias_filter_size: int = 5,
+) -> FaradayMoments:
+    """Build the lazy mom0/mom1/mom2 maps of an FDF cube.
+
+    ``calc_faraday_moments`` reduces along the (never-chunked) Faraday-depth
+    axis, and ``debias_fdf`` handles dask via ``map_overlap``, so the result is
+    three lazy (ny, nx) maps that each spatial chunk contributes to
+    independently. Computing these instead of the cube itself is what keeps the
+    whole FDF out of the calling worker's memory.
+    """
+    return calc_faraday_moments(
+        fdf_cube,
+        phi_arr_radm2=synth_results.phi_arr_radm2,
+        fwhm_rmsf_radm2=synth_results.fwhm_rmsf_radm2,
+        threshold=threshold,
+        debias=debias,
+        lam_sq_0_m2=synth_results.lam_sq_0_m2 if debias else None,
+        debias_filter_size=debias_filter_size,
+    )
+
+
+def write_rm_products(
+    synth_results: RMSynth3DResults,
+    clean_results: RMClean3DResults | None,
     stokes_q_cube: Path,
-    stokes_u_cube: Path,
     rmsynth_options: RMSynthOptions,
     rmclean_options: RMCleanOptions,
     cube_products: list[FDFLabel],
     moment_products: list[FDFLabel],
     output_prefix: Path,
-    stokes_i_cube: Path | None = None,
     dask_client: Client | None = None,
 ) -> list[Path]:
-    """Run RM-synthesis (and RM-CLEAN if needed) and write the requested output products.
+    """Batch-compute and write the requested RM-synthesis/RM-CLEAN output products.
 
     Args:
-        stokes_q_cube (Path): Path to the Stokes Q FITS cube
-        stokes_u_cube (Path): Path to the Stokes U FITS cube
+        synth_results (RMSynth3DResults): Results from ``run_rmsynth_3d``
+        clean_results (RMClean3DResults | None): Results from ``run_rmclean_3d``, or None if 'clean'/'model' were not requested
+        stokes_q_cube (Path): Path to the Stokes Q FITS cube (its header is reused for output WCS)
         rmsynth_options (RMSynthOptions): Options controlling RM-synthesis
         rmclean_options (RMCleanOptions): Options controlling RM-CLEAN
         cube_products (list[FDFLabel]): Which FDF cube(s) to write ('dirty', 'clean', 'model')
         moment_products (list[FDFLabel]): Which FDF(s) to compute Faraday moment maps from
         output_prefix (Path): Common prefix for the output files
-        stokes_i_cube (Path | None, optional): Path to a Stokes I FITS cube for the fractional-polarisation correction. Defaults to None.
         dask_client (Client | None, optional): A distributed Client (e.g. the one backing a Prefect ``DaskTaskRunner``) to compute across, rather than just the local worker. Defaults to None.
 
     Returns:
         list[Path]: Every FITS path written
     """
-    if not cube_products and not moment_products:
-        logger.info("No RM-synthesis products requested, skipping.")
-        return []
-
     if os.environ.get("OMP_NUM_THREADS") != "1":
         logger.warning(
             "OMP_NUM_THREADS is not set to '1'. rm-lite's dask parallelisation guide "
             "warns this oversubscribes cores when combined with Dask-level parallelism."
         )
 
-    synth_results = run_rmsynth_3d(
-        stokes_q_cube=stokes_q_cube,
-        stokes_u_cube=stokes_u_cube,
-        rmsynth_options=rmsynth_options,
-        stokes_i_cube=stokes_i_cube,
-    )
-
-    run_clean = any(
-        label in ("clean", "model") for label in (*cube_products, *moment_products)
-    )
-    clean_results = (
-        run_rmclean_3d(rm_synth_results=synth_results, rmclean_options=rmclean_options)
-        if run_clean
-        else None
-    )
+    run_clean = clean_results is not None
 
     fdf_sources = {"dirty": synth_results.fdf_dirty_cube}
     if clean_results is not None:
         fdf_sources["clean"] = clean_results.clean_fdf_cube
         fdf_sources["model"] = clean_results.model_fdf_cube
 
-    # Cubes written to zarr are stored chunk-by-chunk (one worker writing its
-    # own chunk directly) and so must NOT also be gathered to numpy here --
-    # only labels also needed for moments (small, cheap to gather) go through
-    # the numpy path below.
-    write_cubes_as_zarr = rmsynth_options.write_fdfs_to_zarr and bool(cube_products)
-    zarr_store_path = Path(f"{output_prefix}.fdf.zarr") if write_cubes_as_zarr else None
-    numpy_cube_labels = set() if write_cubes_as_zarr else set(cube_products)
+    # FDF cubes are only ever written to zarr, chunk-by-chunk with each worker
+    # writing its own chunk. Gathering an (n_phi, ny, nx) cube into this process
+    # to write it as FITS is tens of GB on a real mosaic.
+    zarr_store_path = Path(f"{output_prefix}.fdf.zarr") if cube_products else None
 
-    needed_labels = numpy_cube_labels | set(moment_products)
-    compute_targets: dict[str, dask.array.Array] = {
-        label: fdf_sources[label] for label in needed_labels
-    }
-    if write_cubes_as_zarr:
-        for label in cube_products:
-            compute_targets[f"zarr_{label}"] = fdf_sources[label].to_zarr(
-                str(zarr_store_path), component=label, overwrite=True, compute=False
+    # Blockwise fusion has to be off for both the `dask.array.store` below and
+    # the `dask.compute` at the end of this function, or the FDF cubes cost an
+    # extra RM-CLEAN pass each -- see the comment on `zarr_arrays`. Only worth it
+    # when a cube is actually requested: with fusion off, dask keeps each
+    # elementwise step of a moment reduction as its own chunk-sized key instead
+    # of folding it into the task that produced it, which raises peak memory on
+    # the moment-only path (the default) for no gain there.
+    fuse_config = {"optimization.fuse.active": False} if cube_products else {}
+
+    compute_targets: dict[str, Any] = {}
+    if cube_products:
+        # One `dask.array.store` for every cube, fusion off. `to_zarr` runs its
+        # own `store`, which optimises the graph it captures and fuses the shared
+        # per-chunk RM-CLEAN task into each cube's private copy -- so asking for
+        # two cubes ran RM-CLEAN twice. The copy is made when the `Delayed` is
+        # built, so `optimize_graph` at compute time cannot undo it.
+        zarr_arrays = [
+            zarr.create(
+                shape=fdf_sources[label].shape,
+                chunks=[chunk[0] for chunk in fdf_sources[label].chunks],
+                dtype=fdf_sources[label].dtype,
+                store=str(zarr_store_path),
+                path=label,
+                overwrite=True,
             )
-    # stokes_i_alpha_error_map is None unless estimate_stokes_i_noise (or a
-    # supplied Stokes I error) gives the fit something to propagate; the other
-    # maps are None only if the Stokes I fit didn't run at all. Skip whichever
-    # are None rather than feeding them to dask.compute/FITS writers.
+            for label in cube_products
+        ]
+        with dask.config.set(fuse_config):
+            compute_targets["zarr_cubes"] = dask.array.store(
+                [fdf_sources[label] for label in cube_products],
+                zarr_arrays,
+                lock=False,
+                compute=False,
+            )
+        # Without the Faraday depth axis the cubes are not self-describing. Tiny,
+        # and with no upstream graph to share, so it is written here and now.
+        zarr.create(
+            shape=synth_results.phi_arr_radm2.shape,
+            chunks=synth_results.phi_arr_radm2.shape,
+            dtype=synth_results.phi_arr_radm2.dtype,
+            store=str(zarr_store_path),
+            path="phi_arr_radm2",
+            overwrite=True,
+        )[:] = synth_results.phi_arr_radm2
+
+    # Moments enter the batch as their lazy (ny, nx) maps, never as the FDF cube
+    # they reduce: gathering the cube here would pull the whole (n_phi, ny, nx)
+    # array into this one worker, which for a mosaic-sized cube is tens of GB per
+    # requested label.
+    #
+    # Every FDF gets the same amplitude cut, the dirty one included. mom0 is
+    # sum(|FDF|) over the whole Faraday depth axis, so with no cut an off-source
+    # pixel integrates hundreds of noise samples into a large positive floor
+    # (mom1/mom2 are then weighted by that noise and mean nothing). rm-lite
+    # applies this same cut inside RM-CLEAN to its own moment maps, which flint
+    # does not use, so it is rederived here from the shared theoretical noise.
+    moment_threshold = (
+        rmclean_options.moment_threshold_snr
+        * synth_results.theoretical_noise.fdf_error_noise
+    )
+    for label in moment_products:
+        moments = _lazy_faraday_moments(
+            fdf_cube=fdf_sources[label],
+            synth_results=synth_results,
+            threshold=moment_threshold,
+        )
+        for name, moment_map in zip(_MOMENT_NAMES, moments):
+            compute_targets[f"moment.{label}.{name}"] = moment_map
+        if rmsynth_options.debias_moments:
+            debiased = _lazy_faraday_moments(
+                fdf_cube=fdf_sources[label],
+                synth_results=synth_results,
+                threshold=None,
+                debias=True,
+                debias_filter_size=rmsynth_options.debias_filter_size,
+            )
+            for name, moment_map in zip(_MOMENT_NAMES, debiased):
+                compute_targets[f"debiased.{label}.{name}"] = moment_map
+    # stokes_i_alpha_error_map is None unless compute_model_error gives the fit
+    # something to propagate; the other maps are None only if the Stokes I fit
+    # didn't run at all. Skip whichever are None rather than feeding them to
+    # dask.compute/FITS writers.
     stokes_i_maps = {
         "stokes_i_ref_flux": synth_results.stokes_i_ref_flux_map,
         "stokes_i_alpha": synth_results.stokes_i_alpha_map,
         "stokes_i_alpha_error": synth_results.stokes_i_alpha_error_map,
         "stokes_i_model_order": synth_results.stokes_i_model_order_map,
     }
-    stokes_i_maps = {k: v for k, v in stokes_i_maps.items() if v is not None}
+    # Cast before the gather, not after. rm-lite builds these in float64 and the
+    # FITS writers put them out as float32, so gathering them at full width buys
+    # nothing and doubles what this one process has to hold: at 16032^2 each plane
+    # is 2.1 GB as float64 against 1.0 GB as float32.
+    stokes_i_maps = {
+        k: v.astype(np.float32) for k, v in stokes_i_maps.items() if v is not None
+    }
     compute_targets.update(stokes_i_maps)
+
+    # The fitted Stokes I model terms, (n_coeff, ny, nx) each -- n_coeff of the
+    # maps above rather than anything cube-sized, since n_coeff is 3 or 4. Both
+    # are None unless a Stokes I cube was actually *fitted*: a supplied model has
+    # no fitted terms to report. They are batched here and split into one named
+    # map per term after the compute.
+    stokes_i_coeff_cubes = {
+        "stokes_i_coeff": synth_results.stokes_i_coeff_cube,
+        "stokes_i_coeff_error": synth_results.stokes_i_coeff_error_cube,
+    }
+    stokes_i_coeff_cubes = {
+        k: v.astype(np.float32)
+        for k, v in stokes_i_coeff_cubes.items()
+        if v is not None
+    }
+    compute_targets.update(stokes_i_coeff_cubes)
 
     # Batch every lazy array/delayed write needed by the requested products
     # into a single dask.compute call, including the zarr writes above:
@@ -354,7 +557,7 @@ def rmsynth_and_write_products(
     #
     # Per rm-lite's dask parallelisation guide: the threaded scheduler suits
     # the GIL-releasing NUFFT (dirty-only), but RM-CLEAN/Stokes-I fitting are
-    # GIL-bound Python loops that need the process scheduler -- unless a
+    # GIL-bound Python loops that need the process scheduler, unless a
     # distributed Client is given, in which case it takes over entirely.
     scheduler = (
         dask_client
@@ -362,56 +565,36 @@ def rmsynth_and_write_products(
         else ("processes" if run_clean else "threads")
     )
     compute_keys = list(compute_targets.keys())
+    with dask.config.set(fuse_config):
+        computed_values = dask.compute(
+            *(compute_targets[key] for key in compute_keys), scheduler=scheduler
+        )
     computed = dict(
         zip(
             compute_keys,
-            dask.compute(
-                *(compute_targets[key] for key in compute_keys), scheduler=scheduler
-            ),
+            computed_values,
         )
     )
 
     reference_header = fits.getheader(stokes_q_cube)
-    clean_moment_threshold = (
-        rmclean_options.moment_threshold_snr
-        * synth_results.theoretical_noise.fdf_error_noise
-    )
-    moment_thresholds: dict[FDFLabel, float | None] = {
-        "dirty": None,
-        "clean": clean_moment_threshold,
-        "model": clean_moment_threshold,
-    }
 
     output_paths: list[Path] = []
-    if write_cubes_as_zarr:
-        assert zarr_store_path is not None
+    if zarr_store_path is not None:
         output_paths.append(zarr_store_path)
-    else:
-        for label in cube_products:
-            output_path = create_image_cube_name(
-                image_prefix=output_prefix, mode="fdf", suffix=label
-            )
-            output_paths.append(
-                write_fdf_cube_to_fits(
-                    fdf_cube=computed[label],
-                    phi_arr_radm2=synth_results.phi_arr_radm2,
-                    reference_header=reference_header,
-                    output_path=output_path,
-                )
-            )
     for label in moment_products:
         output_paths.extend(
             write_moment_maps_to_fits(
-                fdf_cube=computed[label],
-                phi_arr_radm2=synth_results.phi_arr_radm2,
-                fwhm_rmsf_radm2=synth_results.fwhm_rmsf_radm2,
+                moments=FaradayMoments(
+                    *(computed[f"moment.{label}.{name}"] for name in _MOMENT_NAMES)
+                ),
                 reference_header=reference_header,
                 output_prefix=output_prefix,
                 label=label,
-                threshold=moment_thresholds[label],
-                debias=rmsynth_options.debias_moments,
-                lam_sq_0_m2=synth_results.lam_sq_0_m2,
-                debias_filter_size=rmsynth_options.debias_filter_size,
+                debiased_moments=FaradayMoments(
+                    *(computed[f"debiased.{label}.{name}"] for name in _MOMENT_NAMES)
+                )
+                if rmsynth_options.debias_moments
+                else None,
             )
         )
 
@@ -421,7 +604,31 @@ def rmsynth_and_write_products(
                 stokes_i_maps={key: computed[key] for key in stokes_i_maps},
                 reference_header=reference_header,
                 output_prefix=output_prefix,
+                ref_freq_hz=synth_results.stokes_i_ref_freq_hz,
+                fit_function=rmsynth_options.fit_function,
             )
         )
+
+    if "stokes_i_coeff" in stokes_i_coeff_cubes:
+        # The plane names are what make the terms usable, so without them the
+        # maps are not worth writing -- but they arrive with the cube, so this
+        # would take an rm-lite change to reach.
+        if synth_results.stokes_i_coeff_names is None:
+            logger.warning(
+                "rm-lite returned Stokes I model terms with no names for them, so "
+                "the per-term maps cannot be written."
+            )
+        else:
+            output_paths.extend(
+                write_stokes_i_coeff_maps_to_fits(
+                    coeff_cube=computed["stokes_i_coeff"],
+                    coeff_names=synth_results.stokes_i_coeff_names,
+                    reference_header=reference_header,
+                    output_prefix=output_prefix,
+                    ref_freq_hz=synth_results.stokes_i_ref_freq_hz,
+                    fit_function=rmsynth_options.fit_function,
+                    coeff_error_cube=computed.get("stokes_i_coeff_error"),
+                )
+            )
 
     return output_paths

--- a/flint/rmsynth.py
+++ b/flint/rmsynth.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import logging
 import os
 from pathlib import Path
 from typing import Any, Literal
@@ -119,6 +120,7 @@ def run_rmsynth_3d(
         robust=rmsynth_options.robust,
         nufft_nthreads=rmsynth_options.nufft_nthreads,
         target_chunk_mb=rmsynth_options.target_chunk_mb,
+        log_level=logging.INFO,
         # `per_pixel_rmsf` is deliberately left off. A pixel's RMSF depends only
         # on which channels it has flagged, and flint flags per channel, so the
         # single `rmsf_arr` spectrum rm-lite returns describes the whole cube. The
@@ -148,6 +150,7 @@ def run_rmclean_3d(
         max_iter=rmclean_options.max_iter,
         gain=rmclean_options.gain,
         moment_threshold_snr=rmclean_options.moment_threshold_snr,
+        log_level=logging.INFO,
     )
 
 

--- a/flint/rmsynth.py
+++ b/flint/rmsynth.py
@@ -820,10 +820,7 @@ def write_rm_products(
         "stokes_i_alpha_error": synth_results.stokes_i_alpha_error_map,
         "stokes_i_model_order": synth_results.stokes_i_model_order_map,
     }
-    # Cast before the gather, not after. rm-lite builds these in float64 and the
-    # FITS writers put them out as float32, so gathering them at full width buys
-    # nothing and doubles what this one process has to hold: at 16032^2 each plane
-    # is 2.1 GB as float64 against 1.0 GB as float32.
+    # rm-lite builds these in float64
     stokes_i_maps = {
         k: v.astype(np.float32) for k, v in stokes_i_maps.items() if v is not None
     }

--- a/flint/rmsynth.py
+++ b/flint/rmsynth.py
@@ -37,7 +37,9 @@ from rm_lite.tools_3d.rmsynth import (  # noqa: E402
 )
 from rm_lite.utils.synthesis import (  # noqa: E402
     FaradayMoments,
+    FaradayPeaks,
     calc_faraday_moments,
+    calc_faraday_peaks,
 )
 
 from flint.exceptions import NotSupportedError
@@ -47,21 +49,40 @@ from flint.options import RMCleanOptions, RMSynthOptions
 FDFLabel = Literal["dirty", "clean", "model"]
 _MOMENT_NAMES = ("mom0", "mom1", "mom2")
 
+# The FDF peak statistics, as {FaradayPeaks field: (file suffix, BUNIT, comment)}.
+# Units matter more here than for the moments: three of these are angles in
+# degrees and two are Faraday depths, so a map with no BUNIT is easy to misread.
+_PEAK_MAPS = {
+    "peak_pi": ("peak_pi", "Jy/beam", "peak polarised intensity"),
+    "peak_pi_debias": ("peak_pi_debias", "Jy/beam", "debiased peak"),
+    "peak_pi_error": ("peak_pi_error", "Jy/beam", "1-sigma on the peak"),
+    "peak_rm_radm2": ("peak_rm", "rad/m2", "Faraday depth of the peak"),
+    "peak_rm_error_radm2": ("peak_rm_error", "rad/m2", "1-sigma on the depth"),
+    "peak_pa_deg": ("peak_pa", "deg", "polarisation angle at the peak"),
+    "peak_pa_error_deg": ("peak_pa_error", "deg", "1-sigma on the angle"),
+    "peak_pa0_deg": ("peak_pa0", "deg", "intrinsic polarisation angle"),
+    "peak_pa0_error_deg": ("peak_pa0_error", "deg", "1-sigma on the intrinsic angle"),
+}
+
 
 def needs_rmclean(
-    cube_products: list[FDFLabel], moment_products: list[FDFLabel]
+    cube_products: list[FDFLabel],
+    moment_products: list[FDFLabel],
+    peak_products: list[FDFLabel] | None = None,
 ) -> bool:
     """Whether any requested product requires RM-CLEAN to be run.
 
     Args:
         cube_products (list[FDFLabel]): Requested FDF cubes
         moment_products (list[FDFLabel]): Requested Faraday moment maps
+        peak_products (list[FDFLabel] | None, optional): Requested FDF peak-statistic maps. Defaults to None.
 
     Returns:
         bool: True if RM-CLEAN is needed
     """
     return any(
-        label in ("clean", "model") for label in (*cube_products, *moment_products)
+        label in ("clean", "model")
+        for label in (*cube_products, *moment_products, *(peak_products or ()))
     )
 
 
@@ -141,6 +162,7 @@ def run_rmsynth_3d(
         phi_max_radm2=rmsynth_options.phi_max_radm2,
         d_phi_radm2=rmsynth_options.d_phi_radm2,
         n_samples=rmsynth_options.n_samples,
+        lam_sq_0_m2=rmsynth_options.lam_sq_0_m2,
         weight_type=rmsynth_options.weight_type,
         robust=rmsynth_options.robust,
         per_pixel_rmsf=rmsynth_options.per_pixel_rmsf,
@@ -547,6 +569,69 @@ def _compute_rm_products(
     return computed
 
 
+def write_rmclean_niter_map_to_fits(
+    niter_map: np.ndarray, reference_header: fits.Header, output_prefix: Path
+) -> Path:
+    """Write the per-pixel RM-CLEAN iteration count.
+
+    One small integer map, written whenever RM-CLEAN runs rather than on
+    request: it is the map that answers "why does this field look wrong" --
+    where CLEAN hit ``max_iter`` instead of converging on the threshold -- and
+    that question gets asked after the run, when producing it on demand would
+    mean repeating the whole stage.
+
+    Args:
+        niter_map (np.ndarray): Computed (ny, nx) iteration count
+        reference_header (fits.Header): Header to derive the spatial WCS from
+        output_prefix (Path): Common prefix for the output file
+
+    Returns:
+        Path: The written map path
+    """
+    header = WCS(reference_header).celestial.to_header()
+    header["BUNIT"] = ("", "CLEAN iterations")
+    output_path = Path(f"{output_prefix}.fdf.clean.niter.fits")
+    # int32 rather than rm-lite's int64: max_iter is 1e5 by default, so half the
+    # bytes carry every value this can hold
+    fits.writeto(
+        output_path, np.asarray(niter_map, dtype=np.int32), header, overwrite=True
+    )
+    return output_path
+
+
+def write_peak_maps_to_fits(
+    peaks: FaradayPeaks,
+    reference_header: fits.Header,
+    output_prefix: Path,
+    label: FDFLabel,
+) -> list[Path]:
+    """Write the already-computed FDF peak-statistic maps to FITS.
+
+    Args:
+        peaks (FaradayPeaks): Computed peak maps, each (ny, nx)
+        reference_header (fits.Header): Header to derive the spatial WCS from
+        output_prefix (Path): Common prefix for the output files
+        label (FDFLabel): Which FDF the peaks came from, used to name the outputs
+
+    Returns:
+        list[Path]: The written map paths, nine per FDF
+    """
+    celestial = WCS(reference_header).celestial.to_header()
+    output_paths = []
+    for field, (suffix, unit, comment) in _PEAK_MAPS.items():
+        header = celestial.copy()
+        header["BUNIT"] = (unit, comment)
+        output_path = Path(f"{output_prefix}.fdf.{label}.{suffix}.fits")
+        fits.writeto(
+            output_path,
+            np.asarray(getattr(peaks, field), dtype=np.float32),
+            header,
+            overwrite=True,
+        )
+        output_paths.append(output_path)
+    return output_paths
+
+
 def write_rm_products(
     synth_results: RMSynth3DResults,
     clean_results: RMClean3DResults | None,
@@ -557,6 +642,7 @@ def write_rm_products(
     moment_products: list[FDFLabel],
     output_prefix: Path,
     dask_client: Client | None = None,
+    peak_products: list[FDFLabel] | None = None,
 ) -> list[Path]:
     """Batch-compute and write the requested RM-synthesis/RM-CLEAN output products.
 
@@ -568,6 +654,7 @@ def write_rm_products(
         rmclean_options (RMCleanOptions): Options controlling RM-CLEAN
         cube_products (list[FDFLabel]): Which FDF cube(s) to write ('dirty', 'clean', 'model')
         moment_products (list[FDFLabel]): Which FDF(s) to compute Faraday moment maps from
+        peak_products (list[FDFLabel] | None, optional): Which FDF(s) to write peak-statistic maps from, nine per entry. Defaults to None.
         output_prefix (Path): Common prefix for the output files
         dask_client (Client | None, optional): A distributed Client (e.g. the one backing a Prefect ``DaskTaskRunner``) to compute across, rather than just the local worker. Defaults to None.
 
@@ -670,6 +757,31 @@ def write_rm_products(
             )
             for name, moment_map in zip(_MOMENT_NAMES, debiased):
                 compute_targets[f"debiased.{label}.{name}"] = moment_map
+    # Unconditional whenever RM-CLEAN ran: one small integer map, and the
+    # diagnostic you want already written rather than a stage to repeat.
+    if run_clean:
+        assert clean_results is not None  # run_clean is `clean_results is not None`
+        compute_targets["rmclean_niter"] = clean_results.iter_count_map
+
+    # rm-lite returns peaks of its own on RMClean3DResults, but only for the
+    # clean FDF and only under its own threshold. Deriving them here is what
+    # lets any requested FDF have them -- the dirty one included, which needs no
+    # RM-CLEAN at all -- under the same cut flint gives its moments.
+    for label in peak_products or ():
+        peaks = calc_faraday_peaks(
+            fdf_sources[label],
+            phi_arr_radm2=synth_results.phi_arr_radm2,
+            fwhm_rmsf_radm2=synth_results.fwhm_rmsf_radm2,
+            fdf_error=synth_results.theoretical_noise.fdf_error_noise,
+            lam_sq_0_m2=synth_results.lam_sq_0_m2,
+            lambda_sq_arr_m2=synth_results.lambda_sq_arr_m2,
+            threshold=moment_threshold,
+        )
+        for field in _PEAK_MAPS:
+            compute_targets[f"peak.{label}.{field}"] = getattr(peaks, field).astype(
+                np.float32
+            )
+
     # stokes_i_alpha_error_map is None unless compute_model_error gives the fit
     # something to propagate; the other maps are None only if the Stokes I fit
     # didn't run at all. Skip whichever are None rather than feeding them to
@@ -747,6 +859,27 @@ def write_rm_products(
                 )
                 if rmsynth_options.debias_moments
                 else None,
+            )
+        )
+
+    if "rmclean_niter" in computed:
+        output_paths.append(
+            write_rmclean_niter_map_to_fits(
+                niter_map=computed["rmclean_niter"],
+                reference_header=reference_header,
+                output_prefix=output_prefix,
+            )
+        )
+
+    for label in peak_products or ():
+        output_paths.extend(
+            write_peak_maps_to_fits(
+                peaks=FaradayPeaks(
+                    **{field: computed[f"peak.{label}.{field}"] for field in _PEAK_MAPS}
+                ),
+                reference_header=reference_header,
+                output_prefix=output_prefix,
+                label=label,
             )
         )
 

--- a/flint/rmsynth.py
+++ b/flint/rmsynth.py
@@ -93,10 +93,15 @@ def run_rmsynth_3d(
         stokes_u_cube (Path): Path to the Stokes U FITS cube
         rmsynth_options (RMSynthOptions): Options controlling the synthesis
         stokes_i_cube (Path | None, optional): Path to a Stokes I FITS cube, used to fit a per-pixel fractional-polarisation correction. FDF stays in Q/U flux if not given. Defaults to None.
+        stokes_q_weight_cube (Path | None, optional): Path to the linmos Stokes Q weight cube, giving each pixel its own channel weights rather than one spectrum estimated from the Q/U cubes. rm-lite requires both Q and U, or neither. Defaults to None.
+        stokes_u_weight_cube (Path | None, optional): Path to the linmos Stokes U weight cube. See ``stokes_q_weight_cube``. Defaults to None.
+        stokes_i_weight_cube (Path | None, optional): Path to the linmos Stokes I weight cube, used to weight the per-pixel Stokes I fit and to score it against ``stokes_i_snr_cut``. Falls back to ``RMSynthOptions.estimate_stokes_i_noise`` if not given. Defaults to None.
 
     Returns:
-        RMSynth3DResults: Lazy dirty FDF cube, the RMSF spectrum every pixel
-        shares, and associated parameters
+        RMSynth3DResults: Lazy dirty FDF cube, the RMSF, and associated
+        parameters. The linmos weights vary with the primary beam, so pixels
+        rarely share one RMSF and rm-lite turns on the per-pixel RMSF cube
+        itself; see ``RMSynthOptions.per_pixel_rmsf`` for what that costs
     """
     _check_cubes_memmappable(
         stokes_q_cube,
@@ -104,6 +109,7 @@ def run_rmsynth_3d(
         stokes_i_cube,
         stokes_q_weight_cube,
         stokes_u_weight_cube,
+        stokes_i_weight_cube,
     )
     stokes_i_kwargs = (
         {
@@ -112,6 +118,9 @@ def run_rmsynth_3d(
             "fit_order": rmsynth_options.fit_order,
             "fit_function": rmsynth_options.fit_function,
             "stokes_i_snr_cut": rmsynth_options.stokes_i_snr_cut,
+            # Only consulted when no Stokes I weight cube is given: rm-lite
+            # refuses a stokes_i_snr_cut it has no error to measure against.
+            "estimate_stokes_i_noise": rmsynth_options.estimate_stokes_i_noise,
             "compute_model_error": rmsynth_options.compute_model_error,
             "n_error_samples": rmsynth_options.n_error_samples,
         }
@@ -123,12 +132,15 @@ def run_rmsynth_3d(
         stokes_u_file=stokes_u_cube,
         stokes_q_error_file=stokes_q_weight_cube,
         stokes_u_error_file=stokes_u_weight_cube,
+        # linmos writes 1/sigma**2 directly, so rm-lite must not invert and
+        # square these again. Applies to the Stokes I error cube as well
         noise_files_are_weight=True,
         phi_max_radm2=rmsynth_options.phi_max_radm2,
         d_phi_radm2=rmsynth_options.d_phi_radm2,
         n_samples=rmsynth_options.n_samples,
         weight_type=rmsynth_options.weight_type,
         robust=rmsynth_options.robust,
+        per_pixel_rmsf=rmsynth_options.per_pixel_rmsf,
         nufft_nthreads=rmsynth_options.nufft_nthreads,
         target_chunk_mb=rmsynth_options.target_chunk_mb,
         log_level=logging.INFO,

--- a/flint/rmsynth.py
+++ b/flint/rmsynth.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from typing import Literal
 
@@ -11,6 +12,7 @@ import dask
 import numpy as np
 from astropy.io import fits
 from astropy.wcs import WCS
+from dask.distributed import Client
 from rm_lite.tools_3d.rmclean import RMClean3DResults, run_rmclean_from_synth
 from rm_lite.tools_3d.rmsynth import RMSynth3DResults, rmsynth_3d_from_fits
 from rm_lite.utils.synthesis import calc_faraday_moments
@@ -46,6 +48,8 @@ def run_rmsynth_3d(
             "fit_function": rmsynth_options.fit_function,
             "stokes_i_snr_cut": rmsynth_options.stokes_i_snr_cut,
             "estimate_stokes_i_noise": rmsynth_options.estimate_stokes_i_noise,
+            "compute_model_error": rmsynth_options.compute_model_error,
+            "n_error_samples": rmsynth_options.n_error_samples,
         }
         if stokes_i_cube is not None
         else {}
@@ -131,6 +135,9 @@ def write_moment_maps_to_fits(
     output_prefix: Path,
     label: FDFLabel,
     threshold: float | None = None,
+    debias: bool = False,
+    lam_sq_0_m2: float | None = None,
+    debias_filter_size: int = 5,
 ) -> list[Path]:
     """Compute and write the mom0/mom1/mom2 Faraday moment maps of an FDF cube.
 
@@ -141,7 +148,10 @@ def write_moment_maps_to_fits(
         reference_header (fits.Header): Header to derive the spatial WCS from (e.g. the Stokes Q cube header)
         output_prefix (Path): Common prefix for the output files
         label (FDFLabel): Which FDF ``fdf_cube`` is ('dirty', 'clean', or 'model'), used to name the outputs
-        threshold (float | None, optional): Amplitude cut applied before computing the moments. Defaults to None.
+        threshold (float | None, optional): Amplitude cut applied before computing the moments. Ignored if debias is True. Defaults to None.
+        debias (bool, optional): Debias mom0 via rm_lite's debias_fdf instead of thresholding. Requires lam_sq_0_m2. Defaults to False.
+        lam_sq_0_m2 (float | None, optional): Reference wavelength^2, required if debias is True. Defaults to None.
+        debias_filter_size (int, optional): Median filter size (pixels) used by debiasing. Defaults to 5.
 
     Returns:
         list[Path]: The three written moment-map paths (mom0, mom1, mom2)
@@ -150,7 +160,10 @@ def write_moment_maps_to_fits(
         fdf_cube,
         phi_arr_radm2=phi_arr_radm2,
         fwhm_rmsf_radm2=fwhm_rmsf_radm2,
-        threshold=threshold,
+        threshold=None if debias else threshold,
+        debias=debias,
+        lam_sq_0_m2=lam_sq_0_m2,
+        debias_filter_size=debias_filter_size,
     )
     header = WCS(reference_header).celestial.to_header()
     output_paths = []
@@ -159,6 +172,41 @@ def write_moment_maps_to_fits(
     ):
         output_path = Path(f"{output_prefix}.fdf.{label}.{moment_name}.fits")
         fits.writeto(output_path, np.asarray(moment_map, dtype=np.float32), header, overwrite=True)
+        output_paths.append(output_path)
+    return output_paths
+
+
+_STOKES_I_MAP_SUFFIXES = {
+    "stokes_i_ref_flux": "stokesi.ref_flux",
+    "stokes_i_alpha": "stokesi.alpha",
+    "stokes_i_alpha_error": "stokesi.alpha_error",
+    "stokes_i_model_order": "stokesi.model_order",
+}
+
+
+def write_stokes_i_fit_maps_to_fits(
+    stokes_i_maps: dict[str, np.ndarray],
+    reference_header: fits.Header,
+    output_prefix: Path,
+) -> list[Path]:
+    """Write the per-pixel Stokes I fractional-polarisation fit maps: the fitted
+    reference flux, spectral index (alpha) and its error, and the fitted
+    polynomial order. Cheap 2D maps, always written when a Stokes I cube is used
+    and rm-lite actually returned that particular map (e.g. ``alpha_error`` is
+    only produced if a Stokes I noise estimate was available).
+
+    Args:
+        stokes_i_maps (dict[str, np.ndarray]): Already-computed maps, keyed by
+            one of ``_STOKES_I_MAP_SUFFIXES``'s keys.
+
+    Returns:
+        list[Path]: The written map paths, one per entry in ``stokes_i_maps``
+    """
+    header = WCS(reference_header).celestial.to_header()
+    output_paths = []
+    for key, data in stokes_i_maps.items():
+        output_path = Path(f"{output_prefix}.{_STOKES_I_MAP_SUFFIXES[key]}.fits")
+        fits.writeto(output_path, np.asarray(data, dtype=np.float32), header, overwrite=True)
         output_paths.append(output_path)
     return output_paths
 
@@ -172,6 +220,7 @@ def rmsynth_and_write_products(
     moment_products: list[FDFLabel],
     output_prefix: Path,
     stokes_i_cube: Path | None = None,
+    dask_client: Client | None = None,
 ) -> list[Path]:
     """Run RM-synthesis (and RM-CLEAN if needed) and write the requested output products.
 
@@ -184,6 +233,7 @@ def rmsynth_and_write_products(
         moment_products (list[FDFLabel]): Which FDF(s) to compute Faraday moment maps from
         output_prefix (Path): Common prefix for the output files
         stokes_i_cube (Path | None, optional): Path to a Stokes I FITS cube for the fractional-polarisation correction. Defaults to None.
+        dask_client (Client | None, optional): A distributed Client (e.g. the one backing a Prefect ``DaskTaskRunner``) to compute across, rather than just the local worker. Defaults to None.
 
     Returns:
         list[Path]: Every FITS path written
@@ -191,6 +241,12 @@ def rmsynth_and_write_products(
     if not cube_products and not moment_products:
         logger.info("No RM-synthesis products requested, skipping.")
         return []
+
+    if os.environ.get("OMP_NUM_THREADS") != "1":
+        logger.warning(
+            "OMP_NUM_THREADS is not set to '1'. rm-lite's dask parallelisation guide "
+            "warns this oversubscribes cores when combined with Dask-level parallelism."
+        )
 
     synth_results = run_rmsynth_3d(
         stokes_q_cube=stokes_q_cube,
@@ -211,12 +267,37 @@ def rmsynth_and_write_products(
         fdf_sources["clean"] = clean_results.clean_fdf_cube
         fdf_sources["model"] = clean_results.model_fdf_cube
 
+    needed_labels = {*cube_products, *moment_products}
+    compute_targets: dict[str, dask.array.Array] = {
+        label: fdf_sources[label] for label in needed_labels
+    }
+    # stokes_i_alpha_error_map is None unless estimate_stokes_i_noise (or a
+    # supplied Stokes I error) gives the fit something to propagate; the other
+    # maps are None only if the Stokes I fit didn't run at all. Skip whichever
+    # are None rather than feeding them to dask.compute/FITS writers.
+    stokes_i_maps = {
+        "stokes_i_ref_flux": synth_results.stokes_i_ref_flux_map,
+        "stokes_i_alpha": synth_results.stokes_i_alpha_map,
+        "stokes_i_alpha_error": synth_results.stokes_i_alpha_error_map,
+        "stokes_i_model_order": synth_results.stokes_i_model_order_map,
+    }
+    stokes_i_maps = {k: v for k, v in stokes_i_maps.items() if v is not None}
+    compute_targets.update(stokes_i_maps)
+
     # Batch every lazy array needed by the requested products into a single
     # dask.compute call: computing per-product in a loop would redo the shared
-    # synthesis/RM-CLEAN graph once per product instead of once total.
-    needed_labels = {*cube_products, *moment_products}
+    # synthesis/RM-CLEAN graph once per product instead of once total. Per
+    # rm-lite's dask parallelisation guide: the threaded scheduler suits the
+    # GIL-releasing NUFFT (dirty-only), but RM-CLEAN/Stokes-I fitting are
+    # GIL-bound Python loops that need the process scheduler -- unless a
+    # distributed Client is given, in which case it takes over entirely.
+    scheduler = dask_client if dask_client is not None else ("processes" if run_clean else "threads")
+    compute_keys = list(compute_targets.keys())
     computed = dict(
-        zip(needed_labels, dask.compute(*(fdf_sources[label] for label in needed_labels)))
+        zip(
+            compute_keys,
+            dask.compute(*(compute_targets[key] for key in compute_keys), scheduler=scheduler),
+        )
     )
 
     reference_header = fits.getheader(stokes_q_cube)
@@ -252,6 +333,18 @@ def rmsynth_and_write_products(
                 output_prefix=output_prefix,
                 label=label,
                 threshold=moment_thresholds[label],
+                debias=rmsynth_options.debias_moments,
+                lam_sq_0_m2=synth_results.lam_sq_0_m2,
+                debias_filter_size=rmsynth_options.debias_filter_size,
+            )
+        )
+
+    if stokes_i_maps:
+        output_paths.extend(
+            write_stokes_i_fit_maps_to_fits(
+                stokes_i_maps={key: computed[key] for key in stokes_i_maps},
+                reference_header=reference_header,
+                output_prefix=output_prefix,
             )
         )
 

--- a/flint/rmsynth.py
+++ b/flint/rmsynth.py
@@ -30,6 +30,7 @@ os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "TRUE")
 
 from rm_lite.tools_3d.rmclean import (  # noqa: E402
     RMClean3DResults,
+    faraday_maps,
     run_rmclean_from_synth,
 )
 from rm_lite.tools_3d.rmsynth import (  # noqa: E402
@@ -40,7 +41,6 @@ from rm_lite.utils.synthesis import (  # noqa: E402
     FaradayMoments,
     FaradayPeaks,
     calc_faraday_moments,
-    calc_faraday_peaks,
 )
 
 from flint.exceptions import NotSupportedError
@@ -801,16 +801,26 @@ def write_rm_products(
         moment_threshold_snr,
         synth_results.theoretical_noise.fdf_error_noise,
     )
-    for label in moment_products:
-        moments = _lazy_faraday_moments(
-            fdf_cube=fdf_sources[label],
-            synth_results=synth_results,
-            threshold=moment_threshold,
+    # All 21 maps in one task a chunk, rather than a chain per map. Debiased
+    # maps cannot join: `debias_fdf` needs neighbouring pixels.
+    fused_maps = {
+        label: faraday_maps(
+            fdf_sources[label],
+            phi_arr_radm2=synth_results.phi_arr_radm2,
+            fwhm_rmsf_radm2=synth_results.fwhm_rmsf_radm2,
+            lam_sq_0_m2=synth_results.lam_sq_0_m2,
+            lambda_sq_arr_m2=synth_results.lambda_sq_arr_m2,
+            fdf_noise=synth_results.theoretical_noise.fdf_error_noise,
+            moment_threshold=moment_threshold,
         )
+        for label in dict.fromkeys((*moment_products, *peak_products))
+    }
+
+    for label in moment_products:
         for field in MOMENT_MAPS:
-            compute_targets[f"moment.{label}.{field}"] = getattr(moments, field).astype(
-                np.float32
-            )
+            compute_targets[f"moment.{label}.{field}"] = fused_maps[label][
+                field
+            ].astype(np.float32)
         if rmsynth_options.debias_moments:
             debiased = _lazy_faraday_moments(
                 fdf_cube=fdf_sources[label],
@@ -836,16 +846,8 @@ def write_rm_products(
     # single sample with no such floor, and ``peak_pi_error`` is written beside
     # it, so ``peak_pi / peak_pi_error`` is the SNR to select on afterwards.
     for label in peak_products:
-        peaks = calc_faraday_peaks(
-            fdf_sources[label],
-            phi_arr_radm2=synth_results.phi_arr_radm2,
-            fwhm_rmsf_radm2=synth_results.fwhm_rmsf_radm2,
-            fdf_error=synth_results.theoretical_noise.fdf_error_noise,
-            lam_sq_0_m2=synth_results.lam_sq_0_m2,
-            lambda_sq_arr_m2=synth_results.lambda_sq_arr_m2,
-        )
         for field in PEAK_MAPS:
-            compute_targets[f"peak.{label}.{field}"] = getattr(peaks, field).astype(
+            compute_targets[f"peak.{label}.{field}"] = fused_maps[label][field].astype(
                 np.float32
             )
 

--- a/flint/rmsynth.py
+++ b/flint/rmsynth.py
@@ -55,12 +55,23 @@ from flint.options import (
 
 FDFLabel: TypeAlias = Literal["dirty", "clean", "model"]
 FDFThreshold: TypeAlias = float | np.ndarray | da.Array | None
-_MOMENT_NAMES = ("mom0", "mom1", "mom2")
 
-# The FDF peak statistics, as {FaradayPeaks field: (file suffix, BUNIT, comment)}.
-# Units matter more here than for the moments: three of these are angles in
-# degrees and two are Faraday depths, so a map with no BUNIT is easy to misread.
-_PEAK_MAPS = {
+MOMENT_MAPS = {
+    "mom0": ("mom0", "Jy/beam", "zeroth moment, total polarised intensity"),
+    "mom0_debias": ("mom0_debias", "Jy/beam", "mom0 less the noise's own sum"),
+    "mom0_error": ("mom0_error", "Jy/beam", "1-sigma on mom0"),
+    "mom1": ("mom1", "rad/m2", "first moment, mean Faraday depth"),
+    "mom1_error": ("mom1_error", "rad/m2", "1-sigma on mom1"),
+    "mom2": ("mom2", "rad/m2", "second moment, Faraday depth dispersion"),
+    "mom2_error": ("mom2_error", "rad/m2", "1-sigma on mom2"),
+    "pi_lam_sq_0": ("pi_lam_sq_0", "Jy/beam", "polarised intensity at lambda^2_0"),
+    "pi_lam_sq_0_debias": ("pi_lam_sq_0_debias", "Jy/beam", "debiased pi_lam_sq_0"),
+    "pi_lam_sq_0_error": ("pi_lam_sq_0_error", "Jy/beam", "1-sigma on pi_lam_sq_0"),
+    "pa_lam_sq_0": ("pa_lam_sq_0", "deg", "polarisation angle at lambda^2_0"),
+    "pa_lam_sq_0_error": ("pa_lam_sq_0_error", "deg", "1-sigma on pa_lam_sq_0"),
+}
+
+PEAK_MAPS = {
     "peak_pi": ("peak_pi", "Jy/beam", "peak polarised intensity"),
     "peak_pi_debias": ("peak_pi_debias", "Jy/beam", "debiased peak"),
     "peak_pi_error": ("peak_pi_error", "Jy/beam", "1-sigma on the peak"),
@@ -200,46 +211,54 @@ def write_moment_maps_to_fits(
     label: FDFLabel,
     debiased_moments: FaradayMoments | None = None,
 ) -> list[Path]:
-    """Write already-computed mom0/mom1/mom2 Faraday moment maps to FITS.
+    """Write already-computed Faraday moment maps to FITS.
 
     The moments are built lazily and computed by ``write_rm_products``, which
     keeps the (n_phi, ny, nx) FDF cube they reduce out of this process; only the
     (ny, nx) maps arrive here. See ``_lazy_faraday_moments``.
 
     Args:
-        moments (FaradayMoments): Computed mom0/mom1/mom2 maps, each (ny, nx)
+        moments (FaradayMoments): Computed moment maps, each (ny, nx)
         reference_header (fits.Header): Header to derive the spatial WCS from (e.g. the Stokes Q cube header)
         output_prefix (Path): Common prefix for the output files
         label (FDFLabel): Which FDF the moments came from ('dirty', 'clean', or 'model'), used to name the outputs
         debiased_moments (FaradayMoments | None, optional): Debiased moment set, written alongside with a ``.debiased`` suffix. Defaults to None.
 
     Returns:
-        list[Path]: The written moment-map paths: three (mom0, mom1, mom2), plus
-        three more (mom0.debiased, mom1.debiased, mom2.debiased) if debiased_moments is given
+        list[Path]: One path per ``MOMENT_MAPS`` entry, plus the debiased set
+        less ``mom0_debias`` if debiased_moments is given
     """
-    header = WCS(reference_header).celestial.to_header()
+    celestial = WCS(reference_header).celestial.to_header()
 
-    def _write(moment_set: FaradayMoments, suffix: str) -> list[Path]:
+    def _write(
+        moment_set: FaradayMoments,
+        maps: dict[str, tuple[str, str, str]],
+        suffix: str,
+    ) -> list[Path]:
         written = []
-        for moment_name, moment_map in zip(
-            _MOMENT_NAMES,
-            (moment_set.mom0, moment_set.mom1, moment_set.mom2),
-        ):
-            output_path = Path(
-                f"{output_prefix}.fdf.{label}.{moment_name}{suffix}.fits"
-            )
+        for field, (name, unit, comment) in maps.items():
+            header = celestial.copy()
+            header["BUNIT"] = (unit, comment)
+            output_path = Path(f"{output_prefix}.fdf.{label}.{name}{suffix}.fits")
             fits.writeto(
                 output_path,
-                np.asarray(moment_map, dtype=np.float32),
+                np.asarray(getattr(moment_set, field), dtype=np.float32),
                 header,
                 overwrite=True,
             )
             written.append(output_path)
         return written
 
-    output_paths = _write(moments, suffix="")
+    output_paths = _write(moments, MOMENT_MAPS, suffix="")
     if debiased_moments is not None:
-        output_paths.extend(_write(debiased_moments, suffix=".debiased"))
+        # a debiased FDF leaves mom0_debias unchanged, so writing it again under
+        # a second name would read as a second measurement
+        debiased_maps = {
+            field: entry
+            for field, entry in MOMENT_MAPS.items()
+            if field != "mom0_debias"
+        }
+        output_paths.extend(_write(debiased_moments, debiased_maps, suffix=".debiased"))
 
     return output_paths
 
@@ -427,18 +446,23 @@ def _lazy_faraday_moments(
     debias: bool = False,
     debias_filter_size: int = 5,
 ) -> FaradayMoments:
-    """Build the lazy mom0/mom1/mom2 maps of an FDF cube.
+    """Build the lazy Faraday moment maps of an FDF cube.
 
     ``calc_faraday_moments`` reduces along the (never-chunked) Faraday-depth
     axis, and ``debias_fdf`` handles dask via ``map_overlap``, so the result is
-    three lazy (ny, nx) maps that each spatial chunk contributes to
+    a set of lazy (ny, nx) maps that each spatial chunk contributes to
     independently. Computing these instead of the cube itself is what keeps the
     whole FDF out of the calling worker's memory.
+
+    The theoretical noise is what turns the errors and the debiased maps from
+    NaN into measurements, so it is passed whenever synthesis reported one --
+    it is the same noise the amplitude cut is derived from.
     """
     return calc_faraday_moments(
         fdf_cube,
         phi_arr_radm2=synth_results.phi_arr_radm2,
         fwhm_rmsf_radm2=synth_results.fwhm_rmsf_radm2,
+        fdf_error=synth_results.theoretical_noise.fdf_error_noise,
         threshold=threshold,
         debias=debias,
         lam_sq_0_m2=synth_results.lam_sq_0_m2 if debias else None,
@@ -558,20 +582,27 @@ def _compute_rm_products(
         futures = scheduler.compute(
             [compute_targets[key] for key in compute_keys], sync=False
         )
-    future_to_key = dict(zip(futures, compute_keys))
+    # Products built from the same expression share a future, so the mapping is
+    # one-to-many: one key per future would drop all but the last of each group
+    future_to_keys: dict[Any, list[str]] = {}
+    for future, key in zip(futures, compute_keys):
+        future_to_keys.setdefault(future, []).append(key)
 
     computed: dict[str, Any] = {}
     with _seceded_if_on_a_worker():
-        for future in as_completed(futures):
-            key = future_to_key[future]
+        for future in as_completed(list(future_to_keys)):
+            keys = future_to_keys[future]
             # `.result()` re-raises whatever the worker raised, so a failed
             # product still surfaces here rather than being dropped
-            computed[key] = future.result()
+            result = future.result()
+            for key in keys:
+                computed[key] = result
             # Elapsed since submission, not this product's own runtime: they
             # share one graph, so "how far into the run are we" is the
             # answerable question
             logger.info(
-                f"[{len(computed):>2}/{len(compute_keys)}] {key} at {_elapsed(start)}"
+                f"[{len(computed):>2}/{len(compute_keys)}] "
+                f"{', '.join(keys)} at {_elapsed(start)}"
             )
 
     logger.info(f"Computed {len(compute_keys)} RM products in {_elapsed(start)}")
@@ -627,7 +658,7 @@ def write_peak_maps_to_fits(
     """
     celestial = WCS(reference_header).celestial.to_header()
     output_paths = []
-    for field, (suffix, unit, comment) in _PEAK_MAPS.items():
+    for field, (suffix, unit, comment) in PEAK_MAPS.items():
         header = celestial.copy()
         header["BUNIT"] = (unit, comment)
         output_path = Path(f"{output_prefix}.fdf.{label}.{suffix}.fits")
@@ -652,7 +683,6 @@ def write_rm_products(
     peak_products: list[FDFLabel],
     output_prefix: Path,
     moment_threshold_snr: float = 5.0,
-    peak_threshold_snr: float = 0.0,
     dask_client: Client | None = None,
 ) -> list[Path]:
     """Batch-compute and write the requested RM-synthesis/RM-CLEAN output products.
@@ -667,7 +697,6 @@ def write_rm_products(
         moment_products (list[FDFLabel]): Which FDF(s) to compute Faraday moment maps from
         peak_products (list[FDFLabel]): Which FDF(s) to write peak-statistic maps from, nine per entry
         moment_threshold_snr (float, optional): SNR cut applied before the moment maps. Defaults to 5.0.
-        peak_threshold_snr (float, optional): SNR cut below which peaks are blanked. Zero applies no cut. Defaults to 0.0.
         output_prefix (Path): Common prefix for the output files
         dask_client (Client | None, optional): A distributed Client (e.g. the one backing a Prefect ``DaskTaskRunner``) to compute across, rather than just the local worker. Defaults to None.
 
@@ -758,8 +787,10 @@ def write_rm_products(
             synth_results=synth_results,
             threshold=moment_threshold,
         )
-        for name, moment_map in zip(_MOMENT_NAMES, moments):
-            compute_targets[f"moment.{label}.{name}"] = moment_map
+        for field in MOMENT_MAPS:
+            compute_targets[f"moment.{label}.{field}"] = getattr(moments, field).astype(
+                np.float32
+            )
         if rmsynth_options.debias_moments:
             debiased = _lazy_faraday_moments(
                 fdf_cube=fdf_sources[label],
@@ -768,23 +799,22 @@ def write_rm_products(
                 debias=True,
                 debias_filter_size=rmsynth_options.debias_filter_size,
             )
-            for name, moment_map in zip(_MOMENT_NAMES, debiased):
-                compute_targets[f"debiased.{label}.{name}"] = moment_map
+            for field in MOMENT_MAPS:
+                compute_targets[f"debiased.{label}.{field}"] = getattr(
+                    debiased, field
+                ).astype(np.float32)
     # Unconditional whenever RM-CLEAN ran: one small integer map, and the
     # diagnostic you want already written rather than a stage to repeat.
     if run_clean:
         assert clean_results is not None  # run_clean is `clean_results is not None`
         compute_targets["rmclean_niter"] = clean_results.iter_count_map
 
-    # rm-lite's own peaks cover only the clean FDF under its own threshold;
-    # deriving them here lets any requested FDF have them, the dirty one
-    # included. Cut separately from the moments and off by default: mom0
-    # integrates the whole Faraday depth axis, a peak is one sample with no such
-    # floor, and peak_pi_error is written beside it to judge significance.
-    peak_threshold = _snr_threshold(
-        peak_threshold_snr,
-        synth_results.theoretical_noise.fdf_error_noise,
-    )
+    # rm-lite's own peaks cover only the clean FDF; deriving them here lets any
+    # requested FDF have them, the dirty one included. No amplitude cut is
+    # applied, and rm-lite no longer offers one: mom0 integrates the whole
+    # Faraday depth axis and needs a cut to keep the noise out, but a peak is a
+    # single sample with no such floor, and ``peak_pi_error`` is written beside
+    # it, so ``peak_pi / peak_pi_error`` is the SNR to select on afterwards.
     for label in peak_products:
         peaks = calc_faraday_peaks(
             fdf_sources[label],
@@ -793,9 +823,8 @@ def write_rm_products(
             fdf_error=synth_results.theoretical_noise.fdf_error_noise,
             lam_sq_0_m2=synth_results.lam_sq_0_m2,
             lambda_sq_arr_m2=synth_results.lambda_sq_arr_m2,
-            threshold=peak_threshold,
         )
-        for field in _PEAK_MAPS:
+        for field in PEAK_MAPS:
             compute_targets[f"peak.{label}.{field}"] = getattr(peaks, field).astype(
                 np.float32
             )
@@ -864,13 +893,19 @@ def write_rm_products(
         output_paths.extend(
             write_moment_maps_to_fits(
                 moments=FaradayMoments(
-                    *(computed[f"moment.{label}.{name}"] for name in _MOMENT_NAMES)
+                    **{
+                        field: computed[f"moment.{label}.{field}"]
+                        for field in MOMENT_MAPS
+                    }
                 ),
                 reference_header=reference_header,
                 output_prefix=output_prefix,
                 label=label,
                 debiased_moments=FaradayMoments(
-                    *(computed[f"debiased.{label}.{name}"] for name in _MOMENT_NAMES)
+                    **{
+                        field: computed[f"debiased.{label}.{field}"]
+                        for field in MOMENT_MAPS
+                    }
                 )
                 if rmsynth_options.debias_moments
                 else None,
@@ -890,7 +925,7 @@ def write_rm_products(
         output_paths.extend(
             write_peak_maps_to_fits(
                 peaks=FaradayPeaks(
-                    **{field: computed[f"peak.{label}.{field}"] for field in _PEAK_MAPS}
+                    **{field: computed[f"peak.{label}.{field}"] for field in PEAK_MAPS}
                 ),
                 reference_header=reference_header,
                 output_prefix=output_prefix,

--- a/flint/rmsynth.py
+++ b/flint/rmsynth.py
@@ -120,6 +120,23 @@ def _check_cubes_memmappable(*cubes: Path | None) -> None:
         raise NotSupportedError(msg)
 
 
+def check_cubes_are_single_precision(*cubes: Path | None) -> None:
+    """rm-lite takes the FDF's precision from the cubes it is given, so a
+    double-precision cube doubles every Faraday-depth array it builds. Warned
+    about rather than refused: it is a memory cost, not an error."""
+    double = [
+        cube
+        for cube in cubes
+        if cube is not None and fits.getheader(cube).get("BITPIX") == -64
+    ]
+    if double:
+        logger.warning(
+            f"{double} are double precision, so the FDF, RMSF and CLEAN cubes "
+            "will be complex128 and take twice the memory. Write the cubes as "
+            "float32 unless the extra precision is actually wanted."
+        )
+
+
 def run_rmsynth_3d(
     stokes_cubes: CubesForRMSynth,
     rmsynth_options: RMSynthOptions,
@@ -141,6 +158,7 @@ def run_rmsynth_3d(
     _check_cubes_memmappable(
         *stokes_cubes.paths, *(error_cubes.paths if error_cubes else ())
     )
+    check_cubes_are_single_precision(*stokes_cubes.paths)
     stokes_i_kwargs = (
         {
             "stokes_i_file": stokes_cubes.i_path,
@@ -175,6 +193,7 @@ def run_rmsynth_3d(
         per_pixel_rmsf=rmsynth_options.per_pixel_rmsf,
         nufft_nthreads=rmsynth_options.nufft_nthreads,
         target_chunk_mb=rmsynth_options.target_chunk_mb,
+        convert_to_zarr=rmsynth_options.convert_to_zarr,
         log_level=logging.INFO,
         **stokes_i_kwargs,
     )
@@ -427,7 +446,7 @@ def write_stokes_i_coeff_maps_to_fits(
     return output_paths
 
 
-def _snr_threshold(snr: float, fdf_error_noise: FDFThreshold) -> FDFThreshold:
+def fdf_threshold_from_snr(snr: float, fdf_error_noise: FDFThreshold) -> FDFThreshold:
     """An FDF amplitude cut ``snr`` times the theoretical noise, or None for no cut.
 
     Zero short-circuits rather than multiplying through: the noise is ``inf``
@@ -497,7 +516,8 @@ def _describe_rm_workload(
     per_pixel_rmsf = synth_results.rmsf_cube is not None
     return (
         f"{len(compute_keys)} products over {n_y}x{n_x} pixels and {n_phi} "
-        f"Faraday depths, in {n_chunks} chunks; "
+        f"Faraday depths in {fdf_cube.dtype}, in {n_chunks} chunks of "
+        f"{fdf_cube.chunksize[1]}x{fdf_cube.chunksize[2]} pixels; "
         f"per-pixel RMSF {'on' if per_pixel_rmsf else 'off'}"
     )
 
@@ -533,7 +553,7 @@ def _seceded_if_on_a_worker() -> Iterator[None]:
         rejoin()
 
 
-def _compute_rm_products(
+def compute_rm_products(
     compute_targets: dict[str, Any],
     fuse_config: dict[str, Any],
     scheduler: Client | str,
@@ -777,7 +797,7 @@ def write_rm_products(
     # (mom1/mom2 are then weighted by that noise and mean nothing). rm-lite
     # applies this same cut inside RM-CLEAN to its own moment maps, which flint
     # does not use, so it is rederived here from the shared theoretical noise.
-    moment_threshold = _snr_threshold(
+    moment_threshold = fdf_threshold_from_snr(
         moment_threshold_snr,
         synth_results.theoretical_noise.fdf_error_noise,
     )
@@ -875,7 +895,7 @@ def write_rm_products(
         if dask_client is not None
         else ("processes" if run_clean else "threads")
     )
-    computed = _compute_rm_products(
+    computed = compute_rm_products(
         compute_targets=compute_targets,
         fuse_config=fuse_config,
         scheduler=scheduler,

--- a/flint/spice.py
+++ b/flint/spice.py
@@ -13,14 +13,102 @@ from astropy.coordinates import SkyCoord
 from astropy.io import fits
 from astropy.table import Row, Table
 from astropy.wcs import WCS
-from astropy.wcs.utils import proj_plane_pixel_scales, skycoord_to_pixel
+from astropy.wcs.utils import skycoord_to_pixel
 from radio_beam import Beam
 
 from flint.coadd.linmos import BoundingBox, _merge_bound_boxes
 from flint.convol import BeamShape
-from flint.exceptions import ShapeMismatchError
 from flint.logging import logger
-from flint.options import SpiceOptions
+from flint.options import BaseOptions, SpiceOptions
+
+
+class SkyBoundingBox(BaseOptions):
+    """A bounding box on the sky, held as angular offsets from a reference position.
+
+    Offsets are on-sky angles (the longitude offset already carries the cos(dec)
+    factor), so a box may be projected onto any image's pixel grid.
+    """
+
+    reference_ra_deg: float
+    """Right ascension of the reference position, in degrees"""
+    reference_dec_deg: float
+    """Declination of the reference position, in degrees"""
+    lon_min_arcsec: float
+    """Smallest longitude offset from the reference position"""
+    lon_max_arcsec: float
+    """Largest longitude offset from the reference position"""
+    lat_min_arcsec: float
+    """Smallest latitude offset from the reference position"""
+    lat_max_arcsec: float
+    """Largest latitude offset from the reference position"""
+
+    @property
+    def corners(self) -> SkyCoord:
+        """The four corners of the box"""
+        reference = SkyCoord(
+            self.reference_ra_deg * u.deg, self.reference_dec_deg * u.deg
+        )
+        lon = (
+            np.array(
+                [
+                    self.lon_min_arcsec,
+                    self.lon_max_arcsec,
+                    self.lon_max_arcsec,
+                    self.lon_min_arcsec,
+                ]
+            )
+            * u.arcsec
+        )
+        lat = (
+            np.array(
+                [
+                    self.lat_min_arcsec,
+                    self.lat_min_arcsec,
+                    self.lat_max_arcsec,
+                    self.lat_max_arcsec,
+                ]
+            )
+            * u.arcsec
+        )
+        return reference.spherical_offsets_by(lon, lat)
+
+    def to_bounding_box(
+        self, wcs: WCS, image_shape: tuple[int, int]
+    ) -> BoundingBox | None:
+        """Project onto an image's pixel grid, or None if the box falls off it
+
+        Args:
+            wcs (WCS): WCS of the target image
+            image_shape (tuple[int, int]): Shape of a single plane of the target
+
+        Returns:
+            BoundingBox | None: The clipped pixel box, or None if fully off-image
+        """
+        x_pix, y_pix = skycoord_to_pixel(
+            wcs=wcs.celestial, coords=self.corners, origin=0
+        )
+
+        # BoundingBox.x* is numpy axis -2 (FITS NAXIS2/Dec); .y* is axis -1 (NAXIS1/RA)
+        return BoundingBox(
+            xmin=int(math.floor(float(np.min(y_pix)))),
+            xmax=int(math.ceil(float(np.max(y_pix)))) + 1,
+            ymin=int(math.floor(float(np.min(x_pix)))),
+            ymax=int(math.ceil(float(np.max(x_pix)))) + 1,
+            original_shape=image_shape,
+        ).clip()
+
+
+def _merge_sky_boxes(sky_boxes: list[SkyBoundingBox]) -> SkyBoundingBox:
+    """Smallest sky box containing all inputs. All must share a reference position"""
+    references = {(b.reference_ra_deg, b.reference_dec_deg) for b in sky_boxes}
+    assert len(references) == 1, f"Sky boxes span differing references: {references}"
+
+    return sky_boxes[0].with_options(
+        lon_min_arcsec=min(b.lon_min_arcsec for b in sky_boxes),
+        lon_max_arcsec=max(b.lon_max_arcsec for b in sky_boxes),
+        lat_min_arcsec=min(b.lat_min_arcsec for b in sky_boxes),
+        lat_max_arcsec=max(b.lat_max_arcsec for b in sky_boxes),
+    )
 
 
 def load_component_table(catalogue: Path | Table) -> Table:
@@ -31,14 +119,7 @@ def load_component_table(catalogue: Path | Table) -> Table:
 def _resolve_columns(
     table: Table, spice_options: SpiceOptions, is_user_catalogue: bool
 ) -> tuple[str | None, str, str, tuple[str, str, str] | None]:
-    """Resolve (island_col, ra_col, dec_col, shape_cols) for a catalogue.
-
-    Column names/units are never guessed for a user-supplied catalogue --
-    only the built-in Aegean catalogue has a fixed, known contract (confirmed
-    against the installed aegeantools==2.3.0 source, AegeanTools.source_finder
-    around result_to_components: island/ra/dec (deg) /a/b/pa (arcsec/arcsec/deg),
-    with a/b/pa the as-fit, PSF-convolved sizes -- no reconvolution needed here).
-    """
+    """Resolve (island_col, ra_col, dec_col, shape_cols) for a catalogue."""
     if not is_user_catalogue:
         island_col = "island" if "island" in table.colnames else None
         return island_col, "ra", "dec", ("a", "b", "pa")
@@ -48,8 +129,7 @@ def _resolve_columns(
         or spice_options.catalogue_dec_col is None
     ):
         raise ValueError(
-            "catalogue_ra_col and catalogue_dec_col must be set on SpiceOptions "
-            "for a user-supplied spice_catalogue -- these are never guessed"
+            "catalogue_ra_col and catalogue_dec_col must be set on SpiceOptions"
         )
 
     shape_cols = (
@@ -103,27 +183,27 @@ def _row_psf_beam(
     )
 
 
-def _component_box(
+def _component_sky_box(
     row: Row,
     ra_col: str,
     dec_col: str,
     shape_cols: tuple[str, str, str] | None,
     radec_unit: u.Unit,
     shape_unit: u.Unit,
-    wcs: WCS,
-    image_shape: tuple[int, int],
-    pixel_scale_ra_arcsec: float,
-    pixel_scale_dec_arcsec: float,
+    reference: SkyCoord,
     deconvolved: bool,
     psf_beam: Beam | None,
-) -> BoundingBox:
-    """Bounding box of a single catalogue row's ellipse (or point, if
-    shape_cols is None), in pixel space. No beamwidth padding applied here --
-    that happens once per island, after merging."""
+) -> SkyBoundingBox:
+    """Sky box of a single catalogue row's ellipse, or point if shape_cols is None.
+
+    No beamwidth padding applied here.
+    """
     sky_coord = SkyCoord(
         float(row[ra_col]) * radec_unit, float(row[dec_col]) * radec_unit
     )
-    x_pix, y_pix = skycoord_to_pixel(wcs=wcs.celestial, coords=sky_coord, origin=0)
+    d_lon, d_lat = reference.spherical_offsets_to(sky_coord)
+    lon_arcsec = d_lon.to(u.arcsec).value
+    lat_arcsec = d_lat.to(u.arcsec).value
 
     half_ra_arcsec = half_dec_arcsec = 0.0
     if shape_cols is not None:
@@ -142,50 +222,37 @@ def _component_box(
         half_dec_arcsec = math.hypot(a * math.cos(theta), b * math.sin(theta))
         half_ra_arcsec = math.hypot(a * math.sin(theta), b * math.cos(theta))
 
-    half_dec_pix = half_dec_arcsec / pixel_scale_dec_arcsec
-    half_ra_pix = half_ra_arcsec / pixel_scale_ra_arcsec
-
-    # BoundingBox.x* is numpy axis -2 (FITS NAXIS2/Dec); .y* is axis -1 (NAXIS1/RA)
-    # -- the opposite of skycoord_to_pixel's (x=RA, y=Dec) astropy convention.
-    return BoundingBox(
-        xmin=int(math.floor(y_pix - half_dec_pix)),
-        xmax=int(math.ceil(y_pix + half_dec_pix)) + 1,
-        ymin=int(math.floor(x_pix - half_ra_pix)),
-        ymax=int(math.ceil(x_pix + half_ra_pix)) + 1,
-        original_shape=image_shape,
+    return SkyBoundingBox(
+        reference_ra_deg=float(reference.ra.deg),
+        reference_dec_deg=float(reference.dec.deg),
+        lon_min_arcsec=lon_arcsec - half_ra_arcsec,
+        lon_max_arcsec=lon_arcsec + half_ra_arcsec,
+        lat_min_arcsec=lat_arcsec - half_dec_arcsec,
+        lat_max_arcsec=lat_arcsec + half_dec_arcsec,
     )
 
 
-def _clip_box(box: BoundingBox) -> BoundingBox | None:
-    """Clip a box to its image, or None if it falls entirely off-image"""
-    ny, nx = box.original_shape
-    xmin, xmax = max(0, box.xmin), min(ny, box.xmax)
-    ymin, ymax = max(0, box.ymin), min(nx, box.ymax)
-    if xmin >= xmax or ymin >= ymax:
-        return None
-    return box.with_options(xmin=xmin, xmax=xmax, ymin=ymin, ymax=ymax)
-
-
-def island_bounding_boxes(
+def island_sky_boxes(
     table: Table,
     wcs: WCS,
-    image_shape: tuple[int, int],
     beam_shape: BeamShape,
     spice_options: SpiceOptions,
     is_user_catalogue: bool,
-) -> list[BoundingBox]:
-    """Per-island bounding boxes: group catalogue rows by island, merge each
-    island's component ellipses into one box, then pad by
-    ``spice_options.n_beamwidths`` restoring-beamwidths. Boxes that fall
-    entirely off the image are dropped.
+) -> list[SkyBoundingBox]:
+    """Per-island sky boxes: group catalogue rows by island, merge each island's
+    component ellipses into one box, then pad by ``spice_options.n_beamwidths``
+    restoring-beamwidths.
+
+    Boxes are returned on the sky, referenced to ``wcs``'s reference position.
+    Projection onto a pixel grid happens per target image in ``spice_fits``.
     """
     island_col, ra_col, dec_col, shape_cols = _resolve_columns(
         table=table, spice_options=spice_options, is_user_catalogue=is_user_catalogue
     )
     if len(table) == 0:
-        raise ValueError("Catalogue is empty -- nothing to box")
+        raise ValueError("Catalogue is empty!")
 
-    # Aegean's own catalogue is always degrees/arcsec -- see _resolve_columns
+    # Aegean's own catalogue is always degrees/arcsec see _resolve_columns
     radec_unit = u.Unit(
         "deg" if not is_user_catalogue else spice_options.catalogue_radec_unit
     )
@@ -193,9 +260,7 @@ def island_bounding_boxes(
         "arcsec" if not is_user_catalogue else spice_options.catalogue_shape_unit
     )
     deconvolved = bool(is_user_catalogue and spice_options.catalogue_sizes_deconvolved)
-    pixel_scale_ra_arcsec, pixel_scale_dec_arcsec = proj_plane_pixel_scales(
-        wcs.celestial
-    ) * u.deg.to(u.arcsec)
+    reference = SkyCoord(*wcs.celestial.wcs.crval * u.deg)
 
     groups = (
         list(table.group_by(island_col).groups)
@@ -203,20 +268,17 @@ def island_bounding_boxes(
         else [table[i : i + 1] for i in range(len(table))]
     )
 
-    island_boxes: list[BoundingBox] = []
+    island_sky_boxes: list[SkyBoundingBox] = []
     for group in groups:
         component_boxes = [
-            _component_box(
+            _component_sky_box(
                 row=row,
                 ra_col=ra_col,
                 dec_col=dec_col,
                 shape_cols=shape_cols,
                 radec_unit=radec_unit,
                 shape_unit=shape_unit,
-                wcs=wcs,
-                image_shape=image_shape,
-                pixel_scale_ra_arcsec=pixel_scale_ra_arcsec,
-                pixel_scale_dec_arcsec=pixel_scale_dec_arcsec,
+                reference=reference,
                 deconvolved=deconvolved,
                 psf_beam=_row_psf_beam(
                     row=row,
@@ -229,62 +291,109 @@ def island_bounding_boxes(
             )
             for row in group
         ]
-        island_boxes.append(_merge_bound_boxes(bounding_boxes=component_boxes))
+        island_sky_boxes.append(_merge_sky_boxes(sky_boxes=component_boxes))
 
     pad_arcsec = spice_options.n_beamwidths * max(
         beam_shape.bmaj_arcsec, beam_shape.bmin_arcsec
     )
-    pad_dec_pix = math.ceil(pad_arcsec / pixel_scale_dec_arcsec)
-    pad_ra_pix = math.ceil(pad_arcsec / pixel_scale_ra_arcsec)
-
     padded_boxes = [
         box.with_options(
-            xmin=box.xmin - pad_dec_pix,
-            xmax=box.xmax + pad_dec_pix,
-            ymin=box.ymin - pad_ra_pix,
-            ymax=box.ymax + pad_ra_pix,
+            lon_min_arcsec=box.lon_min_arcsec - pad_arcsec,
+            lon_max_arcsec=box.lon_max_arcsec + pad_arcsec,
+            lat_min_arcsec=box.lat_min_arcsec - pad_arcsec,
+            lat_max_arcsec=box.lat_max_arcsec + pad_arcsec,
         )
-        for box in island_boxes
+        for box in island_sky_boxes
     ]
-    clipped_boxes = [box for box in map(_clip_box, padded_boxes) if box is not None]
 
-    if not clipped_boxes:
-        raise ValueError("No island bounding boxes remain after clipping to the image")
-
-    logger.info(f"Built {len(clipped_boxes)} island bounding boxes")
-    return clipped_boxes
+    logger.info(f"Built {len(padded_boxes)} island sky boxes")
+    return padded_boxes
 
 
 def keep_mask_from_boxes(
-    boxes: list[BoundingBox], image_shape: tuple[int, int]
+    bounding_boxes: list[BoundingBox], image_shape: tuple[int, int]
 ) -> np.ndarray:
     """Boolean mask, True inside the union of the supplied boxes"""
     mask = np.zeros(image_shape, dtype=bool)
-    for box in boxes:
-        mask[box.xmin : box.xmax, box.ymin : box.ymax] = True
+    for bounding_box in bounding_boxes:
+        mask[
+            bounding_box.xmin : bounding_box.xmax,
+            bounding_box.ymin : bounding_box.ymax,
+        ] = True
     return mask
 
 
-def spice_fits(fits_path: Path, boxes: list[BoundingBox]) -> Path:
-    """Mask every pixel outside ``boxes`` to NaN and crop to their union,
-    replacing ``fits_path`` in place. Works on a single plane or a
-    multi-channel cube -- the mask/crop broadcast across any leading axes.
+def any_box_overlaps(fits_path: Path, sky_boxes: list[SkyBoundingBox]) -> bool:
+    """Whether any sky box projects onto ``fits_path``. Reads only the header
+
+    Args:
+        fits_path (Path): The image or cube to test
+        sky_boxes (list[SkyBoundingBox]): Sky boxes to project
+
+    Returns:
+        bool: True if at least one box overlaps
     """
-    if not boxes:
+    header = fits.getheader(fits_path)
+    wcs = WCS(header)
+    image_shape = (header["NAXIS2"], header["NAXIS1"])
+
+    return any(
+        sky_box.to_bounding_box(wcs=wcs, image_shape=image_shape) is not None
+        for sky_box in sky_boxes
+    )
+
+
+def spice_fits(
+    fits_path: Path, sky_boxes: list[SkyBoundingBox], output_path: Path | None = None
+) -> Path:
+    """Mask every pixel outside ``boxes`` to NaN and crop to their union.
+
+    Boxes are projected through this file's own WCS, so it need not share a pixel
+    grid with the image they were built from. Works on a single plane or a
+    multi-channel cube. A file that no box overlaps is left untouched.
+
+    Args:
+        fits_path (Path): The image or cube to spice
+        sky_boxes (list[SkyBoundingBox]): Sky boxes to keep
+        output_path (Path | None, optional): Directory to write the spiced cube into, deleting ``fits_path`` once written. Defaults to replacing ``fits_path`` in place.
+
+    Returns:
+        Path: The spiced cube, or ``fits_path`` unchanged if no box overlapped it
+    """
+    if not sky_boxes:
         raise ValueError(f"No bounding boxes supplied for {fits_path}")
 
-    overall = _merge_bound_boxes(bounding_boxes=boxes)
-    mask = keep_mask_from_boxes(boxes=boxes, image_shape=overall.original_shape)
-    mask_cropped = mask[overall.xmin : overall.xmax, overall.ymin : overall.ymax]
+    # A dask worker death after the unlink below leaves the output written and the
+    # input gone. Recognise that state rather than failing the rerun.
+    if output_path is not None:
+        spiced_path = output_path / fits_path.name
+        if spiced_path.exists() and not fits_path.exists():
+            logger.info(f"{spiced_path} already written, nothing to redo")
+            return spiced_path
 
     with fits.open(fits_path) as hdul:
-        image_shape = tuple(hdul[0].data.shape[-2:])
-        if image_shape != tuple(overall.original_shape):
-            raise ShapeMismatchError(
-                f"{fits_path} has shape {image_shape}, but boxes were built "
-                f"against {overall.original_shape}"
-            )
         header = hdul[0].header.copy()
+        image_shape = tuple(hdul[0].data.shape[-2:])
+        wcs = WCS(header)
+
+        pixel_boxes = [
+            pixel_box
+            for pixel_box in (
+                sky_box.to_bounding_box(wcs=wcs, image_shape=image_shape)
+                for sky_box in sky_boxes
+            )
+            if pixel_box is not None
+        ]
+        if not pixel_boxes:
+            logger.warning(
+                f"No island overlaps {fits_path}, leaving it unspiced. "
+                f"Checked {len(sky_boxes)} sky boxes against shape {image_shape}"
+            )
+            return fits_path
+
+        overall = _merge_bound_boxes(bounding_boxes=pixel_boxes)
+        mask = keep_mask_from_boxes(bounding_boxes=pixel_boxes, image_shape=image_shape)
+        mask_cropped = mask[overall.xmin : overall.xmax, overall.ymin : overall.ymax]
         data = np.array(
             hdul[0].data[..., overall.xmin : overall.xmax, overall.ymin : overall.ymax]
         )
@@ -294,10 +403,22 @@ def spice_fits(fits_path: Path, boxes: list[BoundingBox]) -> Path:
 
     header["CRPIX1"] -= overall.ymin
     header["CRPIX2"] -= overall.xmin
-
-    logger.info(f"Spicing {fits_path}: {overall.original_shape} -> {data.shape[-2:]}")
-    fits.HDUList([fits.PrimaryHDU(data=data, header=header), *extra_hdus]).writeto(
-        fits_path, overwrite=True
+    header.add_history(
+        f"flint.spice: masked outside {len(pixel_boxes)} island boxes and cropped "
+        f"{image_shape} -> {data.shape[-2:]}"
     )
 
-    return fits_path
+    spiced_path = fits_path
+    if output_path is not None:
+        output_path.mkdir(parents=True, exist_ok=True)
+        spiced_path = output_path / fits_path.name
+
+    logger.info(f"Spicing {fits_path}: {image_shape} -> {data.shape[-2:]}")
+    fits.HDUList([fits.PrimaryHDU(data=data, header=header), *extra_hdus]).writeto(
+        spiced_path, overwrite=True
+    )
+    if spiced_path != fits_path:
+        logger.info(f"Removing the unspiced {fits_path}")
+        fits_path.unlink()
+
+    return spiced_path

--- a/flint/spice.py
+++ b/flint/spice.py
@@ -11,7 +11,7 @@ import astropy.units as u
 import numpy as np
 from astropy.coordinates import SkyCoord
 from astropy.io import fits
-from astropy.table import Table
+from astropy.table import Row, Table
 from astropy.wcs import WCS
 from astropy.wcs.utils import proj_plane_pixel_scales, skycoord_to_pixel
 from radio_beam import Beam
@@ -77,7 +77,7 @@ def _resolve_columns(
 
 
 def _row_psf_beam(
-    row,
+    row: Row,
     spice_options: SpiceOptions,
     is_user_catalogue: bool,
     common_beam_shape: BeamShape,
@@ -104,7 +104,7 @@ def _row_psf_beam(
 
 
 def _component_box(
-    row,
+    row: Row,
     ra_col: str,
     dec_col: str,
     shape_cols: tuple[str, str, str] | None,

--- a/flint/spice.py
+++ b/flint/spice.py
@@ -1,5 +1,7 @@
 """SPICE-style cube trimming: mask everything outside small boxes around
-catalogued sources, crop to their union. See ``flint.options.SpiceOptions``.
+catalogued sources, crop to their union. A set of cubes (image and weight,
+across all Stokes) is trimmed with one shared set of boxes, so they all come
+out on the same grid. See ``flint.options.SpiceOptions``.
 """
 
 from __future__ import annotations
@@ -323,44 +325,108 @@ def keep_mask_from_boxes(
     return mask
 
 
-def any_box_overlaps(fits_path: Path, sky_boxes: list[SkyBoundingBox]) -> bool:
-    """Whether any sky box projects onto ``fits_path``. Reads only the header
+def cube_shape(fits_path: Path) -> tuple[int, ...]:
+    """Shape of a FITS file's primary HDU in numpy order, read from its header"""
+    header = fits.getheader(fits_path)
+
+    return tuple(header[f"NAXIS{axis}"] for axis in range(header["NAXIS"], 0, -1))
+
+
+def check_cubes_share_shape(fits_paths: list[Path]) -> tuple[int, ...]:
+    """The shape shared by every cube. Image and weight cubes across all Stokes
+    come off the same linmos grid, so a disagreement means something upstream
+    has gone wrong. Reads headers only.
 
     Args:
-        fits_path (Path): The image or cube to test
+        fits_paths (list[Path]): The cubes to compare
+
+    Returns:
+        tuple[int, ...]: The shape they share
+
+    Raises:
+        ValueError: The cubes do not all share a shape
+    """
+    shapes = {fits_path: cube_shape(fits_path=fits_path) for fits_path in fits_paths}
+    unique_shapes = set(shapes.values())
+    if len(unique_shapes) != 1:
+        raise ValueError(f"Cubes do not share a shape: {shapes}")
+
+    return unique_shapes.pop()
+
+
+def shared_pixel_boxes(
+    fits_paths: list[Path], sky_boxes: list[SkyBoundingBox]
+) -> list[BoundingBox]:
+    """Project sky boxes onto the pixel grid shared by every cube.
+
+    Spicing all cubes with this one set of boxes is what leaves them on an
+    identical grid afterwards, so the cubes must start on one. Reads headers only.
+
+    Args:
+        fits_paths (list[Path]): The cubes about to be spiced together
         sky_boxes (list[SkyBoundingBox]): Sky boxes to project
 
     Returns:
-        bool: True if at least one box overlaps
-    """
-    header = fits.getheader(fits_path)
-    wcs = WCS(header)
-    image_shape = (header["NAXIS2"], header["NAXIS1"])
+        list[BoundingBox]: Those boxes that land on the shared grid
 
-    return any(
-        sky_box.to_bounding_box(wcs=wcs, image_shape=image_shape) is not None
-        for sky_box in sky_boxes
+    Raises:
+        ValueError: The cubes do not share a grid, or no box overlaps it
+    """
+    if not fits_paths:
+        raise ValueError("No cubes supplied")
+    if not sky_boxes:
+        raise ValueError("No sky boxes supplied")
+
+    shape = check_cubes_share_shape(fits_paths=fits_paths)
+    image_shape = (shape[-2], shape[-1])
+
+    reference_wcs = WCS(fits.getheader(fits_paths[0])).celestial
+    for fits_path in fits_paths[1:]:
+        wcs = WCS(fits.getheader(fits_path)).celestial
+        if not wcs.wcs.compare(reference_wcs.wcs, tolerance=1e-9):
+            raise ValueError(
+                f"{fits_path} is not on the same celestial grid as {fits_paths[0]}"
+            )
+
+    pixel_boxes = [
+        pixel_box
+        for pixel_box in (
+            sky_box.to_bounding_box(wcs=reference_wcs, image_shape=image_shape)
+            for sky_box in sky_boxes
+        )
+        if pixel_box is not None
+    ]
+    if not pixel_boxes:
+        raise ValueError(
+            f"None of the {len(sky_boxes)} island boxes overlap the shared "
+            f"{image_shape} grid of the {len(fits_paths)} supplied cubes. Check the "
+            "catalogue and reference image match the field."
+        )
+
+    logger.info(
+        f"{len(pixel_boxes)} of {len(sky_boxes)} island boxes land on the cubes"
     )
+    return pixel_boxes
 
 
 def spice_fits(
-    fits_path: Path, sky_boxes: list[SkyBoundingBox], output_path: Path | None = None
+    fits_path: Path, pixel_boxes: list[BoundingBox], output_path: Path | None = None
 ) -> Path:
-    """Mask every pixel outside ``boxes`` to NaN and crop to their union.
+    """Mask every pixel outside ``pixel_boxes`` to NaN and crop to their union.
 
-    Boxes are projected through this file's own WCS, so it need not share a pixel
-    grid with the image they were built from. Works on a single plane or a
-    multi-channel cube. A file that no box overlaps is left untouched.
+    Works on a single plane or a multi-channel cube. Extensions such as the beam
+    table are carried through untouched. Every cube spiced with the one set of
+    boxes from ``shared_pixel_boxes`` comes out on the same grid.
 
     Args:
         fits_path (Path): The image or cube to spice
-        sky_boxes (list[SkyBoundingBox]): Sky boxes to keep
+        pixel_boxes (list[BoundingBox]): Pixel boxes to keep, on this file's grid
         output_path (Path | None, optional): Directory to write the spiced cube into, deleting ``fits_path`` once written. Defaults to replacing ``fits_path`` in place.
 
     Returns:
-        Path: The spiced cube, or ``fits_path`` unchanged if no box overlapped it
+        Path: The spiced cube
     """
-    if not sky_boxes:
+    if not pixel_boxes:
         raise ValueError(f"No bounding boxes supplied for {fits_path}")
 
     # A dask worker death after the unlink below leaves the output written and the
@@ -371,34 +437,24 @@ def spice_fits(
             logger.info(f"{spiced_path} already written, nothing to redo")
             return spiced_path
 
+    overall = _merge_bound_boxes(bounding_boxes=pixel_boxes)
+
     with fits.open(fits_path) as hdul:
         header = hdul[0].header.copy()
         image_shape = tuple(hdul[0].data.shape[-2:])
-        wcs = WCS(header)
-
-        pixel_boxes = [
-            pixel_box
-            for pixel_box in (
-                sky_box.to_bounding_box(wcs=wcs, image_shape=image_shape)
-                for sky_box in sky_boxes
-            )
-            if pixel_box is not None
-        ]
-        if not pixel_boxes:
-            logger.warning(
-                f"No island overlaps {fits_path}, leaving it unspiced. "
-                f"Checked {len(sky_boxes)} sky boxes against shape {image_shape}"
-            )
-            return fits_path
-
-        overall = _merge_bound_boxes(bounding_boxes=pixel_boxes)
-        mask = keep_mask_from_boxes(bounding_boxes=pixel_boxes, image_shape=image_shape)
-        mask_cropped = mask[overall.xmin : overall.xmax, overall.ymin : overall.ymax]
         data = np.array(
             hdul[0].data[..., overall.xmin : overall.xmax, overall.ymin : overall.ymax]
         )
         extra_hdus = [hdu.copy() for hdu in hdul[1:]]
 
+    if image_shape != overall.original_shape:
+        raise ValueError(
+            f"{fits_path} has plane shape {image_shape}, but the boxes were built "
+            f"against {overall.original_shape}"
+        )
+
+    mask = keep_mask_from_boxes(bounding_boxes=pixel_boxes, image_shape=image_shape)
+    mask_cropped = mask[overall.xmin : overall.xmax, overall.ymin : overall.ymax]
     data[..., ~mask_cropped] = np.nan
 
     header["CRPIX1"] -= overall.ymin

--- a/flint/spice.py
+++ b/flint/spice.py
@@ -1,0 +1,303 @@
+"""SPICE-style cube trimming: mask everything outside small boxes around
+catalogued sources, crop to their union. See ``flint.options.SpiceOptions``.
+"""
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+
+import astropy.units as u
+import numpy as np
+from astropy.coordinates import SkyCoord
+from astropy.io import fits
+from astropy.table import Table
+from astropy.wcs import WCS
+from astropy.wcs.utils import proj_plane_pixel_scales, skycoord_to_pixel
+from radio_beam import Beam
+
+from flint.coadd.linmos import BoundingBox, _merge_bound_boxes
+from flint.convol import BeamShape
+from flint.exceptions import ShapeMismatchError
+from flint.logging import logger
+from flint.options import SpiceOptions
+
+
+def load_component_table(catalogue: Path | Table) -> Table:
+    """Return a table given either a loaded table or a path to one on disk"""
+    return Table.read(catalogue) if isinstance(catalogue, Path) else catalogue
+
+
+def _resolve_columns(
+    table: Table, spice_options: SpiceOptions, is_user_catalogue: bool
+) -> tuple[str | None, str, str, tuple[str, str, str] | None]:
+    """Resolve (island_col, ra_col, dec_col, shape_cols) for a catalogue.
+
+    Column names/units are never guessed for a user-supplied catalogue --
+    only the built-in Aegean catalogue has a fixed, known contract (confirmed
+    against the installed aegeantools==2.3.0 source, AegeanTools.source_finder
+    around result_to_components: island/ra/dec (deg) /a/b/pa (arcsec/arcsec/deg),
+    with a/b/pa the as-fit, PSF-convolved sizes -- no reconvolution needed here).
+    """
+    if not is_user_catalogue:
+        island_col = "island" if "island" in table.colnames else None
+        return island_col, "ra", "dec", ("a", "b", "pa")
+
+    if (
+        spice_options.catalogue_ra_col is None
+        or spice_options.catalogue_dec_col is None
+    ):
+        raise ValueError(
+            "catalogue_ra_col and catalogue_dec_col must be set on SpiceOptions "
+            "for a user-supplied spice_catalogue -- these are never guessed"
+        )
+
+    shape_cols = (
+        spice_options.catalogue_maj_col,
+        spice_options.catalogue_min_col,
+        spice_options.catalogue_pa_col,
+    )
+    if any(shape_cols) and not all(shape_cols):
+        raise ValueError(
+            "catalogue_maj_col/catalogue_min_col/catalogue_pa_col must be all set "
+            "or all unset"
+        )
+    if all(shape_cols) and spice_options.catalogue_sizes_deconvolved is None:
+        raise ValueError(
+            "catalogue_sizes_deconvolved must be set (True or False) whenever "
+            "catalogue_maj_col is set -- never guessed"
+        )
+
+    return (
+        spice_options.catalogue_island_col,
+        spice_options.catalogue_ra_col,
+        spice_options.catalogue_dec_col,
+        shape_cols if all(shape_cols) else None,  # type: ignore[return-value]
+    )
+
+
+def _row_psf_beam(
+    row,
+    spice_options: SpiceOptions,
+    is_user_catalogue: bool,
+    common_beam_shape: BeamShape,
+) -> Beam:
+    """The PSF to re-convolve a deconvolved source size with: per-row columns
+    if given, otherwise the pipeline's common restoring beam."""
+    psf_cols = (
+        spice_options.catalogue_psf_maj_col,
+        spice_options.catalogue_psf_min_col,
+        spice_options.catalogue_psf_pa_col,
+    )
+    if is_user_catalogue and all(psf_cols):
+        shape_unit = u.Unit(spice_options.catalogue_shape_unit)
+        return Beam(
+            major=float(row[psf_cols[0]]) * shape_unit,
+            minor=float(row[psf_cols[1]]) * shape_unit,
+            pa=float(row[psf_cols[2]]) * u.deg,
+        )
+    return Beam(
+        major=common_beam_shape.bmaj_arcsec * u.arcsec,
+        minor=common_beam_shape.bmin_arcsec * u.arcsec,
+        pa=common_beam_shape.bpa_deg * u.deg,
+    )
+
+
+def _component_box(
+    row,
+    ra_col: str,
+    dec_col: str,
+    shape_cols: tuple[str, str, str] | None,
+    radec_unit: u.Unit,
+    shape_unit: u.Unit,
+    wcs: WCS,
+    image_shape: tuple[int, int],
+    pixel_scale_ra_arcsec: float,
+    pixel_scale_dec_arcsec: float,
+    deconvolved: bool,
+    psf_beam: Beam | None,
+) -> BoundingBox:
+    """Bounding box of a single catalogue row's ellipse (or point, if
+    shape_cols is None), in pixel space. No beamwidth padding applied here --
+    that happens once per island, after merging."""
+    sky_coord = SkyCoord(
+        float(row[ra_col]) * radec_unit, float(row[dec_col]) * radec_unit
+    )
+    x_pix, y_pix = skycoord_to_pixel(wcs=wcs.celestial, coords=sky_coord, origin=0)
+
+    half_ra_arcsec = half_dec_arcsec = 0.0
+    if shape_cols is not None:
+        maj = float(row[shape_cols[0]]) * shape_unit
+        minor = float(row[shape_cols[1]]) * shape_unit
+        pa = float(row[shape_cols[2]]) * u.deg
+        if deconvolved:
+            assert psf_beam is not None
+            observed = Beam(major=maj, minor=minor, pa=pa).convolve(psf_beam)
+            maj, minor, pa = observed.major, observed.minor, observed.pa
+
+        # Semi-axes of the as-observed (FWHM) ellipse; pa is East of North.
+        a = maj.to(u.arcsec).value / 2.0
+        b = minor.to(u.arcsec).value / 2.0
+        theta = pa.to(u.rad).value
+        half_dec_arcsec = math.hypot(a * math.cos(theta), b * math.sin(theta))
+        half_ra_arcsec = math.hypot(a * math.sin(theta), b * math.cos(theta))
+
+    half_dec_pix = half_dec_arcsec / pixel_scale_dec_arcsec
+    half_ra_pix = half_ra_arcsec / pixel_scale_ra_arcsec
+
+    # BoundingBox.x* is numpy axis -2 (FITS NAXIS2/Dec); .y* is axis -1 (NAXIS1/RA)
+    # -- the opposite of skycoord_to_pixel's (x=RA, y=Dec) astropy convention.
+    return BoundingBox(
+        xmin=int(math.floor(y_pix - half_dec_pix)),
+        xmax=int(math.ceil(y_pix + half_dec_pix)) + 1,
+        ymin=int(math.floor(x_pix - half_ra_pix)),
+        ymax=int(math.ceil(x_pix + half_ra_pix)) + 1,
+        original_shape=image_shape,
+    )
+
+
+def _clip_box(box: BoundingBox) -> BoundingBox | None:
+    """Clip a box to its image, or None if it falls entirely off-image"""
+    ny, nx = box.original_shape
+    xmin, xmax = max(0, box.xmin), min(ny, box.xmax)
+    ymin, ymax = max(0, box.ymin), min(nx, box.ymax)
+    if xmin >= xmax or ymin >= ymax:
+        return None
+    return box.with_options(xmin=xmin, xmax=xmax, ymin=ymin, ymax=ymax)
+
+
+def island_bounding_boxes(
+    table: Table,
+    wcs: WCS,
+    image_shape: tuple[int, int],
+    beam_shape: BeamShape,
+    spice_options: SpiceOptions,
+    is_user_catalogue: bool,
+) -> list[BoundingBox]:
+    """Per-island bounding boxes: group catalogue rows by island, merge each
+    island's component ellipses into one box, then pad by
+    ``spice_options.n_beamwidths`` restoring-beamwidths. Boxes that fall
+    entirely off the image are dropped.
+    """
+    island_col, ra_col, dec_col, shape_cols = _resolve_columns(
+        table=table, spice_options=spice_options, is_user_catalogue=is_user_catalogue
+    )
+    if len(table) == 0:
+        raise ValueError("Catalogue is empty -- nothing to box")
+
+    # Aegean's own catalogue is always degrees/arcsec -- see _resolve_columns
+    radec_unit = u.Unit(
+        "deg" if not is_user_catalogue else spice_options.catalogue_radec_unit
+    )
+    shape_unit = u.Unit(
+        "arcsec" if not is_user_catalogue else spice_options.catalogue_shape_unit
+    )
+    deconvolved = bool(is_user_catalogue and spice_options.catalogue_sizes_deconvolved)
+    pixel_scale_ra_arcsec, pixel_scale_dec_arcsec = proj_plane_pixel_scales(
+        wcs.celestial
+    ) * u.deg.to(u.arcsec)
+
+    groups = (
+        list(table.group_by(island_col).groups)
+        if island_col is not None
+        else [table[i : i + 1] for i in range(len(table))]
+    )
+
+    island_boxes: list[BoundingBox] = []
+    for group in groups:
+        component_boxes = [
+            _component_box(
+                row=row,
+                ra_col=ra_col,
+                dec_col=dec_col,
+                shape_cols=shape_cols,
+                radec_unit=radec_unit,
+                shape_unit=shape_unit,
+                wcs=wcs,
+                image_shape=image_shape,
+                pixel_scale_ra_arcsec=pixel_scale_ra_arcsec,
+                pixel_scale_dec_arcsec=pixel_scale_dec_arcsec,
+                deconvolved=deconvolved,
+                psf_beam=_row_psf_beam(
+                    row=row,
+                    spice_options=spice_options,
+                    is_user_catalogue=is_user_catalogue,
+                    common_beam_shape=beam_shape,
+                )
+                if deconvolved
+                else None,
+            )
+            for row in group
+        ]
+        island_boxes.append(_merge_bound_boxes(bounding_boxes=component_boxes))
+
+    pad_arcsec = spice_options.n_beamwidths * max(
+        beam_shape.bmaj_arcsec, beam_shape.bmin_arcsec
+    )
+    pad_dec_pix = math.ceil(pad_arcsec / pixel_scale_dec_arcsec)
+    pad_ra_pix = math.ceil(pad_arcsec / pixel_scale_ra_arcsec)
+
+    padded_boxes = [
+        box.with_options(
+            xmin=box.xmin - pad_dec_pix,
+            xmax=box.xmax + pad_dec_pix,
+            ymin=box.ymin - pad_ra_pix,
+            ymax=box.ymax + pad_ra_pix,
+        )
+        for box in island_boxes
+    ]
+    clipped_boxes = [box for box in map(_clip_box, padded_boxes) if box is not None]
+
+    if not clipped_boxes:
+        raise ValueError("No island bounding boxes remain after clipping to the image")
+
+    logger.info(f"Built {len(clipped_boxes)} island bounding boxes")
+    return clipped_boxes
+
+
+def keep_mask_from_boxes(
+    boxes: list[BoundingBox], image_shape: tuple[int, int]
+) -> np.ndarray:
+    """Boolean mask, True inside the union of the supplied boxes"""
+    mask = np.zeros(image_shape, dtype=bool)
+    for box in boxes:
+        mask[box.xmin : box.xmax, box.ymin : box.ymax] = True
+    return mask
+
+
+def spice_fits(fits_path: Path, boxes: list[BoundingBox]) -> Path:
+    """Mask every pixel outside ``boxes`` to NaN and crop to their union,
+    replacing ``fits_path`` in place. Works on a single plane or a
+    multi-channel cube -- the mask/crop broadcast across any leading axes.
+    """
+    if not boxes:
+        raise ValueError(f"No bounding boxes supplied for {fits_path}")
+
+    overall = _merge_bound_boxes(bounding_boxes=boxes)
+    mask = keep_mask_from_boxes(boxes=boxes, image_shape=overall.original_shape)
+    mask_cropped = mask[overall.xmin : overall.xmax, overall.ymin : overall.ymax]
+
+    with fits.open(fits_path) as hdul:
+        image_shape = tuple(hdul[0].data.shape[-2:])
+        if image_shape != tuple(overall.original_shape):
+            raise ShapeMismatchError(
+                f"{fits_path} has shape {image_shape}, but boxes were built "
+                f"against {overall.original_shape}"
+            )
+        header = hdul[0].header.copy()
+        data = np.array(
+            hdul[0].data[..., overall.xmin : overall.xmax, overall.ymin : overall.ymax]
+        )
+        extra_hdus = [hdu.copy() for hdu in hdul[1:]]
+
+    data[..., ~mask_cropped] = np.nan
+
+    header["CRPIX1"] -= overall.ymin
+    header["CRPIX2"] -= overall.xmin
+
+    logger.info(f"Spicing {fits_path}: {overall.original_shape} -> {data.shape[-2:]}")
+    fits.HDUList([fits.PrimaryHDU(data=data, header=header), *extra_hdus]).writeto(
+        fits_path, overwrite=True
+    )
+
+    return fits_path

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
     "scikit-image",
     "pandas",
     "ConfigArgParse>=1.7",
-    "fitscube[pgzip]>=2.5.0",
+    "fitscube[pgzip]>=2.5.1",
     "astroquery>=0.4.8.dev0",
     "crystalball>=0.4.3",
     "jolly-roger>=0.10.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,8 @@ dynamic = ["version"]
 dependencies = [
     "astropy>=6.1.3", # fixing until units change in 6.1.4 addressed in radio-beam
     "numpy>=2.0.0",
+    "numba",
+    "rocket-fft",
     "pydantic>=2",
     "scipy",
     "spython>=0.3.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
     "scikit-image",
     "pandas",
     "ConfigArgParse>=1.7",
-    "fitscube[pgzip]>=2.5.1",
+    "fitscube[pgzip]>=2.6",
     "astroquery>=0.4.8.dev0",
     "crystalball>=0.4.3",
     "jolly-roger>=0.10.1",
@@ -93,7 +93,7 @@ casa =[
     "fixms>=0.4.0"
 ]
 rmsynth = [
-    "rm-lite==2026.8.6",
+    "rm-lite==2026.8.7",
 ]
 all = [
     "askap-flint[dev,casa,rmsynth]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
     "prefect>=3.4.7",
     "prefect-dask>=0.3.7",
     "dask-jobqueue",
-    "RACS-tools>=4.2.1",
+    "RACS-tools>=4.3.2",
     "aegeantools==2.3.0",
     "radio-beam>=0.3.4",
     "reproject",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,9 @@ casa =[
 rmsynth = [
     "rm-lite>=2026.7.7",
 ]
+all = [
+    "askap-flint[dev,casa,rmsynth]",
+]
 
 [project.scripts]
 flint_skymodel = "flint.sky_model:cli"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ casa =[
     "fixms>=0.4.0"
 ]
 rmsynth = [
-    "rm-lite>=2026.7.7",
+    "rm-lite==2026.8.3",
 ]
 all = [
     "askap-flint[dev,casa,rmsynth]",
@@ -126,7 +126,10 @@ flint_flow_bandpass_calibrate = "flint.prefect.flows.bandpass_pipeline:cli"
 flint_flow_continuum_pipeline = "flint.prefect.flows.continuum_pipeline:cli"
 flint_flow_subtract_cube_pipeline = "flint.prefect.flows.subtract_cube_pipeline:cli"
 flint_flow_polarisation_pipeline = "flint.prefect.flows.polarisation_pipeline:cli"
-flint_flow_racs_all_pipeline = "flint.prefect.flows.racs_all_continuum_selfcal:cli"
+flint_flow_racs_all_continuum_pipeline = "flint.prefect.flows.racs_all_continuum_selfcal:cli"
+flint_flow_rmsynth_pipeline = "flint.prefect.flows.rmsynth_pipeline:cli"
+flint_flow_spice_compression_pipeline = "flint.prefect.flows.spice_compression_pipeline:cli"
+flint_flow_racs_all_pipeline = "flint.prefect.flows.racs_all_pipeline:cli"
 
 # [tool.mypy]
 # files = ["flint", "tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,9 @@ casa =[
     "python-casacore>=3.6.0",
     "fixms>=0.4.0"
 ]
+rmsynth = [
+    "rm-lite>=2026.7.7",
+]
 
 [project.scripts]
 flint_skymodel = "flint.sky_model:cli"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ casa =[
     "fixms>=0.4.0"
 ]
 rmsynth = [
-    "rm-lite==2026.8.5",
+    "rm-lite==2026.8.6",
 ]
 all = [
     "askap-flint[dev,casa,rmsynth]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,8 @@ build-backend = "hatchling.build"
 [project]
 name = "askap-flint"
 authors = [
-    {name="Tim Galvin", email="tim.galvin@csiro.au"}
+    {name="Tim Galvin", email="tim.galvin@csiro.au"},
+    {name="Alec Thomson", email="alec.thomson@skao.int"}
 ]
 description = "Pipeline for ASKAP processing, and profit along the way"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ casa =[
     "fixms>=0.4.0"
 ]
 rmsynth = [
-    "rm-lite==2026.8.3",
+    "rm-lite==2026.8.4",
 ]
 all = [
     "askap-flint[dev,casa,rmsynth]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ casa =[
     "fixms>=0.4.0"
 ]
 rmsynth = [
-    "rm-lite==2026.8.4",
+    "rm-lite==2026.8.5",
 ]
 all = [
     "askap-flint[dev,casa,rmsynth]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [build-system]
-requires = ["hatchling", "hatch-vcs"]
+# Pin hatchling for hynek/build-and-inspect-python-package@v2
+requires = ["hatchling<1.32", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ casa =[
     "fixms>=0.4.0"
 ]
 rmsynth = [
-    "rm-lite==2026.9.1",
+    "rm-lite==2026.9.2",
 ]
 all = [
     "askap-flint[dev,casa,rmsynth]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ casa =[
     "fixms>=0.4.0"
 ]
 rmsynth = [
-    "rm-lite==2026.8.7",
+    "rm-lite==2026.9.1",
 ]
 all = [
     "askap-flint[dev,casa,rmsynth]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "prefect>=3.4.7",
     "prefect-dask>=0.3.7",
     "dask-jobqueue",
-    "RACS-tools>=4.3.2",
+    "RACS-tools>=4.4.0",
     "aegeantools==2.3.0",
     "radio-beam>=0.3.4",
     "reproject",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ casa =[
     "fixms>=0.4.0"
 ]
 rmsynth = [
-    "rm-lite==2026.9.4",
+    "rm-lite==2026.9.6",
 ]
 all = [
     "askap-flint[dev,casa,rmsynth]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ casa =[
     "fixms>=0.4.0"
 ]
 rmsynth = [
-    "rm-lite==2026.9.6",
+    "rm-lite==2026.9.7",
 ]
 all = [
     "askap-flint[dev,casa,rmsynth]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ dependencies = [
     "scikit-image",
     "pandas",
     "ConfigArgParse>=1.7",
-    "fitscube[pgzip]>=2.6",
+    "fitscube[pgzip]>=2.7",
     "astroquery>=0.4.8.dev0",
     "crystalball>=0.4.3",
     "jolly-roger>=0.10.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ casa =[
     "fixms>=0.4.0"
 ]
 rmsynth = [
-    "rm-lite==2026.9.2",
+    "rm-lite==2026.9.4",
 ]
 all = [
     "askap-flint[dev,casa,rmsynth]",

--- a/tests/test_bane.py
+++ b/tests/test_bane.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import warnings
 from pathlib import Path
 
 import numpy as np
@@ -115,6 +116,94 @@ def test_blanked_pixels_stay_blank() -> None:
     assert np.isfinite(rms[~blank]).all()
 
 
+def _footprint(radius: int) -> np.ndarray:
+    """Mask of a circular mosaic footprint, as linmos leaves after its cutoff"""
+    yy, xx = np.mgrid[0:NY, 0:NX]
+    return (yy - NY / 2) ** 2 + (xx - NX / 2) ** 2 < radius**2
+
+
+def test_the_linmos_zero_fill_is_treated_as_blank() -> None:
+    """linmos fills beyond its cutoff with exact zeros, not NaNs. Counted as
+    measured data those zeros take the seed median and mad_std to exactly zero
+    once more than half the plane is blank, and the maps collapse to zero
+    everywhere, which reads downstream as a noiseless image."""
+    inside = _footprint(radius=380)
+    assert (~inside).mean() > 0.5, "the collapse needs over half the plane blank"
+
+    sky = _sky(background=5e-4, rms=1e-3)
+    zero_filled = np.where(inside, sky, 0.0).astype(np.float32)
+    nan_filled = np.where(inside, sky, np.nan).astype(np.float32)
+
+    zero_bkg, zero_rms = robust_bane(image=zero_filled, header=_header())
+    nan_bkg, nan_rms = robust_bane(image=nan_filled, header=_header())
+
+    # The noise inside the footprint was measured, not zeroed
+    assert np.nanmedian(zero_rms[inside]) == pytest.approx(1e-3, rel=0.3)
+    # Blanking either way describes the same plane, so it measures the same
+    assert np.nanmedian(zero_rms[inside]) == pytest.approx(
+        np.nanmedian(nan_rms[inside]), rel=0.05
+    )
+    assert np.nanmedian(zero_bkg[inside]) == pytest.approx(
+        np.nanmedian(nan_bkg[inside]), rel=0.05
+    )
+
+    # And the maps blank where the image is blank, so the noise cube and the
+    # image cube it describes share a footprint
+    assert np.isnan(zero_rms[~inside]).all()
+    assert np.isnan(zero_bkg[~inside]).all()
+
+
+def test_invalidate_zeros_can_be_turned_off() -> None:
+    """Off, zeros count as measured data again, which is what a caller whose
+    zeros are real would want."""
+    inside = _footprint(radius=380)
+    zero_filled = np.where(inside, _sky(rms=1e-3), 0.0).astype(np.float32)
+
+    _, rms = robust_bane(
+        image=zero_filled,
+        header=_header(),
+        fft_bane_options=FFTBANEOptions(invalidate_zeros=False),
+    )
+
+    # Nothing is blank, so nothing is NaN, and the collapse described above is
+    # exactly what the zeros produce
+    assert np.isfinite(rms).all()
+    assert np.all(rms == 0.0)
+
+
+def test_the_rms_map_is_never_negative() -> None:
+    """The maps are zoomed back up with a cubic spline, which rings across the
+    step at a footprint edge and undershoots below zero. A negative noise
+    squares to a small variance, so an inverse-variance weight built from it
+    comes out orders of magnitude too large rather than obviously wrong."""
+    inside = _footprint(radius=480)
+    sky = _sky(rms=1e-3)
+
+    for filled in (
+        np.where(inside, sky, np.nan).astype(np.float32),
+        np.where(inside, sky, 0.0).astype(np.float32),
+    ):
+        _, rms = robust_bane(image=filled, header=_header())
+        assert not np.any(rms[np.isfinite(rms)] < 0.0)
+
+
+def test_a_wholly_blank_plane_returns_blank_maps_quietly() -> None:
+    """Nothing measured means no seeds to take a median and a mad_std of. Both
+    come back NaN off an empty slice and reach the same blank maps anyway, but
+    by way of a pair of numpy RuntimeWarnings. linmos hands over such a plane as
+    all zeros rather than all NaNs, so blanking the zeros is what reaches it."""
+    for plane in (
+        np.full((NY, NX), np.nan, dtype=np.float32),
+        np.zeros((NY, NX), dtype=np.float32),
+    ):
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", RuntimeWarning)
+            background, rms = robust_bane(image=plane, header=_header())
+
+        assert np.isnan(background).all()
+        assert np.isnan(rms).all()
+
+
 def test_the_seed_makes_a_rerun_reproducible() -> None:
     """Clipped source pixels are refilled with random noise, so without a fixed
     seed the same image gives different maps run to run."""
@@ -168,7 +257,9 @@ def test_a_kernel_too_big_for_the_image_is_refused() -> None:
     image with a big step downsamples into exactly that."""
     with pytest.raises(ValueError, match="does not fit"):
         robust_bane(
-            image=np.zeros((64, 64), dtype=np.float32),
+            # Not zeros: those are blank now, and a wholly blank plane returns
+            # blank maps before the kernel is ever pressed against the image
+            image=np.ones((64, 64), dtype=np.float32),
             header=_header(),
             fft_bane_options=FFTBANEOptions(step_size=16, box_size=32),
         )

--- a/tests/test_bane.py
+++ b/tests/test_bane.py
@@ -1,0 +1,207 @@
+"""Tests for the FFT BANE port in ``flint.bane``"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+from astropy.io import fits
+from astropy.wcs import WCS
+
+from flint.bane import (
+    FFTBANEOptions,
+    bane_fits_image,
+    fft_average,
+    gaussian_kernel,
+    get_kernel,
+    pad_reflect,
+    robust_bane,
+    tophat_kernel,
+)
+
+NY = NX = 1024
+PIX_PER_BEAM = 10
+
+
+def _header(shape: tuple[int, int] = (NY, NX)) -> fits.Header:
+    """A minimal header carrying the beam and pixel scale ``get_kernel`` needs"""
+    wcs = WCS(naxis=2)
+    wcs.wcs.ctype = ["RA---SIN", "DEC--SIN"]
+    wcs.wcs.crval = [180.0, -30.0]
+    wcs.wcs.crpix = [shape[1] / 2, shape[0] / 2]
+    wcs.wcs.cdelt = [-1 / 3600, 1 / 3600]
+    wcs.wcs.cunit = ["deg", "deg"]
+    header = wcs.to_header()
+    header["BMAJ"] = PIX_PER_BEAM / 3600
+    header["BMIN"] = PIX_PER_BEAM / 3600
+    header["BPA"] = 0.0
+    return header
+
+
+def _sky(background: float = 0.0, rms: float = 1e-3, seed: int = 0) -> np.ndarray:
+    """Noise on a flat background, with three point sources"""
+    rng = np.random.default_rng(seed)
+    image = rng.normal(background, rms, (NY, NX)).astype(np.float32)
+    for y, x in ((200, 300), (700, 800), (500, 120)):
+        image[y, x] += 0.5
+    return image
+
+
+def test_pad_reflect_matches_numpy() -> None:
+    """It is a numba-compatible np.pad(mode='reflect'), so it has to agree with
+    the thing it replaces."""
+    rng = np.random.default_rng(0)
+    array = rng.normal(size=(17, 23)).astype(np.float32)
+
+    for pad_y, pad_x in ((1, 1), (5, 3), (8, 11)):
+        assert np.allclose(
+            pad_reflect(array, (pad_y, pad_x)),
+            np.pad(array, ((pad_y, pad_y), (pad_x, pad_x)), mode="reflect"),
+        ), (pad_y, pad_x)
+
+
+def test_fft_average_preserves_a_flat_image() -> None:
+    """The kernel is normalised by its own sum, so smoothing a constant image
+    returns that constant rather than scaling it."""
+    image = np.full((128, 128), 3.0, dtype=np.float32)
+
+    for kernel in (gaussian_kernel(5), tophat_kernel(8)):
+        assert np.allclose(fft_average(image, kernel), 3.0, atol=1e-4)
+
+
+def test_bane_recovers_a_varying_background_and_rms() -> None:
+    """The point of BANE: both the background and the noise vary across the
+    image, and a single number for either would be wrong. Neither is uniform
+    here, and the sources must not drag the noise up."""
+    rng = np.random.default_rng(0)
+    yy, xx = np.mgrid[0:NY, 0:NX]
+    truth_bkg = 2e-3 * (yy / NY)
+    truth_rms = 1e-3 * (1 + xx / NX)
+    image = (rng.normal(0, 1, (NY, NX)) * truth_rms + truth_bkg).astype(np.float32)
+    image[200, 300] += 0.5
+
+    background, rms = robust_bane(image=image, header=_header())
+
+    assert background.shape == image.shape
+    assert rms.shape == image.shape
+    assert np.isfinite(background).all()
+    assert np.isfinite(rms).all()
+
+    # Downsampling and smoothing bias both low, so this is a loose check that
+    # the maps track the truth rather than a tight one on their values
+    assert np.nanmedian(background) == pytest.approx(np.median(truth_bkg), rel=0.3)
+    assert np.nanmedian(rms) == pytest.approx(np.median(truth_rms), rel=0.3)
+
+    # The gradient is the part a scalar noise estimate cannot express
+    assert np.nanmedian(rms[:, -100:]) > 1.5 * np.nanmedian(rms[:, :100])
+    assert np.nanmedian(background[-100:, :]) > np.nanmedian(background[:100, :])
+
+
+def test_blanked_pixels_stay_blank() -> None:
+    """A linmos mosaic blanks beyond its cutoff. Those pixels have no data to
+    measure, so they come back NaN rather than as an extrapolated background."""
+    image = _sky()
+    blank = np.zeros_like(image, dtype=bool)
+    blank[:50, :] = True
+    image[blank] = np.nan
+
+    background, rms = robust_bane(image=image, header=_header())
+
+    assert np.isnan(background[blank]).all()
+    assert np.isnan(rms[blank]).all()
+    assert np.isfinite(background[~blank]).all()
+    assert np.isfinite(rms[~blank]).all()
+
+
+def test_the_seed_makes_a_rerun_reproducible() -> None:
+    """Clipped source pixels are refilled with random noise, so without a fixed
+    seed the same image gives different maps run to run."""
+    image = _sky()
+    # A cut low enough that the refilled pixels survive the downsampling; at the
+    # default 5 sigma only a handful of pixels are touched and the maps agree
+    # whatever the seed
+    options = FFTBANEOptions(clip_sigma=1.0)
+
+    first, _ = robust_bane(image=image, header=_header(), fft_bane_options=options)
+    again, _ = robust_bane(image=image, header=_header(), fft_bane_options=options)
+    assert np.array_equal(first, again)
+
+    other, _ = robust_bane(
+        image=image,
+        header=_header(),
+        fft_bane_options=options.with_options(seed=99),
+    )
+    assert not np.array_equal(first, other)
+
+
+def test_get_kernel_sizes_itself_from_the_beam() -> None:
+    """Unset sizes come from the restoring beam, at 3 and 10 beams. A negative
+    value keeps that behaviour but sets the beam count."""
+    kernel, step = get_kernel(header=_header())
+    assert step == 3 * PIX_PER_BEAM
+    assert kernel.max() == pytest.approx(1.0)
+
+    _, step = get_kernel(header=_header(), step_size=-5)
+    assert step == 5 * PIX_PER_BEAM
+
+    kernel, step = get_kernel(header=_header(), step_size=7, box_size=4)
+    assert step == 7
+    assert kernel.shape == gaussian_kernel(4).shape
+
+
+def test_get_kernel_needs_a_beam_it_can_read() -> None:
+    """Without a beam there is nothing to size the kernel against, so it says so
+    rather than picking a number."""
+    header = _header()
+    for key in ("BMAJ", "BMIN", "BPA"):
+        del header[key]
+
+    with pytest.raises(ValueError, match="Could not parse beam"):
+        get_kernel(header=header)
+
+
+def test_a_kernel_too_big_for_the_image_is_refused() -> None:
+    """``pad_reflect`` is njit-ed without bounds checking, so a kernel wider than
+    the image it pads reads off the end and returns quietly wrong maps. A small
+    image with a big step downsamples into exactly that."""
+    with pytest.raises(ValueError, match="does not fit"):
+        robust_bane(
+            image=np.zeros((64, 64), dtype=np.float32),
+            header=_header(),
+            fft_bane_options=FFTBANEOptions(step_size=16, box_size=32),
+        )
+
+
+def test_bane_fits_image_writes_maps_on_the_input_grid(tmp_path: Path) -> None:
+    """The maps are stacked into cubes beside the image they came from, so they
+    have to keep its shape, including the degenerate axes a linmos plane carries.
+    """
+    image = _sky(background=0.0, rms=1e-3)
+    header = _header()
+    # A linmos plane is (stokes, freq, ny, nx)
+    fits_path = tmp_path / "field.image.fits"
+    fits.writeto(fits_path, image[np.newaxis, np.newaxis], header, overwrite=True)
+
+    bkg_path, rms_path = bane_fits_image(image=fits_path)
+
+    assert bkg_path == tmp_path / "field.image_bkg.fits"
+    assert rms_path == tmp_path / "field.image_rms.fits"
+
+    for path in (bkg_path, rms_path):
+        assert path.exists()
+        assert fits.getdata(path).shape == (1, 1, NY, NX)
+
+    assert np.nanmedian(fits.getdata(rms_path)) == pytest.approx(1e-3, rel=0.3)
+
+
+def test_bane_fits_image_refuses_a_cube(tmp_path: Path) -> None:
+    """Only single planes are ported, so a real cube is an error rather than a
+    silently measured first channel."""
+    fits_path = tmp_path / "cube.fits"
+    fits.writeto(
+        fits_path, np.zeros((4, 32, 32), dtype=np.float32), _header(), overwrite=True
+    )
+
+    with pytest.raises(ValueError, match="expected a single plane"):
+        bane_fits_image(image=fits_path)

--- a/tests/test_bane.py
+++ b/tests/test_bane.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
 import numpy as np
@@ -205,3 +206,48 @@ def test_bane_fits_image_refuses_a_cube(tmp_path: Path) -> None:
 
     with pytest.raises(ValueError, match="expected a single plane"):
         bane_fits_image(image=fits_path)
+
+
+@pytest.mark.parametrize("beamless", ["missing", "zero"])
+def test_bane_fits_image_blanks_a_plane_with_no_beam(
+    tmp_path: Path, beamless: str, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A blank channel loses its beam keywords through linmos, or carries the
+    zero beam that marks it as holding no PSF. Neither can size a kernel, and
+    neither holds signal, so the maps come out blank rather than raising and
+    taking the whole cube with them."""
+    header = _header()
+    for key in ("BMAJ", "BMIN", "BPA"):
+        if beamless == "missing":
+            del header[key]
+        else:
+            header[key] = 0.0
+
+    fits_path = tmp_path / "field.image.fits"
+    fits.writeto(fits_path, _sky()[np.newaxis, np.newaxis], header, overwrite=True)
+
+    with caplog.at_level(logging.WARNING, logger="flint"):
+        bkg_path, rms_path = bane_fits_image(image=fits_path)
+
+    # A zero beam sizes a 1x1 all-NaN kernel rather than raising, so the maps
+    # coming out blank does not on its own say the beam was checked
+    assert "No usable beam" in caplog.text
+
+    for path in (bkg_path, rms_path):
+        assert fits.getdata(path).shape == (1, 1, NY, NX)
+        assert np.all(np.isnan(fits.getdata(path)))
+
+
+def test_robust_bane_without_a_beam_runs_on_given_sizes() -> None:
+    """The beam only sizes the kernel, so sizes given outright need no beam"""
+    header = _header()
+    for key in ("BMAJ", "BMIN", "BPA"):
+        del header[key]
+
+    background, rms = robust_bane(
+        image=_sky(background=0.0, rms=1e-3),
+        header=header,
+        fft_bane_options=FFTBANEOptions(step_size=10, box_size=10),
+    )
+    assert np.isfinite(background).all()
+    assert np.nanmedian(rms) == pytest.approx(1e-3, rel=0.3)

--- a/tests/test_bane.py
+++ b/tests/test_bane.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import tracemalloc
 import warnings
 from pathlib import Path
 
@@ -10,6 +11,7 @@ import numpy as np
 import pytest
 from astropy.io import fits
 from astropy.wcs import WCS
+from scipy import ndimage
 
 from flint.bane import (
     FFTBANEOptions,
@@ -172,10 +174,11 @@ def test_invalidate_zeros_can_be_turned_off() -> None:
 
 
 def test_the_rms_map_is_never_negative() -> None:
-    """The maps are zoomed back up with a cubic spline, which rings across the
-    step at a footprint edge and undershoots below zero. A negative noise
-    squares to a small variance, so an inverse-variance weight built from it
-    comes out orders of magnitude too large rather than obviously wrong."""
+    """A negative noise squares to a small variance, so an inverse-variance
+    weight built from it comes out orders of magnitude too large rather than
+    obviously wrong. The linear step back up to full resolution cannot
+    undershoot, but a spline rings across the step at a footprint edge and
+    does, so this holds whatever it is interpolated with."""
     inside = _footprint(radius=480)
     sky = _sky(rms=1e-3)
 
@@ -342,3 +345,129 @@ def test_robust_bane_without_a_beam_runs_on_given_sizes() -> None:
     )
     assert np.isfinite(background).all()
     assert np.nanmedian(rms) == pytest.approx(1e-3, rel=0.3)
+
+
+def test_the_working_memory_stays_a_small_multiple_of_the_plane() -> None:
+    """A channel is measured as one task on one worker, so the peak the routine
+    reaches - not the size of the maps it returns - is what has to fit. Held at
+    a few times the plane by keeping the seeds as scalars, building the clip
+    mask in place, and taking the validity mask already downsampled. The bound
+    is loose enough for numpy and scipy to allocate differently between
+    versions, and tight enough to catch a full-resolution array coming back."""
+    image = _sky()
+    header = _header()
+
+    # numba compiles on the first call, and the compilation allocates
+    robust_bane(image=image, header=header)
+
+    for options in (
+        FFTBANEOptions(),
+        FFTBANEOptions(step_size=8, box_size=12),
+        # A cut this low makes a source of most of the plane, so the refill
+        # draws its noise in bulk
+        FFTBANEOptions(clip_sigma=1.0),
+    ):
+        tracemalloc.start()
+        robust_bane(image=image, header=header, fft_bane_options=options)
+        _, peak = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+
+        assert peak < 7 * image.nbytes, (
+            f"{options} peaked at {peak / image.nbytes:.1f}x the plane"
+        )
+
+
+def test_a_wider_plane_is_measured_as_float32() -> None:
+    """``bane_fft`` is compiled for float32 alone. A plane read from a FITS file
+    is float32 already, but a caller computing one in double precision should
+    get the maps rather than a numba typing error."""
+    image = _sky()
+    background, rms = robust_bane(image=image, header=_header())
+    wide_background, wide_rms = robust_bane(
+        image=image.astype(np.float64), header=_header()
+    )
+
+    assert wide_background.dtype == background.dtype == np.float32
+    assert wide_rms.dtype == rms.dtype == np.float32
+    assert np.array_equal(wide_background, background, equal_nan=True)
+    assert np.array_equal(wide_rms, rms, equal_nan=True)
+
+
+def test_fft_average_puts_the_smoothed_pixel_over_the_pixel_it_smooths() -> None:
+    """The kernel is zero-padded out to the image shape, which centres it on the
+    origin rather than on the pixel it smooths unless the window is taken at the
+    matching displacement. A flat image cannot show this - convolving a delta
+    can, and so can comparing against a convolution that is centred by
+    construction."""
+    image = np.zeros((64, 64), dtype=np.float32)
+    image[32, 20] = 1.0
+
+    for kernel in (gaussian_kernel(6), gaussian_kernel(9), tophat_kernel(8)):
+        kernel = (kernel / kernel.max()).astype(np.float32)
+        smoothed = fft_average(np.ascontiguousarray(image), kernel)
+
+        # Centre of mass rather than the brightest pixel: a tophat answers a
+        # delta with a disc of equal values, whose argmax is its first row
+        centre = ndimage.center_of_mass(smoothed)
+        assert centre == pytest.approx((32.0, 20.0), abs=0.01), (
+            f"a {kernel.shape} kernel moved the delta to {centre}"
+        )
+
+        # `pad_reflect` is np.pad's "reflect", which scipy calls "mirror"
+        centred = ndimage.convolve(image, kernel / kernel.sum(), mode="mirror")
+        assert np.allclose(smoothed, centred, atol=1e-6)
+
+
+def test_the_noise_map_lines_up_with_the_noise_it_measures() -> None:
+    """A background or noise map is read against the image it came from, so
+    where it puts a feature matters as much as the value it puts there. Both the
+    kernel centring and the step back up to full resolution can displace it, by
+    tens of pixels each and both in the same direction."""
+    shape = (512, 512)
+    centre_y, centre_x = 300, 180
+    yy, xx = np.mgrid[0 : shape[0], 0 : shape[1]].astype(np.float32)
+    # A smooth blob of louder noise: no edge, so nothing that could bias a
+    # centre by the way the map averages variance rather than amplitude
+    amplitude = 1.0 + 5.0 * np.exp(
+        -0.5 * (((xx - centre_x) / 50) ** 2 + ((yy - centre_y) / 50) ** 2)
+    )
+    rng = np.random.default_rng(11)
+    image = (rng.normal(0.0, 1e-3, shape) * amplitude).astype(np.float32)
+
+    _, rms = robust_bane(
+        image=image,
+        header=_header(shape),
+        fft_bane_options=FFTBANEOptions(step_size=10, box_size=6),
+    )
+
+    peak_y, peak_x = np.unravel_index(int(np.nanargmax(rms)), rms.shape)
+    # Comfortable for a blob this broad, and nowhere near the sixty-odd pixels
+    # an uncentred kernel and a wrongly scaled step back up cost between them
+    assert abs(peak_y - centre_y) < 10, f"noise peak {peak_y} rows from {centre_y}"
+    assert abs(peak_x - centre_x) < 10, f"noise peak {peak_x} columns from {centre_x}"
+
+
+def test_a_plane_measured_without_downsampling() -> None:
+    """``step_size=0`` smooths the plane at its own resolution, which is the one
+    path that never steps the maps back up. The kernel still has to be centred
+    on the pixel it smooths, so a blob of louder noise stays where it was put."""
+    shape = (512, 512)
+    centre_y, centre_x = 300, 180
+    yy, xx = np.mgrid[0 : shape[0], 0 : shape[1]].astype(np.float32)
+    amplitude = 1.0 + 5.0 * np.exp(
+        -0.5 * (((xx - centre_x) / 50) ** 2 + ((yy - centre_y) / 50) ** 2)
+    )
+    rng = np.random.default_rng(11)
+    image = (rng.normal(0.0, 1e-3, shape) * amplitude).astype(np.float32)
+
+    background, rms = robust_bane(
+        image=image,
+        header=_header(shape),
+        fft_bane_options=FFTBANEOptions(step_size=0, box_size=12),
+    )
+
+    assert np.isfinite(background).all()
+    assert np.isfinite(rms).all()
+    peak_y, peak_x = np.unravel_index(int(np.nanargmax(rms)), rms.shape)
+    assert abs(peak_y - centre_y) < 10, f"noise peak {peak_y} rows from {centre_y}"
+    assert abs(peak_x - centre_x) < 10, f"noise peak {peak_x} columns from {centre_x}"

--- a/tests/test_channel_division.py
+++ b/tests/test_channel_division.py
@@ -25,7 +25,7 @@ from flint.imager.wsclean import (
     WSCleanOptions,
     _resolve_wsclean_key_value_to_cli_str,
 )
-from flint.prefect.flows.racs_all_continuum_selfcal import _apply_cube_division
+from flint.prefect.flows.racs_all_continuum_selfcal import apply_cube_division
 
 
 def mock_wsclean_division(
@@ -209,7 +209,7 @@ def test_apply_cube_division() -> None:
         n_blank_planes=0,
     )
 
-    updated = _apply_cube_division(
+    updated = apply_cube_division(
         update_wsclean_options={"channels_out": 16, "niter": 10},
         cube_division=division,
     )
@@ -222,7 +222,7 @@ def test_apply_cube_division() -> None:
     # An explicit division in the strategy is left alone
     pinned = {"channels_out": 16, "channel_division_frequencies": (3e9,)}
     assert (
-        _apply_cube_division(update_wsclean_options=pinned, cube_division=division)
+        apply_cube_division(update_wsclean_options=pinned, cube_division=division)
         == pinned
     )
 

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -621,6 +621,24 @@ def test_polarisation_fitscube_sibling_mode(package_strategy_polarisation) -> No
     assert fitscube_options["compress_method"] == "gzip"
 
 
+def test_polarisation_spice_sibling_mode(package_strategy_polarisation) -> None:
+    """spice, like fitscube, sits directly under the polarisation operation
+    as a sibling of the total/linear/circular polarisation types."""
+    strategy = package_strategy_polarisation
+    strategy["polarisation"]["spice"] = {
+        "n_beamwidths": 2.0,
+    }
+
+    verify_configuration(input_strategy=strategy)
+
+    spice_options = get_options_from_strategy(
+        strategy=strategy,
+        operation="polarisation",
+        mode="spice",
+    )
+    assert spice_options["n_beamwidths"] == 2.0
+
+
 def test_verify_polarisation_catches_bad_override(
     package_strategy_polarisation,
 ) -> None:

--- a/tests/test_convol.py
+++ b/tests/test_convol.py
@@ -5,13 +5,19 @@ from __future__ import annotations
 import shutil
 from pathlib import Path
 
+import astropy.units as u
 import numpy as np
 import pytest
 from astropy.io import fits
+from astropy.table import Table
+from astropy.wcs import WCS
 
 from flint.convol import (
     BeamShape,
     check_if_cube_fits,
+    common_beam_from_cubes,
+    convolve_cubes_to_common_beam,
+    cubes_share_common_beam,
     get_cube_common_beam,
 )
 from flint.utils import get_packaged_resource_path
@@ -210,3 +216,114 @@ def test_get_cube_common_beam_and_convol_cubes(cube_fits) -> None:
 #     )
 #     assert all([isinstance(p, Path) for p in cube_paths])
 #     assert all([p.exists() for p in cube_paths])
+
+
+def _write_cube_with_beam(path: Path, bmaj_arcsec: list[float]) -> Path:
+    """Write a small ASKAP-shaped (chan, stokes, dec, ra) cube whose channels
+    carry the requested major axes"""
+    n_chan = len(bmaj_arcsec)
+    freq_hz = np.linspace(700e6, 1300e6, n_chan)
+
+    wcs = WCS(naxis=4)
+    wcs.wcs.ctype = ["RA---SIN", "DEC--SIN", "STOKES", "FREQ"]
+    wcs.wcs.crval = [180.0, -30.0, 1.0, freq_hz[0]]
+    wcs.wcs.crpix = [8, 8, 1, 1]
+    wcs.wcs.cdelt = [-1e-3, 1e-3, 1.0, freq_hz[1] - freq_hz[0]]
+    wcs.wcs.cunit = ["deg", "deg", "", "Hz"]
+
+    rng = np.random.default_rng(0)
+    primary = fits.PrimaryHDU(
+        data=rng.normal(0, 1e-3, (n_chan, 1, 16, 16)).astype(np.float32),
+        header=wcs.to_header(),
+    )
+    primary.header["BUNIT"] = "Jy/beam"
+    primary.header["CASAMBM"] = True
+
+    beam_table = fits.table_to_hdu(
+        Table(
+            data=[
+                np.array(bmaj_arcsec, dtype="f4"),
+                np.array(bmaj_arcsec, dtype="f4") * 0.8,
+                np.zeros(n_chan, dtype="f4"),
+                np.arange(n_chan, dtype="i4"),
+                np.zeros(n_chan, dtype="i4"),
+            ],
+            names=["BMAJ", "BMIN", "BPA", "CHAN", "POL"],
+            units=["arcsec", "arcsec", "deg", None, None],
+        )
+    )
+    beam_table.header["EXTNAME"] = "BEAMS"
+
+    fits.HDUList([primary, beam_table]).writeto(path, overwrite=True)
+    return path
+
+
+def test_cubes_share_common_beam(tmp_path) -> None:
+    """Cubes only share a resolution when every channel of every cube matches"""
+    matching = [
+        _write_cube_with_beam(tmp_path / f"match_{pol}.fits", [10.0] * 3)
+        for pol in ("q", "u")
+    ]
+    assert cubes_share_common_beam(cube_paths=matching)
+
+    varying = _write_cube_with_beam(tmp_path / "vary.fits", [10.0, 11.0, 12.0])
+    assert not cubes_share_common_beam(cube_paths=[*matching, varying])
+
+    # Differing only across Stokes is enough to need a convolution
+    offset = _write_cube_with_beam(tmp_path / "offset.fits", [10.5] * 3)
+    assert not cubes_share_common_beam(cube_paths=[matching[0], offset])
+
+
+def test_cubes_share_common_beam_without_beams(tmp_path) -> None:
+    """A cube carrying no beam information has no resolution to make common"""
+    cube = _write_cube_with_beam(tmp_path / "no_beam.fits", [10.0] * 3)
+    with fits.open(cube, mode="update") as open_fits:
+        del open_fits["BEAMS"]
+        del open_fits[0].header["CASAMBM"]
+
+    assert cubes_share_common_beam(cube_paths=[cube])
+
+
+def test_convolve_cubes_to_common_beam(tmp_path) -> None:
+    """Convolving leaves the input cubes alone, writes new cubes on the same
+    pixel grid, and brings every channel of every cube to the one beam"""
+    cubes = [
+        _write_cube_with_beam(
+            tmp_path / f"stokes_{pol}.fits",
+            [10.0 + offset, 11.0 + offset, 12.0 + offset],
+        )
+        for pol, offset in (("q", 0.0), ("u", 0.5))
+    ]
+    output_path = tmp_path / "rmsynth"
+
+    convolved = convolve_cubes_to_common_beam(cube_paths=cubes, output_path=output_path)
+
+    assert all(cube.exists() for cube in cubes), "the input cubes were consumed"
+    assert not set(convolved) & set(cubes)
+    assert all(cube.parent == output_path for cube in convolved)
+    # The outputs must pair back to their inputs, which smooth_fits_cube sorts
+    assert [cube.name for cube in convolved] == [
+        "stokes_q.conv.fits",
+        "stokes_u.conv.fits",
+    ]
+    for cube, convolved_cube in zip(cubes, convolved):
+        assert fits.getdata(convolved_cube).shape == fits.getdata(cube).shape
+    assert cubes_share_common_beam(cube_paths=convolved)
+
+
+def test_common_beam_from_cubes(tmp_path: Path) -> None:
+    """The beam every channel of every cube fits inside. The spice stage sizes
+    its island boxes on this, so a box holds its island in the coarsest cube
+    rather than only in the finer reference image."""
+    cubes = [
+        _write_cube_with_beam(tmp_path / "fine.fits", [10.0, 11.0, 12.0]),
+        _write_cube_with_beam(tmp_path / "coarse.fits", [14.0] * 3),
+    ]
+
+    common_beam = common_beam_from_cubes(cube_paths=cubes)
+
+    assert common_beam.major.to(u.arcsec).value >= 14.0
+    # A single cube's own coarsest channel, not the set's
+    assert common_beam_from_cubes(cube_paths=cubes[:1]).major.to(
+        u.arcsec
+    ).value == pytest.approx(12.0, rel=1e-3)

--- a/tests/test_convol.py
+++ b/tests/test_convol.py
@@ -11,14 +11,21 @@ import pytest
 from astropy.io import fits
 from astropy.table import Table
 from astropy.wcs import WCS
+from fitscube.extract import ExtractOptions, extract_plane_from_cube
+from radio_beam import Beam, Beams
+from radio_beam.utils import BeamError
 
 from flint.convol import (
     BeamShape,
+    _beams_from_cubes,
     check_if_cube_fits,
     common_beam_from_cubes,
-    convolve_cubes_to_common_beam,
+    common_beam_shape_from_cubes,
+    convolve_plane_to_beam,
     cubes_share_common_beam,
     get_cube_common_beam,
+    header_beam_is_usable,
+    usable_beam_mask,
 )
 from flint.utils import get_packaged_resource_path
 
@@ -284,31 +291,121 @@ def test_cubes_share_common_beam_without_beams(tmp_path) -> None:
     assert cubes_share_common_beam(cube_paths=[cube])
 
 
-def test_convolve_cubes_to_common_beam(tmp_path) -> None:
-    """Convolving leaves the input cubes alone, writes new cubes on the same
-    pixel grid, and brings every channel of every cube to the one beam"""
-    cubes = [
-        _write_cube_with_beam(
-            tmp_path / f"stokes_{pol}.fits",
-            [10.0 + offset, 11.0 + offset, 12.0 + offset],
-        )
-        for pol, offset in (("q", 0.0), ("u", 0.5))
-    ]
-    output_path = tmp_path / "rmsynth"
+def test_cubes_share_common_beam_with_placeholder_beams(tmp_path) -> None:
+    """A blanked channel carries a placeholder rather than a resolution, so it
+    neither breaks a common beam nor makes one out of cubes that have none"""
+    tiny = float(np.finfo(np.float32).tiny)
+    blanked = _write_cube_with_beam(tmp_path / "blanked.fits", [10.0, 0.0, tiny])
+    assert cubes_share_common_beam(cube_paths=[blanked])
 
-    convolved = convolve_cubes_to_common_beam(cube_paths=cubes, output_path=output_path)
+    all_blank = _write_cube_with_beam(tmp_path / "all_blank.fits", [0.0, tiny, 0.0])
+    assert cubes_share_common_beam(cube_paths=[all_blank])
 
-    assert all(cube.exists() for cube in cubes), "the input cubes were consumed"
-    assert not set(convolved) & set(cubes)
-    assert all(cube.parent == output_path for cube in convolved)
-    # The outputs must pair back to their inputs, which smooth_fits_cube sorts
-    assert [cube.name for cube in convolved] == [
-        "stokes_q.conv.fits",
-        "stokes_u.conv.fits",
+    varying = _write_cube_with_beam(tmp_path / "vary.fits", [10.0, 11.0, 0.0])
+    assert not cubes_share_common_beam(cube_paths=[varying])
+
+
+def test_cubes_share_common_beam_with_cutoff(tmp_path) -> None:
+    """A channel coarser than the cutoff is one to blank, which only the
+    convolution pass does"""
+    coarse = _write_cube_with_beam(tmp_path / "coarse.fits", [10.0, 10.0, 40.0])
+
+    assert not cubes_share_common_beam(cube_paths=[coarse], cutoff=20.0)
+    # Every channel beyond the cutoff leaves nothing to convolve to
+    assert cubes_share_common_beam(cube_paths=[coarse], cutoff=5.0)
+
+
+def _write_plane_with_beam(path: Path, bmaj_arcsec: float | None) -> Path:
+    """A single channel image, cut out of a cube exactly as
+    ``split_cube_into_planes`` does, so the plane carries its channel's beam"""
+    cube = _write_cube_with_beam(
+        path.with_name(f"cube.{path.name}"), [bmaj_arcsec or 0.0] * 2
+    )
+    plane = extract_plane_from_cube(
+        fits_cube=cube,
+        extract_options=ExtractOptions(
+            channel_index=0, output_path=path, overwrite=True
+        ),
+    )
+    if bmaj_arcsec is None:
+        with fits.open(plane, mode="update") as open_fits:
+            for key in ("BMAJ", "BMIN", "BPA"):
+                open_fits[0].header.pop(key, None)
+    return plane
+
+
+def test_usable_beam_mask() -> None:
+    """The placeholders a blank channel carries are not resolutions to convolve to"""
+    tiny = np.finfo(np.float32).tiny
+    beams = Beams(
+        major=[10.0, 0.0, tiny, 40.0, np.nan] * u.arcsec,
+        minor=[8.0, 0.0, tiny, 32.0, np.nan] * u.arcsec,
+        pa=[0.0, 0.0, tiny, 0.0, np.nan] * u.deg,
+    )
+
+    assert list(usable_beam_mask(beams=beams)) == [True, False, False, True, False]
+    assert list(usable_beam_mask(beams=beams, cutoff=20.0)) == [
+        True,
+        False,
+        False,
+        False,
+        False,
     ]
-    for cube, convolved_cube in zip(cubes, convolved):
-        assert fits.getdata(convolved_cube).shape == fits.getdata(cube).shape
-    assert cubes_share_common_beam(cube_paths=convolved)
+
+
+def test_header_beam_is_usable(tmp_path: Path) -> None:
+    """A plane's own header is read the same way as a cube's beam table"""
+    assert header_beam_is_usable(
+        header=fits.getheader(_write_plane_with_beam(tmp_path / "good.fits", 10.0))
+    )
+    assert not header_beam_is_usable(
+        header=fits.getheader(_write_plane_with_beam(tmp_path / "zero.fits", 0.0))
+    )
+    assert not header_beam_is_usable(
+        header=fits.getheader(_write_plane_with_beam(tmp_path / "none.fits", None))
+    )
+    assert not header_beam_is_usable(
+        header=fits.getheader(_write_plane_with_beam(tmp_path / "coarse.fits", 40.0)),
+        cutoff=20.0,
+    )
+
+
+def test_convolve_plane_to_beam(tmp_path: Path) -> None:
+    """A plane is convolved to the target beam, leaving the input in place"""
+    plane = _write_plane_with_beam(tmp_path / "stokes_q.ch0000-0000.fits", 10.0)
+    beam_shape = BeamShape(bmaj_arcsec=14.0, bmin_arcsec=12.0, bpa_deg=0.0)
+
+    convolved = convolve_plane_to_beam(plane=plane, beam_shape=beam_shape)
+
+    assert plane.exists(), "the input plane was consumed"
+    assert convolved == tmp_path / "stokes_q.ch0000-0000.conv.fits"
+    header = fits.getheader(convolved)
+    assert header["BMAJ"] * 3600.0 == pytest.approx(14.0)
+    assert header["BMIN"] * 3600.0 == pytest.approx(12.0)
+    assert fits.getdata(convolved).shape == fits.getdata(plane).shape
+
+
+def test_convolve_plane_to_beam_beyond_cutoff(tmp_path: Path) -> None:
+    """A plane coarser than the cutoff is blanked, and marked as holding no PSF
+    so the cube it is stacked into does not claim one for that channel"""
+    plane = _write_plane_with_beam(tmp_path / "stokes_q.ch0000-0000.fits", 40.0)
+    beam_shape = BeamShape(bmaj_arcsec=14.0, bmin_arcsec=12.0, bpa_deg=0.0)
+
+    convolved = convolve_plane_to_beam(plane=plane, beam_shape=beam_shape, cutoff=20.0)
+
+    assert np.all(np.isnan(fits.getdata(convolved)))
+    assert fits.getheader(convolved)["BMAJ"] == 0.0
+
+
+def test_convolve_plane_to_beam_without_beam(tmp_path: Path) -> None:
+    """A plane carrying no PSF has no resolution to change, so it is copied through"""
+    plane = _write_plane_with_beam(tmp_path / "stokes_q.ch0000-0000.fits", 0.0)
+    beam_shape = BeamShape(bmaj_arcsec=14.0, bmin_arcsec=12.0, bpa_deg=0.0)
+
+    convolved = convolve_plane_to_beam(plane=plane, beam_shape=beam_shape, cutoff=20.0)
+
+    assert fits.getheader(convolved)["BMAJ"] == 0.0
+    assert np.array_equal(fits.getdata(convolved), fits.getdata(plane))
 
 
 def test_common_beam_from_cubes(tmp_path: Path) -> None:
@@ -322,8 +419,81 @@ def test_common_beam_from_cubes(tmp_path: Path) -> None:
 
     common_beam = common_beam_from_cubes(cube_paths=cubes)
 
+    assert common_beam is not None
     assert common_beam.major.to(u.arcsec).value >= 14.0
     # A single cube's own coarsest channel, not the set's
-    assert common_beam_from_cubes(cube_paths=cubes[:1]).major.to(
-        u.arcsec
-    ).value == pytest.approx(12.0, rel=1e-3)
+    single_cube_beam = common_beam_from_cubes(cube_paths=cubes[:1])
+    assert single_cube_beam is not None
+    assert single_cube_beam.major.to(u.arcsec).value == pytest.approx(12.0, rel=1e-3)
+
+    # A channel beyond the cutoff is left out rather than dragging the common
+    # beam out to its resolution
+    cut_beam = common_beam_from_cubes(cube_paths=cubes, cutoff=13.0)
+    assert cut_beam is not None
+    assert cut_beam.major.to(u.arcsec).value == pytest.approx(12.0, rel=1e-2)
+
+    # Every channel has to deconvolve the common beam to reach it, and the
+    # minimum enclosing ellipse sits right against the beams it encloses, so the
+    # solution is rounded up onto a tenth of an arcsecond for headroom
+    for axis in (common_beam.major, common_beam.minor):
+        arcsec = axis.to(u.arcsec).value
+        assert arcsec == pytest.approx(round(arcsec, 1), abs=1e-6)
+        assert (
+            arcsec >= _beams_from_cubes(cube_paths=cubes).major.to(u.arcsec).value.min()
+        )
+
+
+def test_common_beam_from_cubes_without_usable_beams(tmp_path: Path) -> None:
+    """Nothing but placeholder beams constrains no common beam. radio_beam
+    reduces such a set to an empty sequence and raises an opaque argmax error,
+    so it is never handed one."""
+    tiny = float(np.finfo(np.float32).tiny)
+    blank = _write_cube_with_beam(tmp_path / "blank.fits", [0.0, tiny, 0.0])
+
+    assert common_beam_from_cubes(cube_paths=[blank]) is None
+    # Nor when every real beam is beyond the cutoff
+    coarse = _write_cube_with_beam(tmp_path / "coarse.fits", [40.0] * 3)
+    assert common_beam_from_cubes(cube_paths=[coarse], cutoff=20.0) is None
+    # Nor when there is no beam recorded at all
+    no_beam = _write_cube_with_beam(tmp_path / "no_beam.fits", [10.0] * 3)
+    with fits.open(no_beam, mode="update") as open_fits:
+        del open_fits["BEAMS"]
+        del open_fits[0].header["CASAMBM"]
+    assert common_beam_from_cubes(cube_paths=[no_beam]) is None
+
+
+def test_common_beam_from_cubes_retries_on_beam_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """radio_beam can fail to enclose a set of beams at its default tolerance,
+    which is retried at a tenth of it rather than given up on"""
+    cube = _write_cube_with_beam(tmp_path / "fine.fits", [10.0, 11.0, 12.0])
+    solved = Beams.common_beam
+    tolerances: list[float | None] = []
+
+    def _fails_once(self: Beams, **kwargs: float) -> Beam:
+        tolerances.append(kwargs.get("tolerance"))
+        if len(tolerances) == 1:
+            raise BeamError("Could not find common beam")
+        return solved(self, **kwargs)
+
+    monkeypatch.setattr(Beams, "common_beam", _fails_once)
+
+    assert common_beam_from_cubes(cube_paths=[cube]) is not None
+    assert tolerances[0] is None, "the first solve should use the defaults"
+    assert tolerances[1] is not None and tolerances[1] < 1e-4
+
+
+def test_common_beam_shape_from_cubes(tmp_path: Path) -> None:
+    """The spice stage cannot size its island boxes without a beam, so it takes
+    one that raises rather than one it has to None-check"""
+    cube = _write_cube_with_beam(tmp_path / "fine.fits", [10.0, 11.0, 12.0])
+
+    beam_shape = common_beam_shape_from_cubes(cube_paths=[cube])
+
+    assert beam_shape.bmaj_arcsec == pytest.approx(12.0, rel=1e-2)
+
+    tiny = float(np.finfo(np.float32).tiny)
+    blank = _write_cube_with_beam(tmp_path / "blank.fits", [0.0, tiny, 0.0])
+    with pytest.raises(ValueError, match="No usable restoring beam"):
+        common_beam_shape_from_cubes(cube_paths=[blank])

--- a/tests/test_convol.py
+++ b/tests/test_convol.py
@@ -18,9 +18,11 @@ from radio_beam.utils import BeamError
 from flint.convol import (
     BeamShape,
     _beams_from_cubes,
+    blank_images,
     check_if_cube_fits,
     common_beam_from_cubes,
     common_beam_shape_from_cubes,
+    convolve_images_or_blank,
     convolve_plane_to_beam,
     cubes_share_common_beam,
     get_cube_common_beam,
@@ -497,3 +499,54 @@ def test_common_beam_shape_from_cubes(tmp_path: Path) -> None:
     blank = _write_cube_with_beam(tmp_path / "blank.fits", [0.0, tiny, 0.0])
     with pytest.raises(ValueError, match="No usable restoring beam"):
         common_beam_shape_from_cubes(cube_paths=[blank])
+
+
+def test_blank_images(tmp_path: Path) -> None:
+    """A blanked image holds no data and claims no PSF"""
+    planes = [
+        _write_plane_with_beam(tmp_path / f"stokes_q.ch000{idx}-000{idx}.fits", 10.0)
+        for idx in range(2)
+    ]
+
+    blanked = blank_images(image_paths=planes)
+
+    assert blanked == [
+        tmp_path / "stokes_q.ch0000-0000.conv.fits",
+        tmp_path / "stokes_q.ch0001-0001.conv.fits",
+    ]
+    for plane, blank in zip(planes, blanked):
+        assert plane.exists(), "the input image was consumed"
+        assert np.all(np.isnan(fits.getdata(blank)))
+        assert fits.getdata(blank).shape == fits.getdata(plane).shape
+        assert not header_beam_is_usable(header=fits.getheader(blank))
+
+
+def test_convolve_images_or_blank(tmp_path: Path) -> None:
+    """A defined beam is convolved to, as convolve_images would"""
+    plane = _write_plane_with_beam(tmp_path / "stokes_q.ch0000-0000.fits", 10.0)
+    beam_shape = BeamShape(bmaj_arcsec=14.0, bmin_arcsec=12.0, bpa_deg=0.0)
+
+    convolved = convolve_images_or_blank(image_paths=[plane], beam_shape=beam_shape)
+
+    assert convolved == [tmp_path / "stokes_q.ch0000-0000.conv.fits"]
+    assert fits.getheader(convolved[0])["BMAJ"] * 3600.0 == pytest.approx(14.0)
+    assert np.isfinite(fits.getdata(convolved[0])).any()
+
+
+def test_convolve_images_or_blank_without_a_beam(tmp_path: Path) -> None:
+    """An undefined beam blanks rather than copying the images through at their
+    own differing resolutions, which whatever they are co-added into would then
+    misreport as a single beam"""
+    planes = [
+        _write_plane_with_beam(tmp_path / "stokes_q.ch0000-0000.fits", 40.0),
+        _write_plane_with_beam(tmp_path / "stokes_q.ch0001-0001.fits", 50.0),
+    ]
+    beam_shape = BeamShape(bmaj_arcsec=np.nan, bmin_arcsec=np.nan, bpa_deg=np.nan)
+
+    convolved = convolve_images_or_blank(
+        image_paths=planes, beam_shape=beam_shape, cutoff=20.0
+    )
+
+    for blank in convolved:
+        assert np.all(np.isnan(fits.getdata(blank)))
+        assert not header_beam_is_usable(header=fits.getheader(blank))

--- a/tests/test_convol.py
+++ b/tests/test_convol.py
@@ -318,7 +318,7 @@ def test_cubes_share_common_beam_with_cutoff(tmp_path) -> None:
 
 
 def _write_plane_with_beam(path: Path, bmaj_arcsec: float | None) -> Path:
-    """A single channel image, cut out of a cube exactly as
+    """A single channel image, cut out of a cube the way
     ``split_cube_into_planes`` does, so the plane carries its channel's beam"""
     cube = _write_cube_with_beam(
         path.with_name(f"cube.{path.name}"), [bmaj_arcsec or 0.0] * 2

--- a/tests/test_imagesets.py
+++ b/tests/test_imagesets.py
@@ -1,0 +1,188 @@
+"""Test operations around image sets"""
+
+from __future__ import annotations
+
+from pathlib import PosixPath
+
+import pytest
+
+from flint.imager.wsclean import ImageSet, split_and_get_image_set
+
+
+@pytest.fixture
+def example_image_set() -> ImageSet:
+    """Fixture for an example ImageSet object"""
+    return ImageSet(
+        prefix="/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol",
+        image=[
+            PosixPath(
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0000-Q.image.fits"
+            ),
+            PosixPath(
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0001-Q.image.fits"
+            ),
+            PosixPath(
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0002-Q.image.fits"
+            ),
+            PosixPath(
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0003-Q.image.fits"
+            ),
+            PosixPath(
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0004-Q.image.fits"
+            ),
+            PosixPath(
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0005-Q.image.fits"
+            ),
+            PosixPath(
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0006-Q.image.fits"
+            ),
+            PosixPath(
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0007-Q.image.fits"
+            ),
+            PosixPath(
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0008-Q.image.fits"
+            ),
+            PosixPath(
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0009-Q.image.fits"
+            ),
+            PosixPath(
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0010-Q.image.fits"
+            ),
+            PosixPath(
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0011-Q.image.fits"
+            ),
+            PosixPath(
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0012-Q.image.fits"
+            ),
+            PosixPath(
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0013-Q.image.fits"
+            ),
+            PosixPath(
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0014-Q.image.fits"
+            ),
+            PosixPath(
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0015-Q.image.fits"
+            ),
+            PosixPath(
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0016-Q.image.fits"
+            ),
+            PosixPath(
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0017-Q.image.fits"
+            ),
+            PosixPath(
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0018-Q.image.fits"
+            ),
+            PosixPath(
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0019-Q.image.fits"
+            ),
+            PosixPath(
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0020-Q.image.fits"
+            ),
+            PosixPath(
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0021-Q.image.fits"
+            ),
+            PosixPath(
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0022-Q.image.fits"
+            ),
+            PosixPath(
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-MFS-Q.image.fits"
+            ),
+            PosixPath(
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0000-U.image.fits"
+            ),
+            PosixPath(
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0001-U.image.fits"
+            ),
+            PosixPath(
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0002-U.image.fits"
+            ),
+            PosixPath(
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0003-U.image.fits"
+            ),
+            PosixPath(
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0004-U.image.fits"
+            ),
+            PosixPath(
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0005-U.image.fits"
+            ),
+            PosixPath(
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0006-U.image.fits"
+            ),
+            PosixPath(
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0007-U.image.fits"
+            ),
+            PosixPath(
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0008-U.image.fits"
+            ),
+            PosixPath(
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0009-U.image.fits"
+            ),
+            PosixPath(
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0010-U.image.fits"
+            ),
+            PosixPath(
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0011-U.image.fits"
+            ),
+            PosixPath(
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0012-U.image.fits"
+            ),
+            PosixPath(
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0013-U.image.fits"
+            ),
+            PosixPath(
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0014-U.image.fits"
+            ),
+            PosixPath(
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0015-U.image.fits"
+            ),
+            PosixPath(
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0016-U.image.fits"
+            ),
+            PosixPath(
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0017-U.image.fits"
+            ),
+            PosixPath(
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0018-U.image.fits"
+            ),
+            PosixPath(
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0019-U.image.fits"
+            ),
+            PosixPath(
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0020-U.image.fits"
+            ),
+            PosixPath(
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0021-U.image.fits"
+            ),
+            PosixPath(
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0022-U.image.fits"
+            ),
+            PosixPath(
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-MFS-U.image.fits"
+            ),
+        ],
+        psf=None,
+        dirty=None,
+        model=None,
+        residual=[
+            PosixPath(
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-MFS-Q.residual.fits"
+            ),
+            PosixPath(
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-MFS-U.residual.fits"
+            ),
+        ],
+        source_list=None,
+    )
+
+
+def test_split_and_get_image_set(example_image_set: ImageSet) -> None:
+    """Split a image set into separate images based on the file name"""
+    # Tracing down an error when developing racs-all pipeline. More tests are ok.
+    results = split_and_get_image_set(
+        image_set=example_image_set,
+        get="qu",
+        by="pol",
+        mode="image",
+    )
+
+    assert len(results) == len(example_image_set.image)

--- a/tests/test_imagesets.py
+++ b/tests/test_imagesets.py
@@ -11,178 +11,51 @@ from flint.imager.wsclean import ImageSet, split_and_get_image_set
 
 @pytest.fixture
 def example_image_set() -> ImageSet:
-    """Fixture for an example ImageSet object"""
+    """Fixture for an example ImageSet object, reflecting the naming produced by a
+    joint Stokes Q/U wsclean run once it has gone through
+    ``rename_wsclean_prefix_in_image_set`` - wsclean's own per-image ``-Q``/``-U``
+    tag is folded into a single-letter ``pol`` field per image (see
+    ``_rename_wsclean_title``), rather than every image sharing the joint ``qu`` tag."""
+    base = "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1"
+    channels = [f"{i:04d}" for i in range(23)] + ["MFS"]
     return ImageSet(
-        prefix="/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu",
+        prefix=f"{base}.qu",
         image=[
-            PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0000-Q.image.fits"
-            ),
-            PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0001-Q.image.fits"
-            ),
-            PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0002-Q.image.fits"
-            ),
-            PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0003-Q.image.fits"
-            ),
-            PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0004-Q.image.fits"
-            ),
-            PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0005-Q.image.fits"
-            ),
-            PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0006-Q.image.fits"
-            ),
-            PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0007-Q.image.fits"
-            ),
-            PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0008-Q.image.fits"
-            ),
-            PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0009-Q.image.fits"
-            ),
-            PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0010-Q.image.fits"
-            ),
-            PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0011-Q.image.fits"
-            ),
-            PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0012-Q.image.fits"
-            ),
-            PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0013-Q.image.fits"
-            ),
-            PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0014-Q.image.fits"
-            ),
-            PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0015-Q.image.fits"
-            ),
-            PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0016-Q.image.fits"
-            ),
-            PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0017-Q.image.fits"
-            ),
-            PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0018-Q.image.fits"
-            ),
-            PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0019-Q.image.fits"
-            ),
-            PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0020-Q.image.fits"
-            ),
-            PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0021-Q.image.fits"
-            ),
-            PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0022-Q.image.fits"
-            ),
-            PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-MFS-Q.image.fits"
-            ),
-            PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0000-U.image.fits"
-            ),
-            PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0001-U.image.fits"
-            ),
-            PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0002-U.image.fits"
-            ),
-            PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0003-U.image.fits"
-            ),
-            PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0004-U.image.fits"
-            ),
-            PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0005-U.image.fits"
-            ),
-            PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0006-U.image.fits"
-            ),
-            PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0007-U.image.fits"
-            ),
-            PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0008-U.image.fits"
-            ),
-            PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0009-U.image.fits"
-            ),
-            PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0010-U.image.fits"
-            ),
-            PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0011-U.image.fits"
-            ),
-            PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0012-U.image.fits"
-            ),
-            PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0013-U.image.fits"
-            ),
-            PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0014-U.image.fits"
-            ),
-            PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0015-U.image.fits"
-            ),
-            PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0016-U.image.fits"
-            ),
-            PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0017-U.image.fits"
-            ),
-            PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0018-U.image.fits"
-            ),
-            PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0019-U.image.fits"
-            ),
-            PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0020-U.image.fits"
-            ),
-            PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0021-U.image.fits"
-            ),
-            PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0022-U.image.fits"
-            ),
-            PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-MFS-U.image.fits"
-            ),
+            PosixPath(f"{base}.{stokes}.{chan}.image.fits")
+            for stokes in ("q", "u")
+            for chan in channels
         ],
         psf=None,
         dirty=None,
         model=None,
         residual=[
-            PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-MFS-Q.residual.fits"
-            ),
-            PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-MFS-U.residual.fits"
-            ),
+            PosixPath(f"{base}.{stokes}.MFS.residual.fits") for stokes in ("q", "u")
         ],
         source_list=None,
     )
 
 
 def test_split_and_get_image_set(example_image_set: ImageSet) -> None:
-    """Split a image set into separate images based on the file name"""
-    # Tracing down an error when developing racs-all pipeline. More tests are ok.
+    """Split an image set and return the images matching a single Stokes, once
+    wsclean's own per-image Q/U tag has been folded into the pol field"""
     results = split_and_get_image_set(
         image_set=example_image_set,
-        get="qu",
+        get="q",
         by="pol",
         mode="image",
     )
 
-    assert len(results) == len(example_image_set.image)
+    assert len(results) == 24
+
+
+def test_split_and_get_image_set_loop(example_image_set: ImageSet) -> None:
+    """Split an image set into separate images based on the file name"""
+    # Tracing down an error when developing racs-all pipeline. More tests are ok.
+    for stokes in "qu":
+        results = split_and_get_image_set(
+            image_set=example_image_set,
+            get=stokes,
+            by="pol",
+            mode="image",
+        )
+        assert len(results) == 24

--- a/tests/test_imagesets.py
+++ b/tests/test_imagesets.py
@@ -13,151 +13,151 @@ from flint.imager.wsclean import ImageSet, split_and_get_image_set
 def example_image_set() -> ImageSet:
     """Fixture for an example ImageSet object"""
     return ImageSet(
-        prefix="/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol",
+        prefix="/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu",
         image=[
             PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0000-Q.image.fits"
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0000-Q.image.fits"
             ),
             PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0001-Q.image.fits"
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0001-Q.image.fits"
             ),
             PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0002-Q.image.fits"
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0002-Q.image.fits"
             ),
             PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0003-Q.image.fits"
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0003-Q.image.fits"
             ),
             PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0004-Q.image.fits"
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0004-Q.image.fits"
             ),
             PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0005-Q.image.fits"
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0005-Q.image.fits"
             ),
             PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0006-Q.image.fits"
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0006-Q.image.fits"
             ),
             PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0007-Q.image.fits"
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0007-Q.image.fits"
             ),
             PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0008-Q.image.fits"
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0008-Q.image.fits"
             ),
             PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0009-Q.image.fits"
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0009-Q.image.fits"
             ),
             PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0010-Q.image.fits"
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0010-Q.image.fits"
             ),
             PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0011-Q.image.fits"
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0011-Q.image.fits"
             ),
             PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0012-Q.image.fits"
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0012-Q.image.fits"
             ),
             PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0013-Q.image.fits"
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0013-Q.image.fits"
             ),
             PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0014-Q.image.fits"
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0014-Q.image.fits"
             ),
             PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0015-Q.image.fits"
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0015-Q.image.fits"
             ),
             PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0016-Q.image.fits"
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0016-Q.image.fits"
             ),
             PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0017-Q.image.fits"
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0017-Q.image.fits"
             ),
             PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0018-Q.image.fits"
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0018-Q.image.fits"
             ),
             PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0019-Q.image.fits"
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0019-Q.image.fits"
             ),
             PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0020-Q.image.fits"
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0020-Q.image.fits"
             ),
             PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0021-Q.image.fits"
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0021-Q.image.fits"
             ),
             PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0022-Q.image.fits"
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0022-Q.image.fits"
             ),
             PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-MFS-Q.image.fits"
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-MFS-Q.image.fits"
             ),
             PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0000-U.image.fits"
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0000-U.image.fits"
             ),
             PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0001-U.image.fits"
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0001-U.image.fits"
             ),
             PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0002-U.image.fits"
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0002-U.image.fits"
             ),
             PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0003-U.image.fits"
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0003-U.image.fits"
             ),
             PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0004-U.image.fits"
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0004-U.image.fits"
             ),
             PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0005-U.image.fits"
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0005-U.image.fits"
             ),
             PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0006-U.image.fits"
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0006-U.image.fits"
             ),
             PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0007-U.image.fits"
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0007-U.image.fits"
             ),
             PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0008-U.image.fits"
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0008-U.image.fits"
             ),
             PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0009-U.image.fits"
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0009-U.image.fits"
             ),
             PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0010-U.image.fits"
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0010-U.image.fits"
             ),
             PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0011-U.image.fits"
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0011-U.image.fits"
             ),
             PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0012-U.image.fits"
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0012-U.image.fits"
             ),
             PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0013-U.image.fits"
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0013-U.image.fits"
             ),
             PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0014-U.image.fits"
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0014-U.image.fits"
             ),
             PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0015-U.image.fits"
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0015-U.image.fits"
             ),
             PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0016-U.image.fits"
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0016-U.image.fits"
             ),
             PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0017-U.image.fits"
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0017-U.image.fits"
             ),
             PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0018-U.image.fits"
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0018-U.image.fits"
             ),
             PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0019-U.image.fits"
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0019-U.image.fits"
             ),
             PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0020-U.image.fits"
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0020-U.image.fits"
             ),
             PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0021-U.image.fits"
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0021-U.image.fits"
             ),
             PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-0022-U.image.fits"
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-0022-U.image.fits"
             ),
             PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-MFS-U.image.fits"
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-MFS-U.image.fits"
             ),
         ],
         psf=None,
@@ -165,10 +165,10 @@ def example_image_set() -> ImageSet:
         model=None,
         residual=[
             PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-MFS-Q.residual.fits"
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-MFS-Q.residual.fits"
             ),
             PosixPath(
-                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.beam15.round1.qu.pol-MFS-U.residual.fits"
+                "/scratch3/gal16b/flint_racsall/56289/SB56289.RACS_1041+18.project-pol.beam15.round1.qu-MFS-U.residual.fits"
             ),
         ],
         source_list=None,
@@ -186,16 +186,3 @@ def test_split_and_get_image_set(example_image_set: ImageSet) -> None:
     )
 
     assert len(results) == len(example_image_set.image)
-
-
-def test_split_and_get_image_set_loop(example_image_set: ImageSet) -> None:
-    """Split a image set into separate images based on the file name"""
-    # Tracing down an error when developing racs-all pipeline. More tests are ok.
-    for stokes in "qu":
-        results = split_and_get_image_set(
-            image_set=example_image_set,
-            get=stokes,
-            by="pol",
-            mode="image",
-        )
-        assert len(results) == 24

--- a/tests/test_imagesets.py
+++ b/tests/test_imagesets.py
@@ -186,3 +186,16 @@ def test_split_and_get_image_set(example_image_set: ImageSet) -> None:
     )
 
     assert len(results) == len(example_image_set.image)
+
+
+def test_split_and_get_image_set_loop(example_image_set: ImageSet) -> None:
+    """Split a image set into separate images based on the file name"""
+    # Tracing down an error when developing racs-all pipeline. More tests are ok.
+    for stokes in "qu":
+        results = split_and_get_image_set(
+            image_set=example_image_set,
+            get=stokes,
+            by="pol",
+            mode="image",
+        )
+        assert len(results) == 24

--- a/tests/test_linmos_coadd.py
+++ b/tests/test_linmos_coadd.py
@@ -59,20 +59,24 @@ def test_create_name_to_linmos_options():
 
 def test_get_image_weight_plane():
     """The extraction of weights per plane"""
-    data = np.arange(100).reshape((10, 10))
+    mean = 0
+    rms = 2
+    weight = 1.0 / (rms**2)
+    data = np.random.default_rng(42).normal(loc=mean, scale=rms, size=(100, 100))
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         _get_image_weight_plane(image_data=data, mode="noexists")  # type: ignore
 
+    # Sampling noise on the estimated rms, so compare to a few percent
     assert np.isclose(
-        0.0016,
+        weight,
         _get_image_weight_plane(image_data=data, mode="mad", stride=1),
-        atol=0.0001,
+        rtol=0.05,
     )
     assert np.isclose(
-        0.00120012,
+        weight,
         _get_image_weight_plane(image_data=data, mode="std", stride=1),
-        atol=0.0001,
+        rtol=0.05,
     )
 
     data = np.arange(100).reshape((10, 10)) * np.nan

--- a/tests/test_naming.py
+++ b/tests/test_naming.py
@@ -234,6 +234,45 @@ def test_create_path_from_process_named_components_with_scan_range():
     assert ex == out
 
 
+def test_create_path_from_process_named_components_with_project() -> None:
+    """Make sure we can create a name that includes a project field.
+    The one makes sure we can go full circle"""
+    parent = Path("Jacccckkkk/Sparrow")
+    ex = parent / Path(
+        "SB39400.RACS_0000-123.project-pirates.beam33.spw234.round3.i.ch0123-567444.scan0000-0123"
+    )
+    pcn = processed_ms_format(in_name=ex)
+    assert pcn is not None
+    assert pcn.project == "pirates"
+    out = create_path_from_processed_name_components(
+        processed_name_components=pcn, parent_path=parent
+    )
+    assert ex == out
+
+    parent = Path("Jacccckkkk/Sparrow")
+    ex = parent / Path(
+        "SB39400.RACS_0000-123.project-pirates.round3.i.ch0123-0444.scan1234-1236"
+    )
+    pcn = processed_ms_format(in_name=ex)
+    assert pcn is not None
+    assert pcn.project == "pirates"
+    out = create_path_from_processed_name_components(
+        processed_name_components=pcn, parent_path=parent
+    )
+    assert ex == out
+
+    parent = Path("Jacccckkkk/Sparrow")
+    ex = parent / Path("SB39400.RACS_0000-123.project-pirates.round3.scan1234-1236")
+    pcn = processed_ms_format(in_name=ex)
+    assert pcn is not None
+    assert pcn.project == "pirates"
+
+    out = create_path_from_processed_name_components(
+        processed_name_components=pcn, parent_path=parent
+    )
+    assert ex == out
+
+
 def test_processed_name_components_with_scan():
     """See if the scan regex for the processed name behaves"""
     parent = Path("Jacccckkkk/Sparrow")

--- a/tests/test_naming.py
+++ b/tests/test_naming.py
@@ -831,6 +831,23 @@ def test_formatted_name_components_wchannelrange():
     assert components.channel_range == (100, 1009)
 
 
+def test_formatted_name_components_wchannelidx():
+    """wsclean's own bare per-channel index (e.g. produced when channels are
+    imaged individually without a flint ch<lo>-<hi> range) should still resolve
+    to a usable channel_range - regression test for the "No channel range in
+    path" crash in transpose_and_sort_channel_images."""
+    ex = "SB56289.RACS_1041+18.beam00.round1.i.0000.image.conv.fits"
+
+    components = processed_ms_format(in_name=ex)
+    assert isinstance(components, ProcessedNameComponents)
+    assert components.sbid == "56289"
+    assert components.field == "RACS_1041+18"
+    assert components.beam == "00"
+    assert components.round == "1"
+    assert components.pol == "i"
+    assert components.channel_range == (0, 0)
+
+
 def test_formatted_name_components_wround():
     ex = "SB39400.RACS_0635-31.beam33.round1-MFS-image.conv.fits"
 

--- a/tests/test_naming.py
+++ b/tests/test_naming.py
@@ -320,8 +320,8 @@ def test_create_imaging_name_prefix():
     name = create_imaging_name_prefix(ms_path=ms.path, scan_range=(234, 2345))
     assert name == "SB63789.EMU_1743-51.beam03.round4.scan0234-2345"
 
-    name = create_imaging_name_prefix(ms_path=ms.path, pol="i", name_suffix="pol")
-    assert name == "SB63789.EMU_1743-51.beam03.round4.i.pol"
+    name = create_imaging_name_prefix(ms_path=ms.path, pol="i", project="pol")
+    assert name == "SB63789.EMU_1743-51.project-pol.beam03.round4.i"
 
 
 def test_get_cube_fits_from_paths():

--- a/tests/test_naming.py
+++ b/tests/test_naming.py
@@ -281,6 +281,9 @@ def test_create_imaging_name_prefix():
     name = create_imaging_name_prefix(ms_path=ms.path, scan_range=(234, 2345))
     assert name == "SB63789.EMU_1743-51.beam03.round4.scan0234-2345"
 
+    name = create_imaging_name_prefix(ms_path=ms.path, pol="i", name_suffix="pol")
+    assert name == "SB63789.EMU_1743-51.beam03.round4.i.pol"
+
 
 def test_get_cube_fits_from_paths():
     """Identify the files that contain the cube field and are fits, including

--- a/tests/test_natural_resolution.py
+++ b/tests/test_natural_resolution.py
@@ -1,0 +1,226 @@
+"""Tests around the 'natural' resolution convolution the polarisation flow uses:
+one common beam per channel, rather than the single 'total' beam RM-synthesis
+brings its own inputs to.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import astropy.units as u
+import numpy as np
+import pytest
+from astropy.io import fits
+from astropy.wcs import WCS
+from prefect import flow
+from prefect.logging import disable_run_logger
+from prefect.testing.utilities import prefect_test_harness
+from radio_beam import Beam
+
+from flint.prefect.common.imaging import (
+    convolve_channel_groups_to_natural_resolution,
+    convolve_mfs_beam_images_to_common_resolution,
+)
+
+
+def _write_image_with_beam(path: Path, bmaj_arcsec: float) -> Path:
+    """A small ASKAP-shaped (stokes, dec, ra) plane carrying the requested beam"""
+    wcs = WCS(naxis=3)
+    wcs.wcs.ctype = ["RA---SIN", "DEC--SIN", "STOKES"]
+    wcs.wcs.crval = [180.0, -30.0, 1.0]
+    wcs.wcs.crpix = [8, 8, 1]
+    wcs.wcs.cdelt = [-1e-3, 1e-3, 1.0]
+    wcs.wcs.cunit = ["deg", "deg", ""]
+
+    rng = np.random.default_rng(0)
+    header = wcs.to_header()
+    header["BUNIT"] = "Jy/beam"
+    beam = Beam(
+        major=bmaj_arcsec * u.arcsec, minor=bmaj_arcsec * 0.8 * u.arcsec, pa=0.0 * u.deg
+    )
+    header = beam.attach_to_header(header)
+
+    fits.writeto(
+        path,
+        data=rng.normal(0, 1e-3, (1, 16, 16)).astype(np.float32),
+        header=header,
+        overwrite=True,
+    )
+    return path
+
+
+def _bmaj_arcsec(path: Path) -> float:
+    return float(fits.getheader(path)["BMAJ"]) * 3600.0
+
+
+def _channel_groups(
+    tmp_path: Path, beams_per_stokes: dict[str, list[list[float]]]
+) -> dict[str, list[list[Path]]]:
+    """For each Stokes, the per-beam images of each channel, at the given majors"""
+    return {
+        stokes: [
+            [
+                _write_image_with_beam(
+                    tmp_path / f"{stokes}.ch{channel}.beam{beam}.fits", bmaj_arcsec
+                )
+                for beam, bmaj_arcsec in enumerate(channel_beams)
+            ]
+            for channel, channel_beams in enumerate(channels)
+        ]
+        for stokes, channels in beams_per_stokes.items()
+    }
+
+
+def _convolved_naturally(
+    stokes_channel_groups: dict[str, list[list[Path]]],
+    cutoff: float | None = None,
+    fixed_beam_shape: tuple[float, float, float] | None = None,
+) -> dict[str, list[list[Path]]]:
+    @flow
+    def _convolve() -> dict[str, list[list[Path]]]:
+        return convolve_channel_groups_to_natural_resolution(
+            stokes_channel_groups=stokes_channel_groups,
+            cutoff=cutoff,
+            fixed_beam_shape=fixed_beam_shape,
+        )
+
+    with prefect_test_harness(), disable_run_logger():
+        return _convolve()
+
+
+def test_natural_resolution_varies_by_channel(tmp_path: Path) -> None:
+    """Each channel is brought to its own common beam, so a fine channel is not
+    dragged out to the resolution of a coarse one elsewhere in the band"""
+    groups = _channel_groups(
+        tmp_path, {"q": [[10.0, 10.5], [20.0, 20.5]], "u": [[10.2, 10.1], [20.2, 20.1]]}
+    )
+
+    convolved = _convolved_naturally(groups)
+
+    assert set(convolved) == {"q", "u"}
+    channel_majors = [
+        {
+            _bmaj_arcsec(image)
+            for images in (convolved["q"][channel], convolved["u"][channel])
+            for image in images
+        }
+        for channel in range(2)
+    ]
+    # One resolution within a channel, across every beam and both Stokes
+    assert all(len(majors) == 1 for majors in channel_majors)
+    # But a different one between channels, which is what 'natural' means
+    fine, coarse = (majors.pop() for majors in channel_majors)
+    assert fine < coarse
+    assert fine == pytest.approx(10.6, abs=0.15)
+    assert coarse == pytest.approx(20.6, abs=0.15)
+
+
+def test_natural_resolution_shares_a_beam_across_stokes(tmp_path: Path) -> None:
+    """The beam of a channel is solved over every Stokes at that channel, so a
+    per-channel polarisation product is meaningful. A Stokes solved on its own
+    would land on its own resolution."""
+    groups = _channel_groups(tmp_path, {"q": [[10.0]], "u": [[18.0]]})
+
+    convolved = _convolved_naturally(groups)
+
+    assert _bmaj_arcsec(convolved["q"][0][0]) == pytest.approx(
+        _bmaj_arcsec(convolved["u"][0][0])
+    )
+    assert _bmaj_arcsec(convolved["q"][0][0]) >= 18.0, (
+        "the shared beam must cover the coarsest Stokes of the channel"
+    )
+
+
+def test_natural_resolution_blanks_a_channel_beyond_the_cutoff(tmp_path: Path) -> None:
+    """A channel whose every image is beyond the cutoff has no beam to convolve
+    to. It is blanked and marked as holding no PSF, rather than co-added at its
+    own differing resolutions under a beam that describes none of them."""
+    groups = _channel_groups(
+        tmp_path, {"q": [[10.0, 10.5], [40.0, 50.0]], "u": [[10.2, 10.1], [45.0, 55.0]]}
+    )
+
+    convolved = _convolved_naturally(groups, cutoff=20.0)
+
+    for stokes in ("q", "u"):
+        for image in convolved[stokes][0]:
+            assert np.isfinite(fits.getdata(image)).any()
+            assert _bmaj_arcsec(image) > 0.0
+        for image in convolved[stokes][1]:
+            assert np.all(np.isnan(fits.getdata(image)))
+            assert fits.getheader(image)["BMAJ"] == 0.0
+
+
+def test_natural_resolution_honours_a_fixed_beam(tmp_path: Path) -> None:
+    """A fixed beam shape overrides the per-channel solve, as it did the single
+    beam it replaces"""
+    groups = _channel_groups(tmp_path, {"q": [[10.0], [20.0]]})
+
+    convolved = _convolved_naturally(groups, fixed_beam_shape=(25.0, 25.0, 0.0))
+
+    assert [_bmaj_arcsec(images[0]) for images in convolved["q"]] == [
+        pytest.approx(25.0),
+        pytest.approx(25.0),
+    ]
+
+
+def test_natural_resolution_rejects_mismatched_channel_counts(tmp_path: Path) -> None:
+    """Every Stokes has to contribute the same channels, or a channel's beam
+    would be solved over the wrong frequencies"""
+    groups = _channel_groups(tmp_path, {"q": [[10.0], [20.0]], "u": [[10.0]]})
+
+    with pytest.raises(AssertionError, match="differing channel counts"):
+        _convolved_naturally(groups)
+
+
+def _convolved_mfs(
+    mfs_beam_images: dict[str, dict[str, list[Path]]],
+    cutoff: float | None = None,
+) -> dict[str, dict[str, list[Path]]]:
+    @flow
+    def _convolve() -> dict[str, dict[str, list[Path]]]:
+        return convolve_mfs_beam_images_to_common_resolution(
+            mfs_beam_images=mfs_beam_images, cutoff=cutoff
+        )
+
+    with prefect_test_harness(), disable_run_logger():
+        return _convolve()
+
+
+def test_mfs_products_share_one_beam(tmp_path: Path) -> None:
+    """An MFS product has no frequency axis for a natural beam to vary over, so
+    one beam covers every beam, Stokes and product type"""
+    # wsclean gives a residual the same restoring beam as its image, so the beam
+    # solved over the image products covers the residuals it is applied to. The
+    # coarsest, 12.5, is a Stokes Q beam rather than a Stokes I one.
+    beams_per_stokes = {
+        "i": {"image": [10.0, 11.0], "residual": [10.0, 11.0]},
+        "q": {"image": [12.0, 12.5], "residual": [12.0, 12.5]},
+    }
+    mfs_beam_images = {
+        stokes: {
+            product_type: [
+                _write_image_with_beam(
+                    tmp_path / f"{stokes}.{product_type}.beam{beam}.fits", bmaj_arcsec
+                )
+                for beam, bmaj_arcsec in enumerate(majors)
+            ]
+            for product_type, majors in product_type_majors.items()
+        }
+        for stokes, product_type_majors in beams_per_stokes.items()
+    }
+
+    convolved = _convolved_mfs(mfs_beam_images)
+
+    majors = {
+        _bmaj_arcsec(image)
+        for product_type_images in convolved.values()
+        for images in product_type_images.values()
+        for image in images
+    }
+    assert len(majors) == 1, "the MFS products landed on differing resolutions"
+    assert majors.pop() >= 12.5, "the one beam must cover the coarsest MFS image"
+
+
+def test_mfs_products_without_images_are_left_alone(tmp_path: Path) -> None:
+    """No MFS science image means no beam to solve, so nothing is convolved"""
+    assert _convolved_mfs({}) == {}

--- a/tests/test_polarisation_pipeline.py
+++ b/tests/test_polarisation_pipeline.py
@@ -1,0 +1,45 @@
+"""Tests around the polarisation pipeline helpers"""
+
+from __future__ import annotations
+
+from flint.configuration import Strategy
+from flint.prefect.flows.polarisation_pipeline import _polarisations_to_image
+
+
+def test_polarisations_to_image_defaults_to_total():
+    """No polarisation operation at all means Stokes I"""
+    assert _polarisations_to_image(strategy=Strategy()) == {"total": {}}
+
+
+def test_polarisations_to_image_keeps_polarisations():
+    """Polarisation keys and their scoped modes are carried through"""
+    strategy = Strategy(
+        polarisation={
+            "total": {"wsclean": {"niter": 10}},
+            "linear": {"wsclean": {"niter": 20}},
+        }
+    )
+    assert _polarisations_to_image(strategy=strategy) == {
+        "total": {"wsclean": {"niter": 10}},
+        "linear": {"wsclean": {"niter": 20}},
+    }
+
+
+def test_polarisations_to_image_drops_operation_modes():
+    """Modes applied across all polarisations are not polarisations to image"""
+    strategy = Strategy(
+        polarisation={
+            "fftbane": {"step_size": 16},
+            "fitscube": {"compress": True},
+            "linear": {"wsclean": {"niter": 20}},
+        }
+    )
+    assert _polarisations_to_image(strategy=strategy) == {
+        "linear": {"wsclean": {"niter": 20}}
+    }
+
+
+def test_polarisations_to_image_modes_only_defaults_to_total():
+    """A polarisation operation carrying only modes still images Stokes I"""
+    strategy = Strategy(polarisation={"fftbane": {"step_size": 16}})
+    assert _polarisations_to_image(strategy=strategy) == {"total": {}}

--- a/tests/test_prefect_rmsynth_flow.py
+++ b/tests/test_prefect_rmsynth_flow.py
@@ -8,17 +8,24 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import astropy.units as u
 import numpy as np
 import pytest
 from astropy.io import fits
 from distributed import LocalCluster
+from prefect import flow
 from prefect.logging import disable_run_logger
 from prefect.testing.utilities import prefect_test_harness
 from prefect_dask import DaskTaskRunner
 
+from flint.convol import common_beam_from_cubes, cubes_share_common_beam
 from flint.options import RMSynthFieldOptions
-from flint.prefect.flows.rmsynth_pipeline import process_rmsynth
+from flint.prefect.flows.rmsynth_pipeline import (
+    _resolve_common_resolution_cubes,
+    process_rmsynth,
+)
 
+from .test_convol import _write_cube_with_beam
 from .test_rmsynth import NX, NY, PHI_TRUE_RADM2, _make_i_cube, _make_qu_cubes
 
 # create_name_from_common_fields rejects names it cannot decompose
@@ -88,11 +95,16 @@ def test_process_rmsynth_on_dask_cluster(
             silence_logs=40,
         )
         try:
-            output_paths = process_rmsynth.with_options(
+            rmsynth_result = process_rmsynth.with_options(
                 task_runner=DaskTaskRunner(address=cluster.scheduler_address)
             )(rmsynth_field_options=rmsynth_field_options)
         finally:
             cluster.close()
+
+    output_paths = rmsynth_result.written_paths
+    assert rmsynth_result.convolved_cubes == [], (
+        "the cubes carry one beam already, so nothing should have been convolved"
+    )
 
     zarr_store = tmp_path / f"{STEM}.fdf.zarr"
     # The CLEAN iteration count comes out of every RM-CLEAN run, alongside the
@@ -134,7 +146,7 @@ def test_process_rmsynth_no_products_submits_nothing(
     )
 
     with prefect_test_harness(), disable_run_logger():
-        output_paths = process_rmsynth(
+        rmsynth_result = process_rmsynth(
             rmsynth_field_options=RMSynthFieldOptions(
                 stokes_q_cube=stokes_q_cube,
                 stokes_u_cube=stokes_u_cube,
@@ -143,7 +155,8 @@ def test_process_rmsynth_no_products_submits_nothing(
             )
         )
 
-    assert output_paths == []
+    assert rmsynth_result.written_paths == []
+    assert rmsynth_result.convolved_cubes == []
     assert not list(tmp_path.glob("*.fdf.*"))
 
 
@@ -181,7 +194,7 @@ def test_process_rmsynth_with_stokes_i_on_dask_cluster(
         try:
             output_paths = process_rmsynth.with_options(
                 task_runner=DaskTaskRunner(address=cluster.scheduler_address)
-            )(rmsynth_field_options=rmsynth_field_options)
+            )(rmsynth_field_options=rmsynth_field_options).written_paths
         finally:
             cluster.close()
 
@@ -206,3 +219,82 @@ def test_process_rmsynth_with_stokes_i_on_dask_cluster(
     assert np.allclose(alpha, -0.7, atol=0.1), (
         "the fitted spectral index does not match the Stokes I cube's -0.7"
     )
+
+
+def _resolved_cubes(
+    cubes: dict[str, Path], output_path: Path, beam_cutoff: float | None = None
+) -> tuple[dict[str, Path], list[Path]]:
+    @flow
+    def _resolve() -> tuple[dict[str, Path], list[Path]]:
+        return _resolve_common_resolution_cubes(
+            stokes_cubes=cubes, output_path=output_path, beam_cutoff=beam_cutoff
+        )
+
+    with prefect_test_harness(), disable_run_logger():
+        return _resolve()
+
+
+def _cubes_with_beams(tmp_path: Path, offsets: dict[str, float]) -> dict[str, Path]:
+    return {
+        pol: _write_cube_with_beam(tmp_path / f"stokes_{pol}.fits", [10.0 + offset] * 3)
+        for pol, offset in offsets.items()
+    }
+
+
+def test_resolve_common_resolution_cubes_convolves(tmp_path: Path) -> None:
+    """Stokes cubes at differing resolutions are replaced by convolved copies
+    written into the output directory, leaving the inputs in place"""
+    cubes = _cubes_with_beams(tmp_path, {"q": 0.0, "u": 0.5, "i": 1.0})
+    output_path = tmp_path / "rmsynth"
+
+    resolved, convolved_cubes = _resolved_cubes(cubes=cubes, output_path=output_path)
+
+    resolved_cubes = list(resolved.values())
+    assert all(cube.exists() for cube in cubes.values()), "an input cube was consumed"
+    assert not set(resolved_cubes) & set(cubes.values())
+    assert all(cube.parent == output_path for cube in resolved_cubes)
+    assert cubes_share_common_beam(cube_paths=resolved_cubes)
+    # Each Stokes must keep its own data, not be paired to another cube's output
+    for stokes, resolved_cube in resolved.items():
+        assert resolved_cube.name.startswith(cubes[stokes].stem)
+    # The weight cubes are untouched, so the convolved cubes must stay on the
+    # input pixel grid
+    assert fits.getdata(resolved["q"]).shape == fits.getdata(cubes["q"]).shape
+    assert convolved_cubes == resolved_cubes
+
+
+def test_resolve_common_resolution_cubes_reuses_matching_cubes(tmp_path: Path) -> None:
+    """Cubes already at one resolution are used as they are"""
+    cubes = _cubes_with_beams(tmp_path, {"q": 0.0, "u": 0.0, "i": 0.0})
+    output_path = tmp_path / "rmsynth"
+
+    resolved, convolved_cubes = _resolved_cubes(cubes=cubes, output_path=output_path)
+
+    assert resolved == cubes
+    assert not output_path.exists()
+    # Empty, not the inputs echoed back: the racs-all flow concatenates these
+    # with the input cubes to spice, and a repeat would be spiced twice
+    assert convolved_cubes == []
+
+
+def test_resolve_common_resolution_cubes_beam_cutoff_blanks_coarse_channels(
+    tmp_path: Path,
+) -> None:
+    """A channel coarser than the cutoff is blanked rather than dragging the
+    common beam of every channel out to its resolution"""
+    cubes = _cubes_with_beams(tmp_path, {"q": 0.0, "u": 0.5})
+    coarse = _write_cube_with_beam(tmp_path / "stokes_i.fits", [10.0, 10.0, 40.0])
+    cubes["i"] = coarse
+
+    resolved, _ = _resolved_cubes(
+        cubes=cubes, output_path=tmp_path / "rmsynth", beam_cutoff=20.0
+    )
+
+    common_beam = common_beam_from_cubes(cube_paths=[resolved["q"]])
+    assert common_beam.major.to(u.arcsec).value < 20.0, (
+        "the 40 arcsec channel was convolved to rather than cut"
+    )
+    assert np.all(np.isnan(fits.getdata(resolved["i"])[2])), (
+        "the channel above the cutoff should be blanked"
+    )
+    assert np.any(np.isfinite(fits.getdata(resolved["i"])[0]))

--- a/tests/test_prefect_rmsynth_flow.py
+++ b/tests/test_prefect_rmsynth_flow.py
@@ -24,10 +24,17 @@ from flint.convol import (
     cubes_share_common_beam,
     usable_beam_mask,
 )
-from flint.options import CubesForRMSynth, FFTBANEOptions, RMSynthFieldOptions
+from flint.options import (
+    CubesForRMSynth,
+    FFTBANEOptions,
+    RMSynthFieldOptions,
+    WeightCubesForRMSynth,
+)
 from flint.prefect.common.rmsynth import CommonResolutionCubes
+from flint.prefect.flows import rmsynth_pipeline
 from flint.prefect.flows.rmsynth_pipeline import (
     _resolve_common_resolution_cubes,
+    get_parser,
     process_rmsynth,
 )
 
@@ -435,3 +442,145 @@ def test_no_bane_cubes_without_a_convolution(tmp_path: Path) -> None:
     assert resolved.cubes == cubes
     assert resolved.rms_cubes == {}
     assert resolved.all_cubes == []
+
+
+def _cube_names(
+    tmp_path: Path, pols: tuple[str, ...], suffix: str = "image"
+) -> list[Path]:
+    """Cube paths named in the flint scheme, which is what from_paths reads"""
+    # STEM carries a channel range, which the flint scheme puts in place of the
+    # polarisation, so these names need a round instead
+    stem = "SB12345.BENCH_0000+00.round1"
+    return [tmp_path / f"{stem}.{pol}.pol.{suffix}.cube.fits" for pol in pols]
+
+
+def test_get_parser_takes_a_list_of_stokes_cubes(tmp_path: Path) -> None:
+    """The nested cube Options cannot be filled by a single CLI or config value,
+    so the standalone pipeline takes a flat list of cubes instead."""
+    cubes = _cube_names(tmp_path, ("q", "u", "i"))
+
+    args = get_parser().parse_args(["--stokes-cubes", *[str(cube) for cube in cubes]])
+
+    assert args.stokes_cubes == cubes
+    stokes_cubes = CubesForRMSynth.from_paths(paths=args.stokes_cubes)
+    assert (stokes_cubes.q_path, stokes_cubes.u_path, stokes_cubes.i_path) == tuple(
+        cubes
+    )
+
+
+def test_get_parser_takes_stokes_cubes_from_a_config_file(tmp_path: Path) -> None:
+    """The failing case: a list in a --cli-config file, which configargparse
+    rejects outright unless the argument accepts more than one value."""
+    cubes = _cube_names(tmp_path, ("q", "u", "i"))
+    config = tmp_path / "rmsynth.cfg"
+    config.write_text(f"stokes-cubes = [{', '.join(str(cube) for cube in cubes)}]\n")
+
+    args = get_parser().parse_args(["--cli-config", str(config)])
+
+    assert args.stokes_cubes == cubes
+
+
+def test_get_parser_stokes_i_cube_is_optional(tmp_path: Path) -> None:
+    """rm-synthesis runs on Q and U alone"""
+    cubes = _cube_names(tmp_path, ("q", "u"))
+
+    args = get_parser().parse_args(["--stokes-cubes", *[str(cube) for cube in cubes]])
+    stokes_cubes = CubesForRMSynth.from_paths(paths=args.stokes_cubes)
+
+    assert stokes_cubes.i_path is None
+
+
+def test_get_parser_error_cube_kind_picks_the_container(tmp_path: Path) -> None:
+    """Weights and noises are told apart by the kind flag, never guessed: reading
+    one as the other inverts the error by 1/sigma**2."""
+    cubes = _cube_names(tmp_path, ("q", "u"), suffix="weight")
+
+    args = get_parser().parse_args(
+        [
+            "--error-cubes",
+            *[str(cube) for cube in cubes],
+            "--error-cube-kind",
+            "weight",
+        ]
+    )
+
+    assert args.error_cube_kind == "weight"
+    assert args.error_cubes == cubes
+
+
+def test_from_paths_needs_q_and_u(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="missing"):
+        CubesForRMSynth.from_paths(paths=_cube_names(tmp_path, ("q",)))
+
+
+def test_from_paths_rejects_two_cubes_for_one_stokes(tmp_path: Path) -> None:
+    cubes = _cube_names(tmp_path, ("q", "u"))
+    with pytest.raises(ValueError, match="ambiguous"):
+        CubesForRMSynth.from_paths(paths=[*cubes, cubes[0]])
+
+
+def test_from_paths_rejects_unreadable_names(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="flint or CASDA scheme"):
+        CubesForRMSynth.from_paths(paths=[tmp_path / "not-a-flint-name.fits"])
+
+
+def test_cli_assembles_the_cube_options(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """cli() substitutes the cube fields into the namespace, as they are off the
+    parser, so the options class it builds carries the nested containers."""
+    captured: dict[str, RMSynthFieldOptions] = {}
+
+    def _capture(cluster_config: str | Path, **kwargs: RMSynthFieldOptions) -> None:
+        captured.update(kwargs)
+
+    monkeypatch.setattr(rmsynth_pipeline, "setup_run_rmsynth", _capture)
+    stokes = _cube_names(tmp_path, ("q", "u"))
+    errors = _cube_names(tmp_path, ("q", "u"), suffix="weight")
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "flint_flow_rmsynth_pipeline",
+            "--stokes-cubes",
+            *[str(cube) for cube in stokes],
+            "--error-cubes",
+            *[str(cube) for cube in errors],
+            "--error-cube-kind",
+            "weight",
+        ],
+    )
+
+    rmsynth_pipeline.cli()
+
+    options = captured["rmsynth_field_options"]
+    assert isinstance(options.stokes_cubes, CubesForRMSynth)
+    assert options.stokes_cubes.paths == stokes
+    assert isinstance(options.error_cubes, WeightCubesForRMSynth)
+    assert options.error_cubes.paths == errors
+
+
+def test_cli_error_cubes_require_a_kind(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Guessing between a weight and a noise inverts the error by 1/sigma**2"""
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "flint_flow_rmsynth_pipeline",
+            "--error-cubes",
+            *[str(cube) for cube in _cube_names(tmp_path, ("q", "u"))],
+        ],
+    )
+
+    with pytest.raises(SystemExit):
+        rmsynth_pipeline.cli()
+
+
+def test_cli_without_cubes_leaves_them_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The fields stay optional: process_rmsynth raises on a missing stokes_cubes,
+    and the racs-all flow sets them in memory rather than through this CLI."""
+    args = get_parser().parse_args([])
+
+    assert args.stokes_cubes is None
+    assert args.error_cubes is None
+    assert args.error_cube_kind is None

--- a/tests/test_prefect_rmsynth_flow.py
+++ b/tests/test_prefect_rmsynth_flow.py
@@ -95,7 +95,12 @@ def test_process_rmsynth_on_dask_cluster(
             cluster.close()
 
     zarr_store = tmp_path / f"{STEM}.fdf.zarr"
-    assert set(output_paths) == {zarr_store} | {
+    # The CLEAN iteration count comes out of every RM-CLEAN run, alongside the
+    # zarr store and the requested moments
+    assert set(output_paths) == {
+        zarr_store,
+        tmp_path / f"{STEM}.fdf.clean.niter.fits",
+    } | {
         tmp_path / f"{STEM}.fdf.clean.{moment}.fits"
         for moment in ("mom0", "mom1", "mom2")
     }

--- a/tests/test_prefect_rmsynth_flow.py
+++ b/tests/test_prefect_rmsynth_flow.py
@@ -287,6 +287,37 @@ def test_resolve_common_resolution_cubes_reuses_matching_cubes(tmp_path: Path) -
     assert convolved_cubes == []
 
 
+def test_resolve_common_resolution_cubes_from_natural_resolution(
+    tmp_path: Path,
+) -> None:
+    """The handoff from the polarisation stage: cubes at a 'natural' resolution,
+    one beam per channel, are brought to a single 'total' beam covering the whole
+    band, and the natural cubes they came from are left alone to be archived"""
+    cubes = {
+        pol: _write_cube_with_beam(
+            tmp_path / f"{STEM}.{pol}.linmos.fits", [10.0, 15.0, 20.0]
+        )
+        for pol in ("q", "u")
+    }
+    assert not cubes_share_common_beam(cube_paths=list(cubes.values())), (
+        "the inputs must vary with channel for this to be the case under test"
+    )
+
+    resolved, convolved_cubes = _resolved_cubes(
+        cubes=cubes, output_path=tmp_path / "rmsynth"
+    )
+
+    assert convolved_cubes == list(resolved.values())
+    assert cubes_share_common_beam(cube_paths=list(resolved.values()))
+    # The natural-resolution cubes survive, still varying with channel
+    assert all(cube.exists() for cube in cubes.values())
+    assert not cubes_share_common_beam(cube_paths=list(cubes.values()))
+    # And the one beam has to cover the coarsest channel of the band
+    total_beam = common_beam_from_cubes(cube_paths=list(resolved.values()))
+    assert total_beam is not None
+    assert total_beam.major.to(u.arcsec).value >= 20.0
+
+
 def test_resolve_common_resolution_cubes_beam_cutoff_blanks_coarse_channels(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_prefect_rmsynth_flow.py
+++ b/tests/test_prefect_rmsynth_flow.py
@@ -24,7 +24,8 @@ from flint.convol import (
     cubes_share_common_beam,
     usable_beam_mask,
 )
-from flint.options import RMSynthFieldOptions
+from flint.options import CubesForRMSynth, FFTBANEOptions, RMSynthFieldOptions
+from flint.prefect.common.rmsynth import CommonResolutionCubes
 from flint.prefect.flows.rmsynth_pipeline import (
     _resolve_common_resolution_cubes,
     process_rmsynth,
@@ -80,8 +81,7 @@ def test_process_rmsynth_on_dask_cluster(
     monkeypatch.setenv("OMP_NUM_THREADS", "1")
 
     rmsynth_field_options = RMSynthFieldOptions(
-        stokes_q_cube=stokes_q_cube,
-        stokes_u_cube=stokes_u_cube,
+        stokes_cubes=CubesForRMSynth(q_path=stokes_q_cube, u_path=stokes_u_cube),
         cube_products=["dirty"],
         moment_products=["clean"],
     )
@@ -153,8 +153,9 @@ def test_process_rmsynth_no_products_submits_nothing(
     with prefect_test_harness(), disable_run_logger():
         rmsynth_result = process_rmsynth(
             rmsynth_field_options=RMSynthFieldOptions(
-                stokes_q_cube=stokes_q_cube,
-                stokes_u_cube=stokes_u_cube,
+                stokes_cubes=CubesForRMSynth(
+                    q_path=stokes_q_cube, u_path=stokes_u_cube
+                ),
                 cube_products=[],
                 moment_products=[],
             )
@@ -180,9 +181,9 @@ def test_process_rmsynth_with_stokes_i_on_dask_cluster(
     monkeypatch.setenv("OMP_NUM_THREADS", "1")
 
     rmsynth_field_options = RMSynthFieldOptions(
-        stokes_q_cube=stokes_q_cube,
-        stokes_u_cube=stokes_u_cube,
-        stokes_i_cube=stokes_i_cube,
+        stokes_cubes=CubesForRMSynth(
+            q_path=stokes_q_cube, u_path=stokes_u_cube, i_path=stokes_i_cube
+        ),
         cube_products=[],
         moment_products=["clean"],
     )
@@ -226,17 +227,34 @@ def test_process_rmsynth_with_stokes_i_on_dask_cluster(
     )
 
 
-def _resolved_cubes(
-    cubes: dict[str, Path], output_path: Path, beam_cutoff: float | None = None
-) -> tuple[dict[str, Path], list[Path]]:
+def _resolve_cubes(
+    cubes: dict[str, Path],
+    output_path: Path,
+    beam_cutoff: float | None = None,
+    fft_bane_options: FFTBANEOptions | None = None,
+) -> CommonResolutionCubes:
     @flow
-    def _resolve() -> tuple[dict[str, Path], list[Path]]:
+    def _resolve() -> CommonResolutionCubes:
         return _resolve_common_resolution_cubes(
-            stokes_cubes=cubes, output_path=output_path, beam_cutoff=beam_cutoff
+            stokes_cubes=cubes,
+            output_path=output_path,
+            beam_cutoff=beam_cutoff,
+            fft_bane_options=fft_bane_options,
         )
 
     with prefect_test_harness(), disable_run_logger():
         return _resolve()
+
+
+def _resolved_cubes(
+    cubes: dict[str, Path], output_path: Path, beam_cutoff: float | None = None
+) -> tuple[dict[str, Path], list[Path]]:
+    """The cubes to use, and the new ones written, as the callers of
+    ``_resolve_common_resolution_cubes`` see them"""
+    resolved = _resolve_cubes(
+        cubes=cubes, output_path=output_path, beam_cutoff=beam_cutoff
+    )
+    return resolved.cubes, (list(resolved.cubes.values()) if resolved.convolved else [])
 
 
 def _cubes_with_beams(tmp_path: Path, offsets: dict[str, float]) -> dict[str, Path]:
@@ -366,3 +384,54 @@ def test_resolve_common_resolution_cubes_without_usable_beams(tmp_path: Path) ->
 
     assert resolved == cubes
     assert convolved_cubes == []
+
+
+def test_bane_cubes_are_measured_on_the_convolved_planes(tmp_path: Path) -> None:
+    """The noise has to describe the cubes the FDF is built from. Convolving to a
+    common beam changes them, so measuring on the polarisation stage's natural
+    resolution cubes would describe a resolution rm-synthesis never reads. These
+    are measured after the convolution instead, and land on the convolved grid.
+    """
+    cubes = _cubes_with_beams(tmp_path, {"q": 0.0, "u": 0.5})
+    output_path = tmp_path / "rmsynth"
+
+    resolved = _resolve_cubes(
+        cubes=cubes,
+        output_path=output_path,
+        fft_bane_options=FFTBANEOptions(step_size=2, box_size=2),
+    )
+
+    assert resolved.convolved
+    assert set(resolved.bkg_cubes) == set(resolved.rms_cubes) == {"q", "u"}
+    for stokes, rms_cube in resolved.rms_cubes.items():
+        assert rms_cube.exists()
+        # Same grid as the convolved cube it was measured on, so rm-lite can read
+        # the two together
+        assert (
+            fits.getdata(rms_cube).shape == fits.getdata(resolved.cubes[stokes]).shape
+        )
+    assert all(cube.exists() for cube in resolved.bkg_cubes.values())
+    # Everything written is a frequency cube the racs-all flow has to spice
+    assert set(resolved.all_cubes) == {
+        *resolved.cubes.values(),
+        *resolved.bkg_cubes.values(),
+        *resolved.rms_cubes.values(),
+    }
+
+
+def test_no_bane_cubes_without_a_convolution(tmp_path: Path) -> None:
+    """Cubes already at one resolution are used as they are, so this stage writes
+    nothing and has nothing to measure. The caller's own noise cubes, measured on
+    those same cubes by the polarisation stage, are already right."""
+    cubes = _cubes_with_beams(tmp_path, {"q": 0.0, "u": 0.0})
+
+    resolved = _resolve_cubes(
+        cubes=cubes,
+        output_path=tmp_path / "rmsynth",
+        fft_bane_options=FFTBANEOptions(step_size=2, box_size=2),
+    )
+
+    assert not resolved.convolved
+    assert resolved.cubes == cubes
+    assert resolved.rms_cubes == {}
+    assert resolved.all_cubes == []

--- a/tests/test_prefect_rmsynth_flow.py
+++ b/tests/test_prefect_rmsynth_flow.py
@@ -1,0 +1,203 @@
+"""Flow-level tests for the RM-synthesis pipeline. The unit tests in
+``tests/test_rmsynth.py`` mirror this flow's call sequence by hand; these tests
+run the real flow so that mirror cannot silently drift, and so the prefect and
+dask-distributed wiring (task submission, pickling lazy dask arrays between
+tasks, the nested ``get_dask_client()``) is actually exercised."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+from astropy.io import fits
+from distributed import LocalCluster
+from prefect.logging import disable_run_logger
+from prefect.testing.utilities import prefect_test_harness
+from prefect_dask import DaskTaskRunner
+
+from flint.options import RMSynthFieldOptions
+from flint.prefect.flows.rmsynth_pipeline import process_rmsynth
+
+from .test_rmsynth import NX, NY, PHI_TRUE_RADM2, _make_i_cube, _make_qu_cubes
+
+# create_name_from_common_fields rejects names it cannot decompose
+STEM = "SB12345.BENCH_0000+00.ch0000-0019"
+
+
+def _add_degenerate_axis(path: Path) -> Path:
+    """Rewrite a (nfreq, ny, nx) cube in the ASKAP/CASA (nfreq, 1, ny, nx) layout,
+    moving the spectral axis to FITS axis 4 and inserting a degenerate Stokes axis."""
+    data, header = fits.getdata(path, header=True)
+    for key in ("CTYPE", "CRVAL", "CRPIX", "CDELT", "CUNIT"):
+        if f"{key}3" in header:
+            header[f"{key}4"] = header.pop(f"{key}3")
+    header["CTYPE3"] = "STOKES"
+    header["CRVAL3"] = 1.0
+    header["CRPIX3"] = 1.0
+    header["CDELT3"] = 1.0
+    fits.writeto(path, data[:, np.newaxis], header, overwrite=True)
+    return path
+
+
+def _renamed_qu_cubes(
+    tmp_path: Path, degenerate_axis: bool = False
+) -> tuple[Path, Path]:
+    q_path, u_path = _make_qu_cubes(tmp_path)
+    paths = (
+        q_path.rename(tmp_path / f"{STEM}.q.linmos.fits"),
+        u_path.rename(tmp_path / f"{STEM}.u.linmos.fits"),
+    )
+    if not degenerate_axis:
+        return paths
+    # Explicit pair rather than `tuple(map(...))`, which types as tuple[Path, ...]
+    return _add_degenerate_axis(paths[0]), _add_degenerate_axis(paths[1])
+
+
+@pytest.mark.parametrize("degenerate_axis", [False, True], ids=["3d", "askap-4d"])
+def test_process_rmsynth_on_dask_cluster(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, degenerate_axis: bool
+) -> None:
+    """Most of the runtime here is cluster start up and the worker imports of
+    flint/rm_lite/finufft, so shrinking the cubes further does not help. The
+    askap-4d case guards against rm-lite mishandling the degenerate Stokes axis
+    that real ASKAP/CASA cubes carry, which 2026.8.0 regressed on."""
+    stokes_q_cube, stokes_u_cube = _renamed_qu_cubes(
+        tmp_path, degenerate_axis=degenerate_axis
+    )
+    monkeypatch.setenv("OMP_NUM_THREADS", "1")
+
+    rmsynth_field_options = RMSynthFieldOptions(
+        stokes_q_cube=stokes_q_cube,
+        stokes_u_cube=stokes_u_cube,
+        cube_products=["dirty"],
+        moment_products=["clean"],
+    )
+
+    # Checked: worker processes started inside the harness report the harness'
+    # temporary API and database, not the developer's ~/.prefect
+    with prefect_test_harness(), disable_run_logger():
+        # processes=True so that the pickling of lazy dask arrays between
+        # tasks is exercised, which a threaded cluster would not do
+        cluster = LocalCluster(
+            n_workers=2,
+            threads_per_worker=1,
+            processes=True,
+            memory_limit="2GB",
+            dashboard_address=None,
+            silence_logs=40,
+        )
+        try:
+            output_paths = process_rmsynth.with_options(
+                task_runner=DaskTaskRunner(address=cluster.scheduler_address)
+            )(rmsynth_field_options=rmsynth_field_options)
+        finally:
+            cluster.close()
+
+    zarr_store = tmp_path / f"{STEM}.fdf.zarr"
+    assert set(output_paths) == {zarr_store} | {
+        tmp_path / f"{STEM}.fdf.clean.{moment}.fits"
+        for moment in ("mom0", "mom1", "mom2")
+    }
+    for path in output_paths:
+        assert path.exists()
+    assert not list(tmp_path.glob("*.fdf.*.cube.fits")), (
+        "FDF cubes are zarr-only; a FITS cube means the gather path came back"
+    )
+
+    clean_mom1 = fits.getdata(tmp_path / f"{STEM}.fdf.clean.mom1.fits")
+    assert np.allclose(clean_mom1, PHI_TRUE_RADM2, atol=5.0)
+
+    import zarr
+
+    group = zarr.open(str(zarr_store), mode="r")
+    assert set(group.keys()) == {"dirty", "phi_arr_radm2"}
+    dirty = group["dirty"][:]
+    phi_arr_radm2 = group["phi_arr_radm2"][:]
+    assert dirty.shape == (phi_arr_radm2.shape[0], NY, NX)
+    peak_phi = phi_arr_radm2[np.argmax(np.abs(dirty).mean(axis=(1, 2)))]
+    assert peak_phi == pytest.approx(PHI_TRUE_RADM2, abs=5.0)
+
+
+def test_process_rmsynth_no_products_submits_nothing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    stokes_q_cube, stokes_u_cube = _renamed_qu_cubes(tmp_path)
+    monkeypatch.setattr(
+        "flint.prefect.flows.rmsynth_pipeline.task_rmsynth.submit",
+        lambda **kwargs: pytest.fail("task_rmsynth should not be submitted"),
+    )
+
+    with prefect_test_harness(), disable_run_logger():
+        output_paths = process_rmsynth(
+            rmsynth_field_options=RMSynthFieldOptions(
+                stokes_q_cube=stokes_q_cube,
+                stokes_u_cube=stokes_u_cube,
+                cube_products=[],
+                moment_products=[],
+            )
+        )
+
+    assert output_paths == []
+    assert not list(tmp_path.glob("*.fdf.*"))
+
+
+def test_process_rmsynth_with_stokes_i_on_dask_cluster(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The fractional-polarisation path across a real cluster. The Stokes I fit
+    products are the only ones built by a ``map_blocks`` whose output flint
+    slices apart after the gather, so they are the ones a pickling or chunking
+    problem would strand as None or as the wrong plane -- and an unfitted run
+    reports None for all of them, so the failure would only show on the path
+    that fits.
+    """
+    stokes_q_cube, stokes_u_cube = _renamed_qu_cubes(tmp_path)
+    stokes_i_cube = _make_i_cube(tmp_path)
+    monkeypatch.setenv("OMP_NUM_THREADS", "1")
+
+    rmsynth_field_options = RMSynthFieldOptions(
+        stokes_q_cube=stokes_q_cube,
+        stokes_u_cube=stokes_u_cube,
+        stokes_i_cube=stokes_i_cube,
+        cube_products=[],
+        moment_products=["clean"],
+    )
+
+    with prefect_test_harness(), disable_run_logger():
+        cluster = LocalCluster(
+            n_workers=2,
+            threads_per_worker=1,
+            processes=True,
+            memory_limit="2GB",
+            dashboard_address=None,
+            silence_logs=40,
+        )
+        try:
+            output_paths = process_rmsynth.with_options(
+                task_runner=DaskTaskRunner(address=cluster.scheduler_address)
+            )(rmsynth_field_options=rmsynth_field_options)
+        finally:
+            cluster.close()
+
+    # `_make_i_cube` is a pure power law, so the log fit's terms are flux, alpha
+    # and beta, and every pixel is bright enough to clear the SNR cut
+    term_paths = {
+        term: tmp_path / f"{STEM}.stokesi.coeff.{term}.fits"
+        for term in ("flux", "alpha", "beta")
+    }
+    assert set(output_paths) >= set(term_paths.values()), (
+        "the fitted Stokes I model terms came back None or unnamed on the cluster"
+    )
+    for term, path in term_paths.items():
+        data, header = fits.getdata(path, header=True)
+        assert data.shape == (NY, NX)
+        assert np.all(np.isfinite(data)), f"{term} was not fitted"
+        assert header["SICOEFF"] == term
+        assert header["FITFUNC"] == "log"
+        assert header["REFFREQ"] > 0
+
+    alpha = fits.getdata(term_paths["alpha"])
+    assert np.allclose(alpha, -0.7, atol=0.1), (
+        "the fitted spectral index does not match the Stokes I cube's -0.7"
+    )

--- a/tests/test_prefect_rmsynth_flow.py
+++ b/tests/test_prefect_rmsynth_flow.py
@@ -17,8 +17,13 @@ from prefect import flow
 from prefect.logging import disable_run_logger
 from prefect.testing.utilities import prefect_test_harness
 from prefect_dask import DaskTaskRunner
+from radio_beam import Beams
 
-from flint.convol import common_beam_from_cubes, cubes_share_common_beam
+from flint.convol import (
+    common_beam_from_cubes,
+    cubes_share_common_beam,
+    usable_beam_mask,
+)
 from flint.options import RMSynthFieldOptions
 from flint.prefect.flows.rmsynth_pipeline import (
     _resolve_common_resolution_cubes,
@@ -235,8 +240,11 @@ def _resolved_cubes(
 
 
 def _cubes_with_beams(tmp_path: Path, offsets: dict[str, float]) -> dict[str, Path]:
+    """Flint-named cubes, which is what splitting a cube into named planes needs"""
     return {
-        pol: _write_cube_with_beam(tmp_path / f"stokes_{pol}.fits", [10.0 + offset] * 3)
+        pol: _write_cube_with_beam(
+            tmp_path / f"{STEM}.{pol}.linmos.fits", [10.0 + offset] * 3
+        )
         for pol, offset in offsets.items()
     }
 
@@ -258,9 +266,11 @@ def test_resolve_common_resolution_cubes_convolves(tmp_path: Path) -> None:
     for stokes, resolved_cube in resolved.items():
         assert resolved_cube.name.startswith(cubes[stokes].stem)
     # The weight cubes are untouched, so the convolved cubes must stay on the
-    # input pixel grid
+    # input pixel and channel grid
     assert fits.getdata(resolved["q"]).shape == fits.getdata(cubes["q"]).shape
     assert convolved_cubes == resolved_cubes
+    # The planes each cube was split into and convolved through are cleaned up
+    assert not list(output_path.glob("*.planes"))
 
 
 def test_resolve_common_resolution_cubes_reuses_matching_cubes(tmp_path: Path) -> None:
@@ -283,7 +293,9 @@ def test_resolve_common_resolution_cubes_beam_cutoff_blanks_coarse_channels(
     """A channel coarser than the cutoff is blanked rather than dragging the
     common beam of every channel out to its resolution"""
     cubes = _cubes_with_beams(tmp_path, {"q": 0.0, "u": 0.5})
-    coarse = _write_cube_with_beam(tmp_path / "stokes_i.fits", [10.0, 10.0, 40.0])
+    coarse = _write_cube_with_beam(
+        tmp_path / f"{STEM}.i.linmos.fits", [10.0, 10.0, 40.0]
+    )
     cubes["i"] = coarse
 
     resolved, _ = _resolved_cubes(
@@ -291,6 +303,7 @@ def test_resolve_common_resolution_cubes_beam_cutoff_blanks_coarse_channels(
     )
 
     common_beam = common_beam_from_cubes(cube_paths=[resolved["q"]])
+    assert common_beam is not None
     assert common_beam.major.to(u.arcsec).value < 20.0, (
         "the 40 arcsec channel was convolved to rather than cut"
     )
@@ -298,3 +311,27 @@ def test_resolve_common_resolution_cubes_beam_cutoff_blanks_coarse_channels(
         "the channel above the cutoff should be blanked"
     )
     assert np.any(np.isfinite(fits.getdata(resolved["i"])[0]))
+    # The blanked channel must not claim a PSF it does not have
+    blanked_beam = Beams.from_fits_bintable(fits.open(resolved["i"])["BEAMS"])
+    assert usable_beam_mask(beams=blanked_beam)[2] == False  # noqa: E712
+    assert usable_beam_mask(beams=blanked_beam)[0]
+
+
+def test_resolve_common_resolution_cubes_without_usable_beams(tmp_path: Path) -> None:
+    """Cubes carrying nothing but the placeholder beams of blanked channels have
+    no resolution to make common, and are used as they are rather than handed to
+    a common-beam solver that cannot solve them"""
+    tiny = float(np.finfo(np.float32).tiny)
+    cubes = {
+        pol: _write_cube_with_beam(
+            tmp_path / f"{STEM}.{pol}.linmos.fits", [0.0, tiny, 0.0]
+        )
+        for pol in ("q", "u")
+    }
+
+    resolved, convolved_cubes = _resolved_cubes(
+        cubes=cubes, output_path=tmp_path / "rmsynth"
+    )
+
+    assert resolved == cubes
+    assert convolved_cubes == []

--- a/tests/test_prefect_rmsynth_flow.py
+++ b/tests/test_prefect_rmsynth_flow.py
@@ -39,7 +39,14 @@ from flint.prefect.flows.rmsynth_pipeline import (
 )
 
 from .test_convol import _write_cube_with_beam
-from .test_rmsynth import NX, NY, PHI_TRUE_RADM2, _make_i_cube, _make_qu_cubes
+from .test_rmsynth import (
+    MOMENT_MAPS,
+    NX,
+    NY,
+    PHI_TRUE_RADM2,
+    _make_i_cube,
+    _make_qu_cubes,
+)
 
 # create_name_from_common_fields rejects names it cannot decompose
 STEM = "SB12345.BENCH_0000+00.ch0000-0019"
@@ -125,8 +132,8 @@ def test_process_rmsynth_on_dask_cluster(
         zarr_store,
         tmp_path / f"{STEM}.fdf.clean.niter.fits",
     } | {
-        tmp_path / f"{STEM}.fdf.clean.{moment}.fits"
-        for moment in ("mom0", "mom1", "mom2")
+        tmp_path / f"{STEM}.fdf.clean.{name}.fits"
+        for name, _, _ in MOMENT_MAPS.values()
     }
     for path in output_paths:
         assert path.exists()

--- a/tests/test_racs_all_pipeline.py
+++ b/tests/test_racs_all_pipeline.py
@@ -173,6 +173,50 @@ def test_process_racs_all_everything_disabled_returns_immediately(
     assert result == []
 
 
+def test_pol_stage_with_nothing_to_do_still_feeds_rm_synth() -> None:
+    """``process_racs_all`` reads ``weight_cubes`` off the polarisation result,
+    so a polarisation stage that imaged nothing has to return an empty one
+    rather than fail to construct. Both of its give-up paths go through
+    ``_no_products``, which is what this pins."""
+    from unittest.mock import MagicMock
+
+    from prefect.futures import PrefectFuture
+
+    from flint.prefect.flows.polarisation_pipeline import _no_products
+
+    future = MagicMock(spec=PrefectFuture)
+    for result in (_no_products(), _no_products(terminal_futures=[future])):
+        assert result.stokes_cubes == {}
+        assert result.weight_cubes == {}
+        assert result.mfs_products == {}
+
+    # The give-up path that has already built a field summary still propagates it
+    assert _no_products().terminal_futures == []
+    assert _no_products(terminal_futures=[future]).terminal_futures == [future]
+
+
+def test_pol_stage_without_a_strategy_returns_an_empty_result(tmp_path: Path) -> None:
+    """The give-up path that is reachable without any imaging setup, run through
+    the real flow rather than through ``_no_products`` directly: returning an
+    empty result is only useful if the flow actually gets there instead of
+    raising on the way, which is how the missing ``weight_cubes`` surfaced."""
+    from prefect.logging import disable_run_logger
+
+    from flint.options import PolFieldOptions
+    from flint.prefect.flows.polarisation_pipeline import process_science_fields_pol
+
+    with prefect_test_harness(), disable_run_logger():
+        result = process_science_fields_pol(
+            flint_ms_directory=tmp_path,
+            pol_field_options=PolFieldOptions(),
+        )
+
+    assert result.stokes_cubes == {}
+    assert result.weight_cubes == {}
+    assert result.mfs_products == {}
+    assert result.terminal_futures == []
+
+
 def test_get_parser_pol_cube_channel_width_is_independent() -> None:
     """The polarisation cube channelisation is deliberately its own option: a
     field name shared with RACSAllOptions is deduplicated in this combined CLI,

--- a/tests/test_racs_all_pipeline.py
+++ b/tests/test_racs_all_pipeline.py
@@ -331,3 +331,124 @@ def test_stage_prerequisites_requires_polarisation_containers(
             pol_field_options=PolFieldOptions(),
             spice_field_options=SpiceFieldOptions(),
         )
+
+
+def _stage_mocks(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, convolved_cubes: list[Path]
+):
+    """Replace every stage subflow of ``process_racs_all`` with a mock, so the
+    wiring between them can be checked without imaging anything."""
+    from unittest.mock import MagicMock
+
+    from flint.prefect.flows.polarisation_pipeline import PolPipelineResult
+    from flint.prefect.flows.rmsynth_pipeline import RMSynthPipelineResult
+
+    def _stage(result):
+        mock = MagicMock()
+        mock.with_options.return_value.return_value = result
+        return mock
+
+    continuum_result = MagicMock()
+    continuum_result.terminal_futures = []
+    continuum_result.output_science_path = tmp_path
+    continuum_result.holography_path = None
+
+    pol_result = PolPipelineResult(
+        stokes_cubes={"q": tmp_path / "q.fits", "u": tmp_path / "u.fits"},
+        weight_cubes={"q": tmp_path / "q.weight.fits", "u": tmp_path / "u.weight.fits"},
+        mfs_products={},
+        terminal_futures=[],
+    )
+    spice_stage = _stage([])
+
+    monkeypatch.setattr(
+        "flint.prefect.flows.racs_all_pipeline.get_dask_runner", lambda cluster: None
+    )
+    monkeypatch.setattr(
+        "flint.prefect.flows.racs_all_pipeline.process_racs_all_continuum",
+        _stage(continuum_result),
+    )
+    monkeypatch.setattr(
+        "flint.prefect.flows.racs_all_pipeline.process_science_fields_pol",
+        _stage(pol_result),
+    )
+    monkeypatch.setattr(
+        "flint.prefect.flows.racs_all_pipeline.process_rmsynth",
+        _stage(
+            RMSynthPipelineResult(
+                written_paths=[tmp_path / "fdf.fits"], convolved_cubes=convolved_cubes
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        "flint.prefect.flows.racs_all_pipeline.process_spice_compression", spice_stage
+    )
+
+    return pol_result, spice_stage
+
+
+def _run_racs_all(tmp_path: Path) -> None:
+    container = tmp_path / "container.sif"
+    container.touch()
+    catalogue = tmp_path / "components.fits"
+    catalogue.touch()
+
+    with prefect_test_harness(), disable_run_logger():
+        process_racs_all(
+            pipeline_options=RACSAllPipelineOptions(
+                imaging_cluster_config=tmp_path,
+                polarisation_cluster_config=tmp_path,
+                rmsynth_cluster_config=tmp_path,
+                spice_cluster_config=tmp_path,
+            ),
+            racs_all_options=RACSAllOptions(
+                low_data=tmp_path, mid_data=tmp_path, high_data=tmp_path
+            ),
+            pol_field_options=PolFieldOptions(
+                wsclean_container=container, yandasoft_container=container
+            ),
+            rmsynth_field_options=RMSynthFieldOptions(),
+            spice_field_options=SpiceFieldOptions(catalogue=catalogue),
+        )
+
+
+def test_rmsynth_convolved_cubes_are_spiced(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The common-resolution cubes rm-synth writes are full-size copies of the
+    polarisation cubes, so leaving them out of the spice stage would strand an
+    untrimmed, uncompressed set on disk once the originals have been trimmed."""
+    convolved_cubes = [tmp_path / "q.conv.fits", tmp_path / "u.conv.fits"]
+    pol_result, spice_stage = _stage_mocks(
+        monkeypatch=monkeypatch, tmp_path=tmp_path, convolved_cubes=convolved_cubes
+    )
+
+    _run_racs_all(tmp_path=tmp_path)
+
+    spiced_options = spice_stage.with_options.return_value.call_args.kwargs[
+        "spice_field_options"
+    ]
+    assert spiced_options.cubes == [
+        *pol_result.stokes_cubes.values(),
+        *convolved_cubes,
+    ]
+    # Convolution preserves the pixel grid, so the one weight set serves both
+    assert spiced_options.weight_cubes == list(pol_result.weight_cubes.values())
+
+
+def test_spiced_cubes_are_not_repeated_without_convolution(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """rm-synth reports no convolved cubes when the inputs already shared a
+    resolution, so the spice stage never sees the same cube twice."""
+    pol_result, spice_stage = _stage_mocks(
+        monkeypatch=monkeypatch, tmp_path=tmp_path, convolved_cubes=[]
+    )
+
+    _run_racs_all(tmp_path=tmp_path)
+
+    spiced_options = spice_stage.with_options.return_value.call_args.kwargs[
+        "spice_field_options"
+    ]
+    assert spiced_options.cubes == list(pol_result.stokes_cubes.values())
+    assert len(set(spiced_options.cubes)) == len(spiced_options.cubes)

--- a/tests/test_racs_all_pipeline.py
+++ b/tests/test_racs_all_pipeline.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from argparse import ArgumentParser
 from pathlib import Path
+from typing import Any
 
 import pytest
 from capn_crunch import create_options_from_parser
@@ -11,11 +12,14 @@ from prefect.logging import disable_run_logger
 from prefect.testing.utilities import prefect_test_harness
 
 from flint.options import (
+    CubesForRMSynth,
+    NoiseCubesForRMSynth,
     PolFieldOptions,
     RACSAllOptions,
     RACSAllPipelineOptions,
     RMSynthFieldOptions,
     SpiceFieldOptions,
+    WeightCubesForRMSynth,
 )
 from flint.prefect.flows.racs_all_pipeline import (
     _check_racs_all_pipeline_options,
@@ -36,21 +40,21 @@ def test_get_parser() -> None:
 
 
 def test_get_parser_excludes_computed_stage_outputs() -> None:
-    """stokes_q_cube/stokes_u_cube (rm-synth) and cubes/weight_cubes (spice) are
+    """stokes_cubes/error_cubes (rm-synth) and cubes/weight_cubes (spice) are
     computed from the polarisation stage's output inside process_racs_all, so the
     combined CLI must not force the user to supply dummy positional values
     for them -- only low_data/mid_data/high_data should be positional."""
     args = get_parser().parse_args(["/low", "/mid", "/high"])
 
-    assert not hasattr(args, "stokes_q_cube")
-    assert not hasattr(args, "stokes_u_cube")
+    assert not hasattr(args, "stokes_cubes")
+    assert not hasattr(args, "error_cubes")
     assert not hasattr(args, "cubes")
     assert not hasattr(args, "weight_cubes")
 
     # create_options_from_parser reads every field off the namespace, so cli()
     # sets the computed ones to their empty defaults first, as done here.
-    args.stokes_q_cube = None
-    args.stokes_u_cube = None
+    args.stokes_cubes = None
+    args.error_cubes = None
     args.cubes = []
     args.weight_cubes = []
 
@@ -60,7 +64,7 @@ def test_get_parser_excludes_computed_stage_outputs() -> None:
     spice_field_options = create_options_from_parser(
         parser_namespace=args, options_class=SpiceFieldOptions
     )
-    assert rmsynth_field_options.stokes_q_cube is None
+    assert rmsynth_field_options.stokes_cubes is None
     assert spice_field_options.cubes == []
     assert spice_field_options.weight_cubes == []
 
@@ -160,7 +164,9 @@ def test_process_racs_all_everything_disabled_returns_immediately(
     )
     pol_field_options = PolFieldOptions()
     rmsynth_field_options = RMSynthFieldOptions(
-        stokes_q_cube=Path("/tmp/q.fits"), stokes_u_cube=Path("/tmp/u.fits")
+        stokes_cubes=CubesForRMSynth(
+            q_path=Path("/tmp/q.fits"), u_path=Path("/tmp/u.fits")
+        )
     )
     spice_field_options = SpiceFieldOptions(cubes=[Path("/tmp/i.fits")])
 
@@ -334,7 +340,10 @@ def test_stage_prerequisites_requires_polarisation_containers(
 
 
 def _stage_mocks(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, convolved_cubes: list[Path]
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    convolved_cubes: list[Path],
+    bane_cubes: bool = False,
 ):
     """Replace every stage subflow of ``process_racs_all`` with a mock, so the
     wiring between them can be checked without imaging anything."""
@@ -356,10 +365,21 @@ def _stage_mocks(
     pol_result = PolPipelineResult(
         stokes_cubes={"q": tmp_path / "q.fits", "u": tmp_path / "u.fits"},
         weight_cubes={"q": tmp_path / "q.weight.fits", "u": tmp_path / "u.weight.fits"},
+        bkg_cubes={"q": tmp_path / "q_bkg.fits", "u": tmp_path / "u_bkg.fits"}
+        if bane_cubes
+        else {},
+        rms_cubes={"q": tmp_path / "q_rms.fits", "u": tmp_path / "u_rms.fits"}
+        if bane_cubes
+        else {},
         mfs_products={},
         terminal_futures=[],
     )
     spice_stage = _stage([])
+    rmsynth_stage = _stage(
+        RMSynthPipelineResult(
+            written_paths=[tmp_path / "fdf.fits"], convolved_cubes=convolved_cubes
+        )
+    )
 
     monkeypatch.setattr(
         "flint.prefect.flows.racs_all_pipeline.get_dask_runner", lambda cluster: None
@@ -373,18 +393,13 @@ def _stage_mocks(
         _stage(pol_result),
     )
     monkeypatch.setattr(
-        "flint.prefect.flows.racs_all_pipeline.process_rmsynth",
-        _stage(
-            RMSynthPipelineResult(
-                written_paths=[tmp_path / "fdf.fits"], convolved_cubes=convolved_cubes
-            )
-        ),
+        "flint.prefect.flows.racs_all_pipeline.process_rmsynth", rmsynth_stage
     )
     monkeypatch.setattr(
         "flint.prefect.flows.racs_all_pipeline.process_spice_compression", spice_stage
     )
 
-    return pol_result, spice_stage
+    return pol_result, spice_stage, rmsynth_stage
 
 
 def _run_racs_all(tmp_path: Path) -> None:
@@ -419,7 +434,7 @@ def test_rmsynth_convolved_cubes_are_spiced(
     polarisation cubes, so leaving them out of the spice stage would strand an
     untrimmed, uncompressed set on disk once the originals have been trimmed."""
     convolved_cubes = [tmp_path / "q.conv.fits", tmp_path / "u.conv.fits"]
-    pol_result, spice_stage = _stage_mocks(
+    pol_result, spice_stage, _ = _stage_mocks(
         monkeypatch=monkeypatch, tmp_path=tmp_path, convolved_cubes=convolved_cubes
     )
 
@@ -441,7 +456,7 @@ def test_spiced_cubes_are_not_repeated_without_convolution(
 ) -> None:
     """rm-synth reports no convolved cubes when the inputs already shared a
     resolution, so the spice stage never sees the same cube twice."""
-    pol_result, spice_stage = _stage_mocks(
+    pol_result, spice_stage, _ = _stage_mocks(
         monkeypatch=monkeypatch, tmp_path=tmp_path, convolved_cubes=[]
     )
 
@@ -452,3 +467,103 @@ def test_spiced_cubes_are_not_repeated_without_convolution(
     ]
     assert spiced_options.cubes == list(pol_result.stokes_cubes.values())
     assert len(set(spiced_options.cubes)) == len(spiced_options.cubes)
+
+
+def _rmsynth_options(rmsynth_stage):
+    """The options the racs-all flow handed the rm-synth stage"""
+    return rmsynth_stage.with_options.return_value.call_args.kwargs[
+        "rmsynth_field_options"
+    ]
+
+
+def test_bane_rms_cubes_are_preferred_over_the_linmos_weights(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A BANE RMS cube is measured off the co-added planes, so it describes the
+    cubes rm-synth reads; the linmos weights are an inverse variance carried
+    over from the input images. When both exist the RMS cubes win, and the two
+    must not be sent together -- rm-lite is told which it has by a single flag.
+    """
+    _, _, rmsynth_stage = _stage_mocks(
+        monkeypatch=monkeypatch, tmp_path=tmp_path, convolved_cubes=[], bane_cubes=True
+    )
+
+    _run_racs_all(tmp_path=tmp_path)
+
+    options = _rmsynth_options(rmsynth_stage)
+    assert isinstance(options.error_cubes, NoiseCubesForRMSynth)
+    assert options.error_cubes.q_path == tmp_path / "q_rms.fits"
+    assert options.error_cubes.u_path == tmp_path / "u_rms.fits"
+
+
+def test_the_linmos_weights_are_used_when_bane_did_not_run(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """BANE is opt-in, so a polarisation stage that skipped it still has to feed
+    rm-synth something."""
+    _, _, rmsynth_stage = _stage_mocks(
+        monkeypatch=monkeypatch, tmp_path=tmp_path, convolved_cubes=[]
+    )
+
+    _run_racs_all(tmp_path=tmp_path)
+
+    options = _rmsynth_options(rmsynth_stage)
+    assert isinstance(options.error_cubes, WeightCubesForRMSynth)
+    assert options.error_cubes.q_path == tmp_path / "q.weight.fits"
+
+
+def test_the_bane_cubes_are_spiced(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The background and RMS cubes are full-size copies on the polarisation
+    cubes' pixel grid. Left out of the spice stage they would stay untrimmed and
+    uncompressed on disk after everything beside them had been trimmed."""
+    pol_result, spice_stage, _ = _stage_mocks(
+        monkeypatch=monkeypatch, tmp_path=tmp_path, convolved_cubes=[], bane_cubes=True
+    )
+
+    _run_racs_all(tmp_path=tmp_path)
+
+    spiced = spice_stage.with_options.return_value.call_args.kwargs[
+        "spice_field_options"
+    ]
+    assert spiced.weight_cubes == [
+        *pol_result.weight_cubes.values(),
+        *pol_result.bkg_cubes.values(),
+        *pol_result.rms_cubes.values(),
+    ]
+
+
+def test_rmsynth_refuses_a_polarisation_strategy_without_the_linear_stokes(
+    tmp_path: Path,
+) -> None:
+    """The FDF is built from Q+iU, so a circular-only strategy has nothing to
+    give rm-synthesis. Caught up front rather than after imaging has run."""
+    from flint.prefect.flows.racs_all_pipeline import _check_rmsynth_has_linear_stokes
+
+    strategy = tmp_path / "polarisation.yaml"
+
+    def _check(**pol_options: Any) -> None:
+        _check_rmsynth_has_linear_stokes(
+            pipeline_options=RACSAllPipelineOptions(),
+            pol_field_options=PolFieldOptions(**pol_options),
+        )
+
+    strategy.write_text(
+        "version: 0.2\ndefaults: {}\npolarisation:\n  circular:\n    wsclean: {}\n"
+    )
+    with pytest.raises(ValueError, match="rm-synthesis needs Stokes"):
+        _check(imaging_strategy=strategy)
+
+    strategy.write_text(
+        "version: 0.2\ndefaults: {}\npolarisation:\n  linear:\n    wsclean: {}\n"
+    )
+    _check(imaging_strategy=strategy)
+
+    # No strategy is the polarisation stage's business, not this check's
+    _check()
+
+    _check_rmsynth_has_linear_stokes(
+        pipeline_options=RACSAllPipelineOptions(skip_rmsynth=True),
+        pol_field_options=PolFieldOptions(imaging_strategy=strategy),
+    )

--- a/tests/test_racs_all_pipeline.py
+++ b/tests/test_racs_all_pipeline.py
@@ -36,8 +36,8 @@ def test_get_parser() -> None:
 
 
 def test_get_parser_excludes_computed_stage_outputs() -> None:
-    """stokes_q_cube/stokes_u_cube (rm-synth) and cubes (spice) are computed
-    from the polarisation stage's output inside process_racs_all, so the
+    """stokes_q_cube/stokes_u_cube (rm-synth) and cubes/weight_cubes (spice) are
+    computed from the polarisation stage's output inside process_racs_all, so the
     combined CLI must not force the user to supply dummy positional values
     for them -- only low_data/mid_data/high_data should be positional."""
     args = get_parser().parse_args(["/low", "/mid", "/high"])
@@ -45,12 +45,14 @@ def test_get_parser_excludes_computed_stage_outputs() -> None:
     assert not hasattr(args, "stokes_q_cube")
     assert not hasattr(args, "stokes_u_cube")
     assert not hasattr(args, "cubes")
+    assert not hasattr(args, "weight_cubes")
 
     # create_options_from_parser reads every field off the namespace, so cli()
     # sets the computed ones to their empty defaults first, as done here.
     args.stokes_q_cube = None
     args.stokes_u_cube = None
     args.cubes = []
+    args.weight_cubes = []
 
     rmsynth_field_options = create_options_from_parser(
         parser_namespace=args, options_class=RMSynthFieldOptions
@@ -60,6 +62,7 @@ def test_get_parser_excludes_computed_stage_outputs() -> None:
     )
     assert rmsynth_field_options.stokes_q_cube is None
     assert spice_field_options.cubes == []
+    assert spice_field_options.weight_cubes == []
 
 
 @pytest.fixture

--- a/tests/test_racs_all_pipeline.py
+++ b/tests/test_racs_all_pipeline.py
@@ -1,0 +1,286 @@
+"""Tests around the racs-all flow-of-flows"""
+
+from __future__ import annotations
+
+from argparse import ArgumentParser
+from pathlib import Path
+
+import pytest
+from capn_crunch import create_options_from_parser
+from prefect.logging import disable_run_logger
+from prefect.testing.utilities import prefect_test_harness
+
+from flint.options import (
+    PolFieldOptions,
+    RACSAllOptions,
+    RACSAllPipelineOptions,
+    RMSynthFieldOptions,
+    SpiceFieldOptions,
+)
+from flint.prefect.flows.racs_all_pipeline import (
+    _check_racs_all_pipeline_options,
+    _check_spice_mfs_dependency,
+    _check_stage_prerequisites,
+    get_parser,
+    process_racs_all,
+)
+
+
+def test_get_parser() -> None:
+    """Simple test to ensure that the parser, composed from five options
+    classes on one shared parser=, can be built without a duplicate-flag
+    error (e.g. from imaging_strategy/sbid_copy_path/aegean_container, which
+    are fields shared by more than one of the five classes)."""
+    parser = get_parser()
+    assert isinstance(parser, ArgumentParser)
+
+
+def test_get_parser_excludes_computed_stage_outputs() -> None:
+    """stokes_q_cube/stokes_u_cube (rm-synth) and cubes (spice) are computed
+    from the polarisation stage's output inside process_racs_all, so the
+    combined CLI must not force the user to supply dummy positional values
+    for them -- only low_data/mid_data/high_data should be positional."""
+    args = get_parser().parse_args(["/low", "/mid", "/high"])
+
+    assert not hasattr(args, "stokes_q_cube")
+    assert not hasattr(args, "stokes_u_cube")
+    assert not hasattr(args, "cubes")
+
+    # create_options_from_parser reads every field off the namespace, so cli()
+    # sets the computed ones to their empty defaults first, as done here.
+    args.stokes_q_cube = None
+    args.stokes_u_cube = None
+    args.cubes = []
+
+    rmsynth_field_options = create_options_from_parser(
+        parser_namespace=args, options_class=RMSynthFieldOptions
+    )
+    spice_field_options = create_options_from_parser(
+        parser_namespace=args, options_class=SpiceFieldOptions
+    )
+    assert rmsynth_field_options.stokes_q_cube is None
+    assert spice_field_options.cubes == []
+
+
+@pytest.fixture
+def racs_all_options() -> RACSAllOptions:
+    return RACSAllOptions(
+        low_data=Path("/does/not/exist/low"),
+        mid_data=Path("/does/not/exist/mid"),
+        high_data=Path("/does/not/exist/high"),
+    )
+
+
+def test_check_racs_all_pipeline_options_polarisation_requires_imaging() -> None:
+    with pytest.raises(ValueError):
+        _check_racs_all_pipeline_options(
+            RACSAllPipelineOptions(skip_imaging=True, skip_polarisation=False)
+        )
+
+
+def test_check_racs_all_pipeline_options_rmsynth_requires_polarisation() -> None:
+    with pytest.raises(ValueError):
+        _check_racs_all_pipeline_options(
+            RACSAllPipelineOptions(skip_polarisation=True, skip_rmsynth=False)
+        )
+
+
+def test_check_racs_all_pipeline_options_spice_requires_polarisation() -> None:
+    with pytest.raises(ValueError):
+        _check_racs_all_pipeline_options(
+            RACSAllPipelineOptions(
+                skip_polarisation=True, skip_rmsynth=True, skip_spice=False
+            )
+        )
+
+
+def test_check_racs_all_pipeline_options_default_is_valid() -> None:
+    """The default (everything enabled) already respects the stage order."""
+    _check_racs_all_pipeline_options(RACSAllPipelineOptions())
+
+
+def test_check_racs_all_pipeline_options_everything_skipped_is_valid() -> None:
+    _check_racs_all_pipeline_options(
+        RACSAllPipelineOptions(
+            skip_imaging=True,
+            skip_polarisation=True,
+            skip_rmsynth=True,
+            skip_spice=True,
+        )
+    )
+
+
+def test_check_spice_mfs_dependency_errors_without_catalogue_or_strategy(
+    racs_all_options: RACSAllOptions,
+) -> None:
+    """No user catalogue and no strategy (so flint_save_mfs_products defaults
+    False) means no aegean reference image would be available."""
+    with pytest.raises(ValueError):
+        _check_spice_mfs_dependency(
+            RACSAllPipelineOptions(skip_spice=False),
+            racs_all_options,
+            SpiceFieldOptions(cubes=[Path("/tmp/i.fits")], catalogue=None),
+        )
+
+
+def test_check_spice_mfs_dependency_ok_with_user_catalogue(
+    racs_all_options: RACSAllOptions,
+) -> None:
+    """A user-supplied catalogue sources WCS/shape from a cube header
+    directly, so no MFS reference image check is needed."""
+    _check_spice_mfs_dependency(
+        RACSAllPipelineOptions(skip_spice=False),
+        racs_all_options,
+        SpiceFieldOptions(cubes=[Path("/tmp/i.fits")], catalogue=Path("/tmp/cat.fits")),
+    )
+
+
+def test_check_spice_mfs_dependency_ok_when_spice_disabled(
+    racs_all_options: RACSAllOptions,
+) -> None:
+    _check_spice_mfs_dependency(
+        RACSAllPipelineOptions(skip_spice=True),
+        racs_all_options,
+        SpiceFieldOptions(cubes=[Path("/tmp/i.fits")], catalogue=None),
+    )
+
+
+def test_process_racs_all_everything_disabled_returns_immediately(
+    racs_all_options: RACSAllOptions,
+) -> None:
+    """The cheapest possible smoke test that stage-skip wiring doesn't blow
+    up on the all-disabled edge case."""
+    from flint.options import PolFieldOptions, RMSynthFieldOptions
+
+    pipeline_options = RACSAllPipelineOptions(
+        skip_imaging=True, skip_polarisation=True, skip_rmsynth=True, skip_spice=True
+    )
+    pol_field_options = PolFieldOptions()
+    rmsynth_field_options = RMSynthFieldOptions(
+        stokes_q_cube=Path("/tmp/q.fits"), stokes_u_cube=Path("/tmp/u.fits")
+    )
+    spice_field_options = SpiceFieldOptions(cubes=[Path("/tmp/i.fits")])
+
+    with prefect_test_harness(), disable_run_logger():
+        result = process_racs_all(
+            pipeline_options=pipeline_options,
+            racs_all_options=racs_all_options,
+            pol_field_options=pol_field_options,
+            rmsynth_field_options=rmsynth_field_options,
+            spice_field_options=spice_field_options,
+        )
+
+    assert result == []
+
+
+def test_get_parser_pol_cube_channel_width_is_independent() -> None:
+    """The polarisation cube channelisation is deliberately its own option: a
+    field name shared with RACSAllOptions is deduplicated in this combined CLI,
+    which would silently tie the pol cubes to the continuum grid."""
+    args = get_parser().parse_args(
+        [
+            "/low",
+            "/mid",
+            "/high",
+            "--cube-channel-width",
+            "1e6",
+            "--pol-cube-channel-width",
+            "2e6",
+        ]
+    )
+
+    pol_field_options = create_options_from_parser(
+        parser_namespace=args, options_class=PolFieldOptions
+    )
+    racs_all_options = create_options_from_parser(
+        parser_namespace=args, options_class=RACSAllOptions
+    )
+
+    assert racs_all_options.cube_channel_width == 1e6
+    assert pol_field_options.pol_cube_channel_width == 2e6
+
+
+def _containers(tmp_path: Path) -> dict[str, Path]:
+    paths = {}
+    for name in ("wsclean", "yandasoft", "aegean"):
+        path = tmp_path / f"{name}.sif"
+        path.touch()
+        paths[name] = path
+    return paths
+
+
+def test_stage_prerequisites_accepts_existing_containers(
+    tmp_path: Path, racs_all_options: RACSAllOptions
+) -> None:
+    containers = _containers(tmp_path)
+    _check_stage_prerequisites(
+        pipeline_options=RACSAllPipelineOptions(skip_imaging=True),
+        racs_all_options=racs_all_options,
+        pol_field_options=PolFieldOptions(
+            wsclean_container=containers["wsclean"],
+            yandasoft_container=containers["yandasoft"],
+        ),
+        spice_field_options=SpiceFieldOptions(aegean_container=containers["aegean"]),
+    )
+
+
+def test_stage_prerequisites_rejects_missing_container_path(
+    tmp_path: Path, racs_all_options: RACSAllOptions
+) -> None:
+    containers = _containers(tmp_path)
+    with pytest.raises(ValueError, match="does not exist"):
+        _check_stage_prerequisites(
+            pipeline_options=RACSAllPipelineOptions(skip_imaging=True),
+            racs_all_options=racs_all_options,
+            pol_field_options=PolFieldOptions(
+                wsclean_container=containers["wsclean"],
+                yandasoft_container=tmp_path / "absent.sif",
+            ),
+            spice_field_options=SpiceFieldOptions(
+                aegean_container=containers["aegean"]
+            ),
+        )
+
+
+def test_stage_prerequisites_requires_aegean_without_catalogue(
+    tmp_path: Path, racs_all_options: RACSAllOptions
+) -> None:
+    containers = _containers(tmp_path)
+    with pytest.raises(ValueError, match="aegean_container"):
+        _check_stage_prerequisites(
+            pipeline_options=RACSAllPipelineOptions(skip_imaging=True),
+            racs_all_options=racs_all_options,
+            pol_field_options=PolFieldOptions(
+                wsclean_container=containers["wsclean"],
+                yandasoft_container=containers["yandasoft"],
+            ),
+            spice_field_options=SpiceFieldOptions(),
+        )
+
+
+def test_stage_prerequisites_skipped_stages_are_not_checked(
+    racs_all_options: RACSAllOptions,
+) -> None:
+    _check_stage_prerequisites(
+        pipeline_options=RACSAllPipelineOptions(
+            skip_imaging=True,
+            skip_polarisation=True,
+            skip_rmsynth=True,
+            skip_spice=True,
+        ),
+        racs_all_options=racs_all_options,
+        pol_field_options=PolFieldOptions(),
+        spice_field_options=SpiceFieldOptions(),
+    )
+
+
+def test_stage_prerequisites_requires_polarisation_containers(
+    racs_all_options: RACSAllOptions,
+) -> None:
+    with pytest.raises(ValueError, match="polarisation stage requires"):
+        _check_stage_prerequisites(
+            pipeline_options=RACSAllPipelineOptions(skip_imaging=True, skip_spice=True),
+            racs_all_options=racs_all_options,
+            pol_field_options=PolFieldOptions(),
+            spice_field_options=SpiceFieldOptions(),
+        )

--- a/tests/test_rmsynth.py
+++ b/tests/test_rmsynth.py
@@ -174,7 +174,9 @@ def test_rmsynth_with_stokes_i_writes_fit_maps(
         assert fits.getheader(alpha_error_path)["NAXIS"] == 2
 
 
-def test_rmsynth_debias_moments_runs(tmp_path: Path, qu_cubes: tuple[Path, Path]) -> None:
+def test_rmsynth_debias_moments_runs(
+    tmp_path: Path, qu_cubes: tuple[Path, Path]
+) -> None:
     stokes_q_cube, stokes_u_cube = qu_cubes
     output_prefix = tmp_path / "test_field"
 
@@ -189,11 +191,44 @@ def test_rmsynth_debias_moments_runs(tmp_path: Path, qu_cubes: tuple[Path, Path]
     )
 
     mom0_path = Path(f"{output_prefix}.fdf.clean.mom0.fits")
+    debiased_mom0_path = Path(f"{output_prefix}.fdf.clean.mom0.debiased.fits")
     assert mom0_path in output_paths
     assert mom0_path.exists()
+    assert debiased_mom0_path in output_paths
+    assert debiased_mom0_path.exists()
+    assert len(output_paths) == 6
 
 
-def test_rmsynth_no_products_is_noop(tmp_path: Path, qu_cubes: tuple[Path, Path]) -> None:
+def test_rmsynth_write_fdfs_to_zarr(
+    tmp_path: Path, qu_cubes: tuple[Path, Path]
+) -> None:
+    stokes_q_cube, stokes_u_cube = qu_cubes
+    output_prefix = tmp_path / "test_field"
+
+    output_paths = rmsynth_and_write_products(
+        stokes_q_cube=stokes_q_cube,
+        stokes_u_cube=stokes_u_cube,
+        rmsynth_options=RMSynthOptions(write_fdfs_to_zarr=True),
+        rmclean_options=RMCleanOptions(),
+        cube_products=["dirty", "clean"],
+        moment_products=["clean"],
+        output_prefix=output_prefix,
+    )
+
+    zarr_store = Path(f"{output_prefix}.fdf.zarr")
+    assert zarr_store in output_paths
+    assert not list(tmp_path.glob("*.fdf.*.cube.fits"))
+
+    import zarr
+
+    group = zarr.open(str(zarr_store), mode="r")
+    assert set(group.keys()) == {"dirty", "clean"}
+    assert group["dirty"].shape[1:] == (NY, NX)
+
+
+def test_rmsynth_no_products_is_noop(
+    tmp_path: Path, qu_cubes: tuple[Path, Path]
+) -> None:
     stokes_q_cube, stokes_u_cube = qu_cubes
 
     output_paths = rmsynth_and_write_products(

--- a/tests/test_rmsynth.py
+++ b/tests/test_rmsynth.py
@@ -129,7 +129,7 @@ def _synth_and_write(
     stokes_i_weight_cube: Path | None = None,
     stokes_q_weight_cube: Path | None = None,
     stokes_u_weight_cube: Path | None = None,
-    peak_products: list[FDFLabel] | None = None,
+    peak_products: list[FDFLabel] = [],
 ) -> list[Path]:
     if not cube_products and not moment_products and not peak_products:
         return []
@@ -381,6 +381,7 @@ def test_unnamed_stokes_i_model_terms_are_skipped_with_a_warning(
         rmclean_options=RMCleanOptions(),
         cube_products=[],
         moment_products=["dirty"],
+        peak_products=[],
         output_prefix=tmp_path / "test_field",
     )
 
@@ -423,6 +424,7 @@ def test_stokes_i_model_rebuilds_from_the_written_term_maps(
         rmclean_options=RMCleanOptions(),
         cube_products=[],
         moment_products=["dirty"],
+        peak_products=[],
         output_prefix=output_prefix,
     )
 
@@ -1160,6 +1162,7 @@ def test_rmclean_runs_once_per_chunk_whatever_is_requested(
         rmclean_options=RMCleanOptions(),
         cube_products=cube_products,
         moment_products=moment_products,
+        peak_products=[],
         output_prefix=tmp_path / "test_field",
     )
 
@@ -1240,6 +1243,7 @@ def test_rmclean_runs_once_per_chunk_on_a_distributed_client(
                 rmclean_options=RMCleanOptions(),
                 cube_products=[],
                 moment_products=["clean", "dirty", "model"],
+                peak_products=[],
                 output_prefix=tmp_path / "field",
                 dask_client=client,
             )

--- a/tests/test_rmsynth.py
+++ b/tests/test_rmsynth.py
@@ -126,6 +126,8 @@ def _synth_and_write(
     output_prefix: Path,
     stokes_i_cube: Path | None = None,
     stokes_i_weight_cube: Path | None = None,
+    stokes_q_weight_cube: Path | None = None,
+    stokes_u_weight_cube: Path | None = None,
 ) -> list[Path]:
     if not cube_products and not moment_products:
         return []
@@ -136,6 +138,8 @@ def _synth_and_write(
         rmsynth_options=rmsynth_options,
         stokes_i_cube=stokes_i_cube,
         stokes_i_weight_cube=stokes_i_weight_cube,
+        stokes_q_weight_cube=stokes_q_weight_cube,
+        stokes_u_weight_cube=stokes_u_weight_cube,
     )
     clean_results = (
         run_rmclean_3d(rm_synth_results=synth_results, rmclean_options=rmclean_options)
@@ -567,6 +571,322 @@ def test_rmsynth_rejects_compressed_cubes(tmp_path: Path) -> None:
         )
 
 
+def test_rmsynth_rejects_a_compressed_weight_cube(tmp_path: Path) -> None:
+    """The weight cubes are read block-by-block just like the Stokes cubes, so a
+    gzipped one inflates the whole cube per read in exactly the same way."""
+    stokes_q_cube, stokes_u_cube = _make_qu_cubes(tmp_path)
+    for weights in (
+        {"stokes_q_weight_cube": tmp_path / "q.weight.fits.gz"},
+        {"stokes_u_weight_cube": tmp_path / "u.weight.fits.gz"},
+        {"stokes_i_weight_cube": tmp_path / "i.weight.fits.gz"},
+    ):
+        with pytest.raises(NotSupportedError):
+            run_rmsynth_3d(
+                stokes_q_cube=stokes_q_cube,
+                stokes_u_cube=stokes_u_cube,
+                stokes_i_cube=_make_i_cube(tmp_path),
+                rmsynth_options=RMSynthOptions(),
+                **weights,
+            )
+
+
+def test_stokes_i_noise_is_estimated_when_no_weight_cube_is_given(
+    tmp_path: Path, qu_cubes: tuple[Path, Path]
+) -> None:
+    """The linmos weight cubes are the preferred Stokes I error, but they only
+    exist when the cubes came from the polarisation pipeline. rm-lite refuses a
+    ``stokes_i_snr_cut`` with no error to score against, so a Stokes I cube on its
+    own has to fall back to the per-channel estimate rather than raise."""
+    assert RMSynthOptions().estimate_stokes_i_noise is True
+    assert RMSynthOptions().stokes_i_snr_cut is not None
+
+    stokes_q_cube, stokes_u_cube = qu_cubes
+    output_prefix = tmp_path / "no_i_weights"
+
+    output_paths = _synth_and_write(
+        stokes_q_cube=stokes_q_cube,
+        stokes_u_cube=stokes_u_cube,
+        stokes_i_cube=_make_i_cube(tmp_path),
+        rmsynth_options=RMSynthOptions(),
+        rmclean_options=RMCleanOptions(),
+        cube_products=[],
+        moment_products=["dirty"],
+        output_prefix=output_prefix,
+        stokes_i_weight_cube=None,
+    )
+
+    alpha_path = Path(f"{output_prefix}.stokesi.alpha.fits")
+    assert alpha_path in output_paths
+    assert np.all(np.isfinite(fits.getdata(alpha_path)))
+
+
+def test_rmsynth_options_reach_rm_lite(
+    tmp_path: Path, qu_cubes: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Every RMSynthOptions field is there to change what rm-lite does, so one
+    that is never passed on is a silently ignored setting rather than a default."""
+    import flint.rmsynth as rmsynth_mod
+
+    captured: dict[str, object] = {}
+
+    def _capture(**kwargs: object) -> None:
+        captured.update(kwargs)
+        msg = "stop before synthesising"
+        raise NotSupportedError(msg)
+
+    monkeypatch.setattr(rmsynth_mod, "rmsynth_3d_from_fits", _capture)
+
+    stokes_q_cube, stokes_u_cube = qu_cubes
+    rmsynth_options = RMSynthOptions(per_pixel_rmsf=True, estimate_stokes_i_noise=False)
+    with pytest.raises(NotSupportedError, match="stop before synthesising"):
+        run_rmsynth_3d(
+            stokes_q_cube=stokes_q_cube,
+            stokes_u_cube=stokes_u_cube,
+            stokes_i_cube=_make_i_cube(tmp_path),
+            rmsynth_options=rmsynth_options,
+        )
+
+    assert captured["per_pixel_rmsf"] is True
+    assert captured["estimate_stokes_i_noise"] is False
+
+
+def _within_cutoff(blank_outside: float) -> np.ndarray:
+    """The (ny, nx) mask ``_make_linmos_weight_cube`` leaves non-zero."""
+    yy, xx = np.mgrid[0:NY, 0:NX]
+    return np.hypot(yy - (NY - 1) / 2, xx - (NX - 1) / 2) <= blank_outside
+
+
+def _make_linmos_weight_cube(
+    tmp_path: Path,
+    name: str,
+    blank_outside: float | None = None,
+    blank_channels: tuple[int, ...] = (),
+    taper_per_channel: bool = False,
+) -> Path:
+    """A weight cube shaped like the one linmos writes: a primary-beam taper,
+    zero outside the ``LinmosOptions.cutoff``, and an all-zero plane for any
+    channel that was flagged everywhere.
+
+    ``taper_per_channel`` narrows the taper with frequency, as a real primary
+    beam does. That is what stops pixels sharing one channel weighting, so it is
+    the case that earns the per-pixel RMSF; the default keeps the taper flat in
+    frequency so the shared spectrum still describes every pixel.
+    """
+    freq_hz = np.linspace(700e6, 1300e6, N_CHAN)
+    yy, xx = np.mgrid[0:NY, 0:NX]
+    radius = np.hypot(yy - (NY - 1) / 2, xx - (NX - 1) / 2)
+
+    plane = np.exp(-(radius**2) / 2.0)
+    if blank_outside is not None:
+        plane = np.where(radius > blank_outside, 0.0, plane)
+
+    if taper_per_channel:
+        # Beam width goes as 1/frequency, so each channel tapers differently
+        scale = (freq_hz / freq_hz[0]) ** 2
+        cube = np.exp(-(radius[None] ** 2) * scale[:, None, None] / 2.0)
+        if blank_outside is not None:
+            cube = np.where(radius[None] > blank_outside, 0.0, cube)
+        cube = (cube / 1e-3**2).astype(np.float32)
+    else:
+        cube = (plane[None] / 1e-3**2).repeat(N_CHAN, axis=0).astype(np.float32)
+    for channel in blank_channels:
+        cube[channel] = 0.0
+
+    wcs = WCS(naxis=3)
+    wcs.wcs.ctype = ["RA---SIN", "DEC--SIN", "FREQ"]
+    wcs.wcs.crval = [180.0, -30.0, freq_hz[0]]
+    wcs.wcs.crpix = [NX / 2, NY / 2, 1]
+    wcs.wcs.cdelt = [-1e-3, 1e-3, freq_hz[1] - freq_hz[0]]
+    wcs.wcs.cunit = ["deg", "deg", "Hz"]
+
+    path = tmp_path / f"{name}.weight.fits"
+    fits.writeto(path, cube, wcs.to_header(), overwrite=True)
+    return path
+
+
+def test_one_linmos_weight_cube_is_refused(
+    tmp_path: Path, qu_cubes: tuple[Path, Path]
+) -> None:
+    """rm-lite builds the weights from Q and U together, so a lone cube is a
+    wiring mistake it refuses rather than half-applies. Pinned here because the
+    racs-all flow passes the pair positionally and a silent drop would look like
+    a linmos-weighted run that never was."""
+    stokes_q_cube, stokes_u_cube = qu_cubes
+
+    with pytest.raises(ValueError, match="[Mm]ust pass both"):
+        run_rmsynth_3d(
+            stokes_q_cube=stokes_q_cube,
+            stokes_u_cube=stokes_u_cube,
+            rmsynth_options=RMSynthOptions(),
+            stokes_q_weight_cube=_make_linmos_weight_cube(
+                tmp_path, "q", blank_outside=1.5
+            ),
+        )
+
+
+def test_rmsynth_with_linmos_weights_stays_cleanable(
+    tmp_path: Path, qu_cubes: tuple[Path, Path]
+) -> None:
+    """The whole point of the weight cubes is the run that follows them.
+
+    A linmos weight cube is dominated by the primary-beam taper, so pixels do
+    not share one channel weighting and rm-lite gives each its own noise and
+    RMSF. That makes the theoretical noise an (ny, nx) map rather than a scalar,
+    and RM-CLEAN scales its mask and threshold by it -- so this is the run that
+    catches a shape or laziness mismatch between the two.
+    """
+    stokes_q_cube, stokes_u_cube = qu_cubes
+
+    synth_results = run_rmsynth_3d(
+        stokes_q_cube=stokes_q_cube,
+        stokes_u_cube=stokes_u_cube,
+        rmsynth_options=RMSynthOptions(),
+        stokes_q_weight_cube=_make_linmos_weight_cube(tmp_path, "q", blank_outside=1.5),
+        stokes_u_weight_cube=_make_linmos_weight_cube(tmp_path, "u", blank_outside=1.5),
+    )
+
+    # Per-pixel weights, so a map over the sky rather than one number for it
+    fdf_error_noise = np.asarray(synth_results.theoretical_noise.fdf_error_noise)
+    assert fdf_error_noise.shape == (NY, NX)
+    assert np.all(fdf_error_noise[np.isfinite(fdf_error_noise)] > 0)
+
+    clean_results = run_rmclean_3d(
+        rm_synth_results=synth_results, rmclean_options=RMCleanOptions()
+    )
+    clean_cube = np.asarray(clean_results.clean_fdf_cube)
+
+    # Per-pixel weights mean a pixel linmos blanked has no weight of its own and
+    # so no FDF, rather than borrowing the rest of the field's. Blank there,
+    # finite everywhere the cutoff kept.
+    inside_cutoff = _within_cutoff(1.5)
+    assert np.all(np.isfinite(clean_cube[:, inside_cutoff])), (
+        "pixels inside the linmos cutoff have data and must not come back blank"
+    )
+    assert np.all(np.isnan(clean_cube[:, ~inside_cutoff])), (
+        "pixels linmos blanked carry no weight, so they must stay blank"
+    )
+
+    phi_arr_radm2 = np.asarray(synth_results.phi_arr_radm2)
+    peak_phi = phi_arr_radm2[np.abs(clean_cube[:, inside_cutoff]).mean(axis=1).argmax()]
+    assert peak_phi == pytest.approx(PHI_TRUE_RADM2, abs=5.0)
+
+
+def test_linmos_weights_give_each_pixel_its_own_rmsf(
+    tmp_path: Path, qu_cubes: tuple[Path, Path]
+) -> None:
+    """A per-pixel RMSF is the costly half of per-pixel weights, so flint should
+    not be surprised into it. rm-lite turns it on by itself whenever pixels
+    weight the channels differently -- which is what a frequency-dependent
+    primary beam does -- and the linmos cubes are exactly that case."""
+    stokes_q_cube, stokes_u_cube = qu_cubes
+
+    synth_results = run_rmsynth_3d(
+        stokes_q_cube=stokes_q_cube,
+        stokes_u_cube=stokes_u_cube,
+        rmsynth_options=RMSynthOptions(),
+        stokes_q_weight_cube=_make_linmos_weight_cube(
+            tmp_path, "q", blank_outside=1.5, taper_per_channel=True
+        ),
+        stokes_u_weight_cube=_make_linmos_weight_cube(
+            tmp_path, "u", blank_outside=1.5, taper_per_channel=True
+        ),
+    )
+
+    assert synth_results.rmsf_cube is not None, (
+        "pixels weighting channels differently must get the per-pixel RMSF cube"
+    )
+    rmsf_cube = np.asarray(synth_results.rmsf_cube)
+    assert rmsf_cube.shape[-2:] == (NY, NX)
+
+    # RM-CLEAN has to consume that cube rather than the shared spectrum
+    clean_results = run_rmclean_3d(
+        rm_synth_results=synth_results, rmclean_options=RMCleanOptions()
+    )
+    assert np.asarray(clean_results.clean_fdf_cube).shape[-2:] == (NY, NX)
+
+
+def test_channels_linmos_blanked_everywhere_drop_out(
+    tmp_path: Path, qu_cubes: tuple[Path, Path]
+) -> None:
+    """An all-zero weight plane is linmos saying that channel was flagged across
+    the whole field. It has to leave the synthesis rather than divide into it:
+    zero weight is a channel that contributes nothing, not one whose 1/0 poisons
+    every pixel that would have used it."""
+    stokes_q_cube, stokes_u_cube = qu_cubes
+    blanked_channels = (0, 5, N_CHAN - 1)
+
+    synth_results = run_rmsynth_3d(
+        stokes_q_cube=stokes_q_cube,
+        stokes_u_cube=stokes_u_cube,
+        rmsynth_options=RMSynthOptions(),
+        stokes_q_weight_cube=_make_linmos_weight_cube(
+            tmp_path, "q", blank_outside=1.5, blank_channels=blanked_channels
+        ),
+        stokes_u_weight_cube=_make_linmos_weight_cube(
+            tmp_path, "u", blank_outside=1.5, blank_channels=blanked_channels
+        ),
+    )
+    clean_results = run_rmclean_3d(
+        rm_synth_results=synth_results, rmclean_options=RMCleanOptions()
+    )
+
+    inside_cutoff = _within_cutoff(1.5)
+    clean_cube = np.asarray(clean_results.clean_fdf_cube)
+    noise = np.asarray(synth_results.theoretical_noise.fdf_error_noise)
+
+    assert np.all(np.isfinite(clean_cube[:, inside_cutoff]))
+    assert np.all(np.isfinite(noise[inside_cutoff]))
+
+    phi_arr_radm2 = np.asarray(synth_results.phi_arr_radm2)
+    peak_phi = phi_arr_radm2[np.abs(clean_cube[:, inside_cutoff]).mean(axis=1).argmax()]
+    assert peak_phi == pytest.approx(PHI_TRUE_RADM2, abs=5.0), (
+        "losing three channels must not move the recovered Faraday depth"
+    )
+
+
+def test_linmos_weights_through_to_the_moment_maps(
+    tmp_path: Path, qu_cubes: tuple[Path, Path]
+) -> None:
+    """Weights plus moment maps is what the racs-all flow actually runs, and it
+    is where the per-pixel shapes have to agree: the moment threshold is
+    ``moment_threshold_snr * theoretical_noise``, now an (ny, nx) map, while the
+    RMSF FWHM it is applied alongside stays a scalar. A mismatch between those
+    two would not raise -- it would broadcast into the wrong threshold per pixel
+    and quietly reshape every moment map."""
+    stokes_q_cube, stokes_u_cube = qu_cubes
+    output_prefix = tmp_path / "field"
+
+    output_paths = _synth_and_write(
+        stokes_q_cube=stokes_q_cube,
+        stokes_u_cube=stokes_u_cube,
+        rmsynth_options=RMSynthOptions(),
+        rmclean_options=RMCleanOptions(),
+        cube_products=[],
+        moment_products=["clean"],
+        output_prefix=output_prefix,
+        stokes_q_weight_cube=_make_linmos_weight_cube(
+            tmp_path, "q", blank_outside=1.5, taper_per_channel=True
+        ),
+        stokes_u_weight_cube=_make_linmos_weight_cube(
+            tmp_path, "u", blank_outside=1.5, taper_per_channel=True
+        ),
+    )
+
+    assert {path.name for path in output_paths} == {
+        f"{output_prefix.name}.fdf.clean.{moment}.fits"
+        for moment in ("mom0", "mom1", "mom2")
+    }
+
+    mom1 = fits.getdata(Path(f"{output_prefix}.fdf.clean.mom1.fits"))
+    inside_cutoff = _within_cutoff(1.5)
+    assert np.allclose(mom1[inside_cutoff], PHI_TRUE_RADM2, atol=5.0), (
+        "the per-pixel noise map must threshold each pixel, not reshape the field"
+    )
+    assert np.all(np.isnan(mom1[~inside_cutoff])), (
+        "pixels linmos blanked have no weight, so they get no moment"
+    )
+
+
 def _make_noise_only_cubes(
     tmp_path: Path, prefix: str = "noise"
 ) -> tuple[Path, Path, Path, Path]:
@@ -692,13 +1012,13 @@ def test_rmclean_runs_once_per_chunk_whatever_is_requested(
     stokes_q_cube, stokes_u_cube = qu_cubes
 
     calls: list[int] = []
-    original = rmclean_mod._clean_block
+    original = rmclean_mod._rmclean_on_block
 
     def counting_clean_block(*args: object, **kwargs: object) -> object:
         calls.append(1)
         return original(*args, **kwargs)
 
-    monkeypatch.setattr(rmclean_mod, "_clean_block", counting_clean_block)
+    monkeypatch.setattr(rmclean_mod, "_rmclean_on_block", counting_clean_block)
     # write_rm_products picks the process scheduler when cleaning, which would
     # put the counter in a subprocess. Fusion, not the scheduler, is what
     # duplicates the task, so counting under threads measures the same thing.

--- a/tests/test_rmsynth.py
+++ b/tests/test_rmsynth.py
@@ -1,7 +1,4 @@
-"""Plumbing tests for RM-synthesis via rm-lite. rm-lite's own synthesis
-correctness is its responsibility, not flint-pol's -- these tests only check
-that FITS in -> WCS/product-selection -> FITS out behaves as expected.
-"""
+"""Plumbing tests for RM-synthesis via rm-lite"""
 
 from __future__ import annotations
 
@@ -11,9 +8,18 @@ import numpy as np
 import pytest
 from astropy.io import fits
 from astropy.wcs import WCS
+from pydantic import ValidationError
 
+from flint.exceptions import NotSupportedError
 from flint.options import RMCleanOptions, RMSynthOptions
-from flint.rmsynth import rmsynth_and_write_products
+from flint.rmsynth import (
+    FDFLabel,
+    needs_rmclean,
+    run_rmclean_3d,
+    run_rmsynth_3d,
+    write_rm_products,
+    write_stokes_i_coeff_maps_to_fits,
+)
 
 N_CHAN = 20
 NY = 5
@@ -80,11 +86,50 @@ def qu_cubes(tmp_path: Path) -> tuple[Path, Path]:
     return _make_qu_cubes(tmp_path)
 
 
+def _synth_and_write(
+    stokes_q_cube: Path,
+    stokes_u_cube: Path,
+    rmsynth_options: RMSynthOptions,
+    rmclean_options: RMCleanOptions,
+    cube_products: list[FDFLabel],
+    moment_products: list[FDFLabel],
+    output_prefix: Path,
+    stokes_i_cube: Path | None = None,
+) -> list[Path]:
+    """Mirror of the call sequence in ``flint.prefect.flows.rmsynth_pipeline``,
+    keeping these unit tests off prefect and dask. The flow itself is tested in
+    ``tests/test_prefect_rmsynth_flow.py``."""
+    if not cube_products and not moment_products:
+        return []
+
+    synth_results = run_rmsynth_3d(
+        stokes_q_cube=stokes_q_cube,
+        stokes_u_cube=stokes_u_cube,
+        rmsynth_options=rmsynth_options,
+        stokes_i_cube=stokes_i_cube,
+    )
+    clean_results = (
+        run_rmclean_3d(rm_synth_results=synth_results, rmclean_options=rmclean_options)
+        if needs_rmclean(cube_products=cube_products, moment_products=moment_products)
+        else None
+    )
+    return write_rm_products(
+        synth_results=synth_results,
+        clean_results=clean_results,
+        stokes_q_cube=stokes_q_cube,
+        rmsynth_options=rmsynth_options,
+        rmclean_options=rmclean_options,
+        cube_products=cube_products,
+        moment_products=moment_products,
+        output_prefix=output_prefix,
+    )
+
+
 def test_rmsynth_all_products(tmp_path: Path, qu_cubes: tuple[Path, Path]) -> None:
     stokes_q_cube, stokes_u_cube = qu_cubes
     output_prefix = tmp_path / "test_field"
 
-    output_paths = rmsynth_and_write_products(
+    output_paths = _synth_and_write(
         stokes_q_cube=stokes_q_cube,
         stokes_u_cube=stokes_u_cube,
         rmsynth_options=RMSynthOptions(),
@@ -94,16 +139,16 @@ def test_rmsynth_all_products(tmp_path: Path, qu_cubes: tuple[Path, Path]) -> No
         output_prefix=output_prefix,
     )
 
-    assert len(output_paths) == 3 + 3 * 3
+    # One zarr store holding all three cubes, plus three moments per label
+    assert len(output_paths) == 1 + 3 * 3
     for path in output_paths:
         assert path.exists()
 
-    for label in ("dirty", "clean", "model"):
-        cube_path = Path(f"{output_prefix}.fdf.{label}.cube.fits")
-        assert cube_path.exists()
-        header = fits.getheader(cube_path)
-        assert header["CTYPE3"] == "FDEPTH"
+    assert not list(tmp_path.glob("*.fdf.*.cube.fits")), (
+        "FDF cubes are zarr-only; a FITS cube means the gather path came back"
+    )
 
+    for label in ("dirty", "clean", "model"):
         for moment in ("mom0", "mom1", "mom2"):
             moment_path = Path(f"{output_prefix}.fdf.{label}.{moment}.fits")
             assert moment_path.exists()
@@ -125,7 +170,7 @@ def test_rmsynth_dirty_only_skips_rmclean(
         "flint.rmsynth.run_rmclean_3d", lambda *args, **kwargs: calls.append(1)
     )
 
-    output_paths = rmsynth_and_write_products(
+    output_paths = _synth_and_write(
         stokes_q_cube=stokes_q_cube,
         stokes_u_cube=stokes_u_cube,
         rmsynth_options=RMSynthOptions(),
@@ -148,7 +193,7 @@ def test_rmsynth_with_stokes_i_writes_fit_maps(
     stokes_i_cube = _make_i_cube(tmp_path)
     output_prefix = tmp_path / "test_field"
 
-    output_paths = rmsynth_and_write_products(
+    output_paths = _synth_and_write(
         stokes_q_cube=stokes_q_cube,
         stokes_u_cube=stokes_u_cube,
         stokes_i_cube=stokes_i_cube,
@@ -173,6 +218,199 @@ def test_rmsynth_with_stokes_i_writes_fit_maps(
         assert alpha_error_path.exists()
         assert fits.getheader(alpha_error_path)["NAXIS"] == 2
 
+    # A spectral index or a reference flux is unreadable without the frequency it
+    # is defined at and the functional form it belongs to.
+    header = fits.getheader(Path(f"{output_prefix}.stokesi.alpha.fits"))
+    assert header["FITFUNC"] == "log"
+    assert 700e6 < header["REFFREQ"] < 1300e6
+
+
+@pytest.mark.parametrize(
+    ("fit_function", "expected_names"),
+    [("log", ("flux", "alpha", "beta")), ("linear", ("c0", "c1", "c2"))],
+)
+def test_rmsynth_writes_a_named_map_per_stokes_i_model_term(
+    tmp_path: Path,
+    qu_cubes: tuple[Path, Path],
+    fit_function: str,
+    expected_names: tuple[str, ...],
+) -> None:
+    """Each fitted Stokes I model term gets its own named map, since the names
+    are what make the terms usable, and they differ by fit function."""
+    stokes_q_cube, stokes_u_cube = qu_cubes
+    stokes_i_cube = _make_i_cube(tmp_path)
+    output_prefix = tmp_path / "test_field"
+
+    output_paths = _synth_and_write(
+        stokes_q_cube=stokes_q_cube,
+        stokes_u_cube=stokes_u_cube,
+        stokes_i_cube=stokes_i_cube,
+        rmsynth_options=RMSynthOptions(
+            estimate_stokes_i_noise=True, fit_function=fit_function
+        ),
+        rmclean_options=RMCleanOptions(),
+        cube_products=[],
+        moment_products=["dirty"],
+        output_prefix=output_prefix,
+    )
+
+    for index, name in enumerate(expected_names):
+        term_path = Path(f"{output_prefix}.stokesi.coeff.{name}.fits")
+        assert term_path in output_paths
+        header = fits.getheader(term_path)
+        assert header["NAXIS"] == 2
+        assert header["SICOEFF"] == name
+        assert header["SICOEFFI"] == index
+        assert header["FITFUNC"] == fit_function
+        assert 700e6 < header["REFFREQ"] < 1300e6
+
+        error_path = Path(f"{output_prefix}.stokesi.coeff.{name}_error.fits")
+        assert error_path in output_paths
+        assert fits.getheader(error_path)["NAXIS"] == 2
+
+    # Under the log fit, term 1 *is* the spectral index, so it has to match the
+    # standalone alpha map. Not so for the linear fit, where alpha is
+    # d ln I / d ln nu at the reference frequency rather than any single c_i.
+    if fit_function == "log":
+        assert np.allclose(
+            fits.getdata(Path(f"{output_prefix}.stokesi.alpha.fits")),
+            fits.getdata(Path(f"{output_prefix}.stokesi.coeff.alpha.fits")),
+            equal_nan=True,
+        )
+
+
+def test_stokes_i_coeff_maps_without_an_error_cube(tmp_path: Path) -> None:
+    """The error cube is optional, so the term maps are written without it."""
+    reference_header = fits.getheader(_make_i_cube(tmp_path))
+    output_prefix = tmp_path / "test_field"
+
+    output_paths = write_stokes_i_coeff_maps_to_fits(
+        coeff_cube=np.zeros((2, NY, NX)),
+        coeff_names=("flux", "alpha"),
+        reference_header=reference_header,
+        output_prefix=output_prefix,
+    )
+
+    assert output_paths == [
+        Path(f"{output_prefix}.stokesi.coeff.flux.fits"),
+        Path(f"{output_prefix}.stokesi.coeff.alpha.fits"),
+    ]
+    assert not list(tmp_path.glob("*_error.fits"))
+    # Nothing told us what the terms are referenced to, so nothing is claimed.
+    header = fits.getheader(output_paths[0])
+    assert "REFFREQ" not in header
+    assert "FITFUNC" not in header
+
+
+def test_stokes_i_coeff_maps_refuse_a_name_and_plane_mismatch(tmp_path: Path) -> None:
+    """Writing the planes under the wrong names would be worse than not writing
+    them, so a disagreement between the two is refused rather than truncated."""
+    with pytest.raises(ValueError, match="named 2 Stokes I model terms"):
+        write_stokes_i_coeff_maps_to_fits(
+            coeff_cube=np.zeros((3, NY, NX)),
+            coeff_names=("flux", "alpha"),
+            reference_header=fits.getheader(_make_i_cube(tmp_path)),
+            output_prefix=tmp_path / "test_field",
+        )
+
+
+def test_unnamed_stokes_i_model_terms_are_skipped_with_a_warning(
+    tmp_path: Path, qu_cubes: tuple[Path, Path], caplog: pytest.LogCaptureFixture
+) -> None:
+    """rm-lite names the terms whenever it returns them, so this state takes an
+    rm-lite regression to reach. Unnamed planes are not worth writing, but they
+    are not worth losing the rest of the products over either.
+    """
+    stokes_q_cube, stokes_u_cube = qu_cubes
+    rmsynth_options = RMSynthOptions(estimate_stokes_i_noise=True)
+    synth_results = run_rmsynth_3d(
+        stokes_q_cube=stokes_q_cube,
+        stokes_u_cube=stokes_u_cube,
+        rmsynth_options=rmsynth_options,
+        stokes_i_cube=_make_i_cube(tmp_path),
+    )
+    assert synth_results.stokes_i_coeff_names is not None
+
+    output_paths = write_rm_products(
+        synth_results=synth_results._replace(stokes_i_coeff_names=None),
+        clean_results=None,
+        stokes_q_cube=stokes_q_cube,
+        rmsynth_options=rmsynth_options,
+        rmclean_options=RMCleanOptions(),
+        cube_products=[],
+        moment_products=["dirty"],
+        output_prefix=tmp_path / "test_field",
+    )
+
+    assert not any("coeff" in path.name for path in output_paths)
+    assert any("no names for them" in record.message for record in caplog.records)
+    # The maps that are still nameable are written regardless.
+    assert any(path.name.endswith("stokesi.alpha.fits") for path in output_paths)
+
+
+def test_stokes_i_model_rebuilds_from_the_written_term_maps(
+    tmp_path: Path, qu_cubes: tuple[Path, Path]
+) -> None:
+    """The point of writing the terms is that the model can be evaluated at any
+    frequency from them alone. Rebuild it from the written maps and their
+    headers, and check it against the model cube rm-lite fitted.
+
+    ``fit_order=-3`` lets the AIC pick the order, so this also pins the
+    zero-versus-NaN convention: our Stokes I spectrum is a pure power law, so the
+    higher terms are dropped, and a dropped term has to come back as zero -- it
+    contributes nothing to the model -- rather than NaN, which would poison the
+    sum below.
+    """
+    stokes_q_cube, stokes_u_cube = qu_cubes
+    stokes_i_cube = _make_i_cube(tmp_path)
+    output_prefix = tmp_path / "test_field"
+    rmsynth_options = RMSynthOptions(estimate_stokes_i_noise=True, fit_order=-3)
+
+    synth_results = run_rmsynth_3d(
+        stokes_q_cube=stokes_q_cube,
+        stokes_u_cube=stokes_u_cube,
+        rmsynth_options=rmsynth_options,
+        stokes_i_cube=stokes_i_cube,
+    )
+    write_rm_products(
+        synth_results=synth_results,
+        clean_results=None,
+        stokes_q_cube=stokes_q_cube,
+        rmsynth_options=rmsynth_options,
+        rmclean_options=RMCleanOptions(),
+        cube_products=[],
+        moment_products=["dirty"],
+        output_prefix=output_prefix,
+    )
+
+    names = synth_results.stokes_i_coeff_names
+    assert names is not None
+    terms = np.stack(
+        [
+            fits.getdata(Path(f"{output_prefix}.stokesi.coeff.{name}.fits"))
+            for name in names
+        ]
+    )
+    header = fits.getheader(Path(f"{output_prefix}.stokesi.coeff.{names[0]}.fits"))
+    assert header["FITFUNC"] == "log"
+
+    # A dropped term is zero, not NaN, and model_order says how many were fitted.
+    order_map = fits.getdata(Path(f"{output_prefix}.stokesi.model_order.fits"))
+    dropped = terms[int(order_map.max()) + 1 :]
+    assert dropped.size, "expected the AIC to drop at least one term here"
+    assert np.all(dropped == 0.0)
+
+    freq_hz = np.linspace(700e6, 1300e6, N_CHAN)
+    log_freq_ratio = np.log10(freq_hz / header["REFFREQ"])[:, None, None]
+    exponent = sum(
+        terms[power] * log_freq_ratio**power for power in range(1, len(names))
+    )
+    rebuilt = terms[0] * 10.0**exponent
+
+    assert np.allclose(
+        rebuilt, np.asarray(synth_results.stokes_i_model_cube), rtol=1e-5
+    )
+
 
 def test_rmsynth_debias_moments_runs(
     tmp_path: Path, qu_cubes: tuple[Path, Path]
@@ -180,7 +418,7 @@ def test_rmsynth_debias_moments_runs(
     stokes_q_cube, stokes_u_cube = qu_cubes
     output_prefix = tmp_path / "test_field"
 
-    output_paths = rmsynth_and_write_products(
+    output_paths = _synth_and_write(
         stokes_q_cube=stokes_q_cube,
         stokes_u_cube=stokes_u_cube,
         rmsynth_options=RMSynthOptions(debias_moments=True),
@@ -199,16 +437,16 @@ def test_rmsynth_debias_moments_runs(
     assert len(output_paths) == 6
 
 
-def test_rmsynth_write_fdfs_to_zarr(
+def test_rmsynth_writes_fdf_cubes_to_zarr(
     tmp_path: Path, qu_cubes: tuple[Path, Path]
 ) -> None:
     stokes_q_cube, stokes_u_cube = qu_cubes
     output_prefix = tmp_path / "test_field"
 
-    output_paths = rmsynth_and_write_products(
+    output_paths = _synth_and_write(
         stokes_q_cube=stokes_q_cube,
         stokes_u_cube=stokes_u_cube,
-        rmsynth_options=RMSynthOptions(write_fdfs_to_zarr=True),
+        rmsynth_options=RMSynthOptions(),
         rmclean_options=RMCleanOptions(),
         cube_products=["dirty", "clean"],
         moment_products=["clean"],
@@ -222,8 +460,48 @@ def test_rmsynth_write_fdfs_to_zarr(
     import zarr
 
     group = zarr.open(str(zarr_store), mode="r")
-    assert set(group.keys()) == {"dirty", "clean"}
+    assert set(group.keys()) == {"dirty", "clean", "phi_arr_radm2"}
     assert group["dirty"].shape[1:] == (NY, NX)
+    # Without the Faraday depth axis the store is not self-describing
+    assert group["phi_arr_radm2"].shape[0] == group["dirty"].shape[0]
+
+
+def test_moment_only_never_computes_a_full_cube(
+    tmp_path: Path, qu_cubes: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Moment maps must be computed as lazy (ny, nx) reductions, never by
+    gathering the (n_phi, ny, nx) FDF cube into the calling process. Gathering
+    is invisible on these tiny test cubes but is tens of GB on a real mosaic."""
+    import dask
+
+    stokes_q_cube, stokes_u_cube = qu_cubes
+    real_compute = dask.compute
+    computed_shapes: list[tuple[int, ...]] = []
+
+    def _spy_compute(*args, **kwargs):
+        results = real_compute(*args, **kwargs)
+        computed_shapes.extend(
+            np.shape(result) for result in results if hasattr(result, "shape")
+        )
+        return results
+
+    monkeypatch.setattr(dask, "compute", _spy_compute)
+
+    _synth_and_write(
+        stokes_q_cube=stokes_q_cube,
+        stokes_u_cube=stokes_u_cube,
+        rmsynth_options=RMSynthOptions(),
+        rmclean_options=RMCleanOptions(),
+        cube_products=[],
+        moment_products=["dirty", "clean", "model"],
+        output_prefix=tmp_path / "test_field",
+    )
+
+    assert computed_shapes, "expected a batched dask.compute call"
+    # Every gathered array is a 2D map; a 3D shape means an FDF cube came back.
+    assert all(len(shape) == 2 for shape in computed_shapes), computed_shapes
+    # 3 labels x mom0/mom1/mom2, and nothing else.
+    assert len(computed_shapes) == 9
 
 
 def test_rmsynth_no_products_is_noop(
@@ -231,7 +509,7 @@ def test_rmsynth_no_products_is_noop(
 ) -> None:
     stokes_q_cube, stokes_u_cube = qu_cubes
 
-    output_paths = rmsynth_and_write_products(
+    output_paths = _synth_and_write(
         stokes_q_cube=stokes_q_cube,
         stokes_u_cube=stokes_u_cube,
         rmsynth_options=RMSynthOptions(),
@@ -244,4 +522,312 @@ def test_rmsynth_no_products_is_noop(
     assert output_paths == []
     assert not list(tmp_path.glob("*.fits")) or all(
         p in (stokes_q_cube, stokes_u_cube) for p in tmp_path.glob("*.fits")
+    )
+
+
+def test_rmsynth_rejects_compressed_cubes(tmp_path: Path) -> None:
+    """A gzipped cube cannot be memmapped, so rm-lite's per-block reopens would
+    each inflate the whole cube into memory."""
+    with pytest.raises(NotSupportedError):
+        run_rmsynth_3d(
+            stokes_q_cube=tmp_path / "q.fits.gz",
+            stokes_u_cube=tmp_path / "u.fits.gz",
+            rmsynth_options=RMSynthOptions(),
+        )
+
+
+def _make_noise_only_cubes(
+    tmp_path: Path, prefix: str = "noise"
+) -> tuple[Path, Path, Path]:
+    """Q/U/I cubes of pure noise, no source anywhere.
+
+    The point of a noise-only cube is that everything the pipeline reports for
+    it is a property of the noise handling rather than of a signal: no pixel
+    should be fitted, cleaned, or given a polarised flux.
+    """
+    freq_hz = np.linspace(800e6, 1800e6, 40)
+    rng = np.random.default_rng(20)
+    shape = (freq_hz.size, 8, 8)
+
+    wcs = WCS(naxis=3)
+    wcs.wcs.ctype = ["RA---SIN", "DEC--SIN", "FREQ"]
+    wcs.wcs.crval = [180.0, -30.0, freq_hz[0]]
+    wcs.wcs.crpix = [shape[2] / 2, shape[1] / 2, 1]
+    wcs.wcs.cdelt = [-1e-3, 1e-3, freq_hz[1] - freq_hz[0]]
+    wcs.wcs.cunit = ["deg", "deg", "Hz"]
+    header = wcs.to_header()
+
+    paths = []
+    for stokes in ("q", "u", "i"):
+        cube = rng.normal(0.0, 1e-3, shape).astype(np.float32)
+        path = tmp_path / f"{prefix}.{stokes}.fits"
+        fits.writeto(path, cube, header, overwrite=True)
+        paths.append(path)
+    return paths[0], paths[1], paths[2]
+
+
+def test_estimate_stokes_i_noise_defaults_on() -> None:
+    """The Stokes I SNR cut is inert without a noise to compare against, so the
+    estimate that gives it one has to be on by default -- see
+    ``_warn_if_snr_cut_inert``."""
+    options = RMSynthOptions()
+    assert options.estimate_stokes_i_noise is True
+    assert options.stokes_i_snr_cut is not None
+
+
+def test_snr_cut_without_a_noise_estimate_is_refused() -> None:
+    """The combination is broken, not merely slow, so it must not be
+    constructible: rm-lite scores every pixel as infinite SNR without a noise
+    estimate, so the cut passes all of them and a power law fitted to noise can
+    pass close enough to zero that Q/U divided by it is infinite."""
+    with pytest.raises(ValidationError, match="requires estimate_stokes_i_noise"):
+        RMSynthOptions(stokes_i_snr_cut=5.0, estimate_stokes_i_noise=False)
+
+    # ... including when reached through with_options rather than the constructor
+    with pytest.raises(ValidationError, match="requires estimate_stokes_i_noise"):
+        RMSynthOptions().with_options(estimate_stokes_i_noise=False)
+
+    # Turning the cut off deliberately is allowed, and so is the default pairing
+    assert (
+        RMSynthOptions(
+            stokes_i_snr_cut=None, estimate_stokes_i_noise=False
+        ).stokes_i_snr_cut
+        is None
+    )
+    assert RMSynthOptions().estimate_stokes_i_noise is True
+
+
+def test_snr_cut_rule_is_enforced_from_a_strategy_file(tmp_path: Path) -> None:
+    """A strategy file is the likely way in, so it has to fail there too rather
+    than after imaging has already run."""
+    strategy_path = tmp_path / "strategy.yaml"
+    strategy_path.write_text(
+        "defaults:\n"
+        "  rmsynth:\n"
+        "    estimate_stokes_i_noise: false\n"
+        "version: 0.2\n"
+        "rmsynth:\n"
+        "  rmsynth:\n"
+        "    estimate_stokes_i_noise: false\n"
+    )
+    from flint.configuration import get_options_from_strategy, load_strategy_yaml
+
+    strategy = load_strategy_yaml(input_yaml=strategy_path, verify=False)
+    options = get_options_from_strategy(
+        strategy=strategy, operation="rmsynth", mode="rmsynth"
+    )
+    with pytest.raises(ValidationError, match="requires estimate_stokes_i_noise"):
+        RMSynthOptions(**options)
+
+
+def test_multiscale_rmclean_is_refused_rather_than_ignored(tmp_path: Path) -> None:
+    """flint does not support multiscale RM-CLEAN for now. A strategy asking for
+    it has to be told so at load, rather than have the request quietly dropped
+    and the run look like it honoured the setting.
+    """
+    strategy_path = tmp_path / "strategy.yaml"
+    strategy_path.write_text(
+        "defaults:\n"
+        "  rmsynth:\n"
+        "    auto_mask: 7\n"
+        "version: 0.2\n"
+        "rmsynth:\n"
+        "  rmclean:\n"
+        "    multiscale: true\n"
+    )
+    from flint.configuration import get_options_from_strategy, load_strategy_yaml
+
+    strategy = load_strategy_yaml(input_yaml=strategy_path, verify=False)
+    options = get_options_from_strategy(
+        strategy=strategy, operation="rmsynth", mode="rmclean"
+    )
+    with pytest.raises(ValidationError, match="multiscale"):
+        RMCleanOptions(**options)
+
+
+def test_stokes_i_fit_on_noise_stays_finite(tmp_path: Path) -> None:
+    """With the SNR cut working, a noise-only cube must come back with no
+    polarised flux and nothing infinite.
+
+    A power law fitted to a noise spectrum is unconstrained and can dip to
+    ~1e-10 mid-band; Q/U divided by that is an infinite FDF and an infinite
+    mom0. The cut is what stops those pixels being fitted at all.
+    """
+    q_cube, u_cube, i_cube = _make_noise_only_cubes(tmp_path)
+    output_prefix = tmp_path / "noise_field"
+
+    _synth_and_write(
+        stokes_q_cube=q_cube,
+        stokes_u_cube=u_cube,
+        stokes_i_cube=i_cube,
+        rmsynth_options=RMSynthOptions(
+            estimate_stokes_i_noise=True, stokes_i_snr_cut=5.0
+        ),
+        rmclean_options=RMCleanOptions(),
+        cube_products=[],
+        moment_products=["dirty", "clean"],
+        output_prefix=output_prefix,
+    )
+
+    for label in ("dirty", "clean"):
+        mom0 = fits.getdata(Path(f"{output_prefix}.fdf.{label}.mom0.fits"))
+        assert np.isfinite(mom0).all(), f"{label} mom0 has non-finite pixels"
+        # Nothing clears the moment threshold, so there is no polarised flux
+        assert np.allclose(mom0, 0.0), f"{label} mom0 found flux in pure noise"
+
+
+@pytest.mark.parametrize(
+    ("cube_products", "moment_products"),
+    [
+        ([], ["clean"]),
+        ([], ["clean", "model"]),
+        (["clean"], ["clean"]),
+        (["clean", "model"], ["clean", "model"]),
+        (["dirty", "clean", "model"], ["dirty", "clean", "model"]),
+    ],
+    ids=["moments", "two-moments", "cube+moments", "two-cubes", "everything"],
+)
+def test_rmclean_runs_once_per_chunk_whatever_is_requested(
+    tmp_path: Path,
+    qu_cubes: tuple[Path, Path],
+    monkeypatch: pytest.MonkeyPatch,
+    cube_products: list[FDFLabel],
+    moment_products: list[FDFLabel],
+) -> None:
+    """RM-CLEAN is the expensive part of the stage, and every requested product
+    descends from one ``dask.delayed`` call per spatial chunk, so it must run
+    once per chunk no matter how many products are asked for.
+
+    It is easy to lose: ``dask.array.Array.to_zarr`` optimises the graph it
+    captures, and the blockwise fuse pass inlines the shared RM-CLEAN task into
+    each consumer branch, giving every cube its own private copy. Before this
+    was pinned down, two cubes ran RM-CLEAN twice per chunk and three ran it
+    three times -- invisible in the output, just twice or three times the
+    runtime of the slowest stage.
+    """
+    import dask
+    import rm_lite.tools_3d.rmclean as rmclean_mod
+
+    stokes_q_cube, stokes_u_cube = qu_cubes
+
+    calls: list[int] = []
+    original = rmclean_mod._clean_block
+
+    def counting_clean_block(*args: object, **kwargs: object) -> object:
+        calls.append(1)
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(rmclean_mod, "_clean_block", counting_clean_block)
+    # write_rm_products picks the process scheduler when cleaning, which would
+    # put the counter in a subprocess. Fusion, not the scheduler, is what
+    # duplicates the task, so counting under threads measures the same thing.
+    real_compute = dask.compute
+    monkeypatch.setattr(
+        dask,
+        "compute",
+        lambda *a, **k: real_compute(*a, **{**k, "scheduler": "threads"}),
+    )
+
+    synth_results = run_rmsynth_3d(
+        stokes_q_cube=stokes_q_cube,
+        stokes_u_cube=stokes_u_cube,
+        rmsynth_options=RMSynthOptions(),
+    )
+    n_chunks = (
+        synth_results.fdf_dirty_cube.numblocks[1]
+        * synth_results.fdf_dirty_cube.numblocks[2]
+    )
+    clean_results = run_rmclean_3d(
+        rm_synth_results=synth_results, rmclean_options=RMCleanOptions()
+    )
+    write_rm_products(
+        synth_results=synth_results,
+        clean_results=clean_results,
+        stokes_q_cube=stokes_q_cube,
+        rmsynth_options=RMSynthOptions(),
+        rmclean_options=RMCleanOptions(),
+        cube_products=cube_products,
+        moment_products=moment_products,
+        output_prefix=tmp_path / "test_field",
+    )
+
+    assert len(calls) == n_chunks, (
+        f"RM-CLEAN ran {len(calls) / n_chunks:.0f}x per chunk for "
+        f"cubes={cube_products}, moments={moment_products}"
+    )
+
+
+def test_stokes_i_fit_does_not_multiply_with_requested_products(
+    tmp_path: Path, qu_cubes: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The per-pixel Stokes I fit is the most expensive step of the stage, so the
+    number of FDF products asked for must not scale it -- the same guard as
+    ``test_rmclean_runs_once_per_chunk_whatever_is_requested``, for the other
+    expensive kernel.
+
+    The count is compared between product mixes rather than against a fixed
+    number on purpose. rm-lite's ``run_rmclean`` takes the dirty cube through
+    ``to_delayed()``, which optimises and so re-keys the synthesis graph, so the
+    copy RM-CLEAN consumes is not the one the Stokes I maps are sliced from and
+    the fit currently runs twice per chunk however little is requested. That is
+    upstream and constant; what flint controls, and what this pins, is that its
+    own batching adds nothing on top.
+    """
+    import dask
+    import rm_lite.tools_3d.rmsynth as rmsynth_mod
+
+    stokes_q_cube, stokes_u_cube = qu_cubes
+    stokes_i_cube = _make_i_cube(tmp_path)
+
+    calls: list[int] = []
+    original = rmsynth_mod._fit_stokes_i_block
+
+    def counting_fit_block(*args: object, **kwargs: object) -> object:
+        calls.append(1)
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(rmsynth_mod, "_fit_stokes_i_block", counting_fit_block)
+    # As above: the counter has to stay in this process, and it is the graph
+    # rather than the scheduler that decides how often the fit is called.
+    real_compute = dask.compute
+    monkeypatch.setattr(
+        dask,
+        "compute",
+        lambda *a, **k: real_compute(*a, **{**k, "scheduler": "threads"}),
+    )
+
+    # Built once, and never computed, only to read the chunking off it
+    n_chunks = run_rmsynth_3d(
+        stokes_q_cube=stokes_q_cube,
+        stokes_u_cube=stokes_u_cube,
+        rmsynth_options=RMSynthOptions(),
+        stokes_i_cube=stokes_i_cube,
+    ).fdf_dirty_cube.numblocks[1:]
+    n_chunks = n_chunks[0] * n_chunks[1]
+
+    counts: dict[str, float] = {}
+    product_mixes: tuple[tuple[list[FDFLabel], list[FDFLabel]], ...] = (
+        ([], ["clean"]),
+        ([], ["dirty", "clean"]),
+        (["clean"], ["clean"]),
+        (["dirty", "clean"], ["dirty", "clean"]),
+    )
+    for cube_products, moment_products in product_mixes:
+        calls.clear()
+        _synth_and_write(
+            stokes_q_cube=stokes_q_cube,
+            stokes_u_cube=stokes_u_cube,
+            stokes_i_cube=stokes_i_cube,
+            rmsynth_options=RMSynthOptions(),
+            rmclean_options=RMCleanOptions(),
+            cube_products=cube_products,
+            moment_products=moment_products,
+            output_prefix=tmp_path / "test_field",
+        )
+        counts[f"cubes={cube_products}, moments={moment_products}"] = (
+            len(calls) / n_chunks
+        )
+
+    assert len(set(counts.values())) == 1, (
+        f"the Stokes I fit count moves with the requested products: {counts}"
     )

--- a/tests/test_rmsynth.py
+++ b/tests/test_rmsynth.py
@@ -53,6 +53,28 @@ def _make_qu_cubes(tmp_path: Path) -> tuple[Path, Path]:
     return q_path, u_path
 
 
+def _make_i_cube(tmp_path: Path) -> Path:
+    """Write a synthetic Stokes I FITS cube (power-law spectrum + noise)
+    matching the Q/U cube's WCS."""
+    freq_hz = np.linspace(700e6, 1300e6, N_CHAN)
+    i_spec = (freq_hz / freq_hz[0]) ** -0.7
+    rng = np.random.default_rng(1)
+    i_cube = np.repeat(i_spec[:, None, None], NY, axis=1).repeat(NX, axis=2)
+    i_cube = (i_cube + rng.normal(0, 1e-3, i_cube.shape)).astype(np.float32)
+
+    wcs = WCS(naxis=3)
+    wcs.wcs.ctype = ["RA---SIN", "DEC--SIN", "FREQ"]
+    wcs.wcs.crval = [180.0, -30.0, freq_hz[0]]
+    wcs.wcs.crpix = [NX / 2, NY / 2, 1]
+    wcs.wcs.cdelt = [-1e-3, 1e-3, freq_hz[1] - freq_hz[0]]
+    wcs.wcs.cunit = ["deg", "deg", "Hz"]
+    header = wcs.to_header()
+
+    i_path = tmp_path / "stokesi.fits"
+    fits.writeto(i_path, i_cube, header, overwrite=True)
+    return i_path
+
+
 @pytest.fixture
 def qu_cubes(tmp_path: Path) -> tuple[Path, Path]:
     return _make_qu_cubes(tmp_path)
@@ -117,6 +139,58 @@ def test_rmsynth_dirty_only_skips_rmclean(
     assert len(output_paths) == 1
     assert output_paths[0].exists()
     assert not list(tmp_path.glob("*.mom*.fits"))
+
+
+def test_rmsynth_with_stokes_i_writes_fit_maps(
+    tmp_path: Path, qu_cubes: tuple[Path, Path]
+) -> None:
+    stokes_q_cube, stokes_u_cube = qu_cubes
+    stokes_i_cube = _make_i_cube(tmp_path)
+    output_prefix = tmp_path / "test_field"
+
+    output_paths = rmsynth_and_write_products(
+        stokes_q_cube=stokes_q_cube,
+        stokes_u_cube=stokes_u_cube,
+        stokes_i_cube=stokes_i_cube,
+        rmsynth_options=RMSynthOptions(estimate_stokes_i_noise=True),
+        rmclean_options=RMCleanOptions(),
+        cube_products=[],
+        moment_products=["dirty"],
+        output_prefix=output_prefix,
+    )
+
+    for suffix in ("ref_flux", "alpha", "model_order"):
+        fit_map_path = Path(f"{output_prefix}.stokesi.{suffix}.fits")
+        assert fit_map_path in output_paths
+        assert fit_map_path.exists()
+        assert fits.getheader(fit_map_path)["NAXIS"] == 2
+
+    # alpha_error is only produced when rm-lite actually has a Stokes I noise
+    # estimate to propagate -- assert we never crash either way, and if it
+    # was produced, it's a valid written 2D map.
+    alpha_error_path = Path(f"{output_prefix}.stokesi.alpha_error.fits")
+    if alpha_error_path in output_paths:
+        assert alpha_error_path.exists()
+        assert fits.getheader(alpha_error_path)["NAXIS"] == 2
+
+
+def test_rmsynth_debias_moments_runs(tmp_path: Path, qu_cubes: tuple[Path, Path]) -> None:
+    stokes_q_cube, stokes_u_cube = qu_cubes
+    output_prefix = tmp_path / "test_field"
+
+    output_paths = rmsynth_and_write_products(
+        stokes_q_cube=stokes_q_cube,
+        stokes_u_cube=stokes_u_cube,
+        rmsynth_options=RMSynthOptions(debias_moments=True),
+        rmclean_options=RMCleanOptions(),
+        cube_products=[],
+        moment_products=["clean"],
+        output_prefix=output_prefix,
+    )
+
+    mom0_path = Path(f"{output_prefix}.fdf.clean.mom0.fits")
+    assert mom0_path in output_paths
+    assert mom0_path.exists()
 
 
 def test_rmsynth_no_products_is_noop(tmp_path: Path, qu_cubes: tuple[Path, Path]) -> None:

--- a/tests/test_rmsynth.py
+++ b/tests/test_rmsynth.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
+from unittest.mock import patch
 
 import numpy as np
 import pytest
@@ -12,9 +13,18 @@ from astropy.wcs import WCS
 from pydantic import ValidationError
 
 from flint.exceptions import NotSupportedError
-from flint.options import RMCleanOptions, RMSynthOptions
+from flint.options import (
+    CubesForRMSynth,
+    ErrorCubesForRMSynth,
+    NoiseCubesForRMSynth,
+    RMCleanOptions,
+    RMSynthFieldOptions,
+    RMSynthOptions,
+    WeightCubesForRMSynth,
+)
 from flint.rmsynth import (
     FDFLabel,
+    RMSynth3DResults,
     _snr_threshold,
     needs_rmclean,
     run_rmclean_3d,
@@ -118,6 +128,46 @@ def qu_cubes(tmp_path: Path) -> tuple[Path, Path]:
     return _make_qu_cubes(tmp_path)
 
 
+def _run_rmsynth_3d(
+    stokes_q_cube: Path,
+    stokes_u_cube: Path,
+    rmsynth_options: RMSynthOptions,
+    stokes_i_cube: Path | None = None,
+    stokes_q_weight_cube: Path | None = None,
+    stokes_u_weight_cube: Path | None = None,
+    stokes_i_weight_cube: Path | None = None,
+    stokes_q_noise_cube: Path | None = None,
+    stokes_u_noise_cube: Path | None = None,
+    stokes_i_noise_cube: Path | None = None,
+) -> RMSynth3DResults:
+    """``run_rmsynth_3d`` from a flat set of paths.
+
+    These tests are about what rm-synthesis does, not how its arguments are
+    grouped, so the containers are built here rather than at ninety call sites.
+    ``ErrorCubesForRMSynth`` itself is covered by its own tests below.
+    """
+    error_cubes: ErrorCubesForRMSynth | None = None
+    if stokes_q_noise_cube is not None:
+        error_cubes = NoiseCubesForRMSynth(
+            q_path=stokes_q_noise_cube,
+            u_path=stokes_u_noise_cube,
+            i_path=stokes_i_noise_cube,
+        )
+    elif stokes_q_weight_cube is not None:
+        error_cubes = WeightCubesForRMSynth(
+            q_path=stokes_q_weight_cube,
+            u_path=stokes_u_weight_cube,
+            i_path=stokes_i_weight_cube,
+        )
+    return run_rmsynth_3d(
+        stokes_cubes=CubesForRMSynth(
+            q_path=stokes_q_cube, u_path=stokes_u_cube, i_path=stokes_i_cube
+        ),
+        rmsynth_options=rmsynth_options,
+        error_cubes=error_cubes,
+    )
+
+
 def _synth_and_write(
     stokes_q_cube: Path,
     stokes_u_cube: Path,
@@ -131,11 +181,13 @@ def _synth_and_write(
     stokes_q_weight_cube: Path | None = None,
     stokes_u_weight_cube: Path | None = None,
     peak_products: list[FDFLabel] = [],
+    moment_threshold_snr: float = 5.0,
+    peak_threshold_snr: float = 0.0,
 ) -> list[Path]:
     if not cube_products and not moment_products and not peak_products:
         return []
 
-    synth_results = run_rmsynth_3d(
+    synth_results = _run_rmsynth_3d(
         stokes_q_cube=stokes_q_cube,
         stokes_u_cube=stokes_u_cube,
         rmsynth_options=rmsynth_options,
@@ -163,6 +215,8 @@ def _synth_and_write(
         moment_products=moment_products,
         peak_products=peak_products,
         output_prefix=output_prefix,
+        moment_threshold_snr=moment_threshold_snr,
+        peak_threshold_snr=peak_threshold_snr,
     )
 
 
@@ -365,7 +419,7 @@ def test_unnamed_stokes_i_model_terms_are_skipped_with_a_warning(
     """
     stokes_q_cube, stokes_u_cube = qu_cubes
     rmsynth_options = RMSynthOptions()
-    synth_results = run_rmsynth_3d(
+    synth_results = _run_rmsynth_3d(
         stokes_q_cube=stokes_q_cube,
         stokes_u_cube=stokes_u_cube,
         rmsynth_options=rmsynth_options,
@@ -410,7 +464,7 @@ def test_stokes_i_model_rebuilds_from_the_written_term_maps(
     output_prefix = tmp_path / "test_field"
     rmsynth_options = RMSynthOptions(fit_order=-3)
 
-    synth_results = run_rmsynth_3d(
+    synth_results = _run_rmsynth_3d(
         stokes_q_cube=stokes_q_cube,
         stokes_u_cube=stokes_u_cube,
         rmsynth_options=rmsynth_options,
@@ -577,7 +631,7 @@ def test_rmsynth_rejects_compressed_cubes(tmp_path: Path) -> None:
     """A gzipped cube cannot be memmapped, so rm-lite's per-block reopens would
     each inflate the whole cube into memory."""
     with pytest.raises(NotSupportedError):
-        run_rmsynth_3d(
+        _run_rmsynth_3d(
             stokes_q_cube=tmp_path / "q.fits.gz",
             stokes_u_cube=tmp_path / "u.fits.gz",
             rmsynth_options=RMSynthOptions(),
@@ -588,13 +642,32 @@ def test_rmsynth_rejects_a_compressed_weight_cube(tmp_path: Path) -> None:
     """The weight cubes are read block-by-block just like the Stokes cubes, so a
     gzipped one inflates the whole cube per read in exactly the same way."""
     stokes_q_cube, stokes_u_cube = _make_qu_cubes(tmp_path)
+    uncompressed = _make_weight_cube(
+        tmp_path,
+        (N_CHAN, NY, NX),
+        np.linspace(700e6, 1300e6, N_CHAN),
+        1e-3,
+        "plain",
+    )
+    # One compressed cube at a time, the rest readable, so the check is on the
+    # gzipped one rather than on a half-filled set
     for weights in (
-        {"stokes_q_weight_cube": tmp_path / "q.weight.fits.gz"},
-        {"stokes_u_weight_cube": tmp_path / "u.weight.fits.gz"},
-        {"stokes_i_weight_cube": tmp_path / "i.weight.fits.gz"},
+        {
+            "stokes_q_weight_cube": tmp_path / "q.weight.fits.gz",
+            "stokes_u_weight_cube": uncompressed,
+        },
+        {
+            "stokes_q_weight_cube": uncompressed,
+            "stokes_u_weight_cube": tmp_path / "u.weight.fits.gz",
+        },
+        {
+            "stokes_q_weight_cube": uncompressed,
+            "stokes_u_weight_cube": uncompressed,
+            "stokes_i_weight_cube": tmp_path / "i.weight.fits.gz",
+        },
     ):
         with pytest.raises(NotSupportedError):
-            run_rmsynth_3d(
+            _run_rmsynth_3d(
                 stokes_q_cube=stokes_q_cube,
                 stokes_u_cube=stokes_u_cube,
                 stokes_i_cube=_make_i_cube(tmp_path),
@@ -652,7 +725,7 @@ def test_rmsynth_options_reach_rm_lite(
     stokes_q_cube, stokes_u_cube = qu_cubes
     rmsynth_options = RMSynthOptions(per_pixel_rmsf=True, estimate_stokes_i_noise=False)
     with pytest.raises(NotSupportedError, match="stop before synthesising"):
-        run_rmsynth_3d(
+        _run_rmsynth_3d(
             stokes_q_cube=stokes_q_cube,
             stokes_u_cube=stokes_u_cube,
             stokes_i_cube=_make_i_cube(tmp_path),
@@ -717,24 +790,20 @@ def _make_linmos_weight_cube(
     return path
 
 
-def test_one_linmos_weight_cube_is_refused(
-    tmp_path: Path, qu_cubes: tuple[Path, Path]
-) -> None:
+def test_one_linmos_weight_cube_is_refused(tmp_path: Path) -> None:
     """rm-lite builds the weights from Q and U together, so a lone cube is a
-    wiring mistake it refuses rather than half-applies. Pinned here because the
-    racs-all flow passes the pair positionally and a silent drop would look like
-    a linmos-weighted run that never was."""
-    stokes_q_cube, stokes_u_cube = qu_cubes
+    wiring mistake rather than something to half-apply. The container now
+    refuses it at construction, before any cube is opened, so a half-filled set
+    cannot reach rm-lite at all."""
+    weights = _make_linmos_weight_cube(tmp_path, "q", blank_outside=1.5)
 
-    with pytest.raises(ValueError, match="[Mm]ust pass both"):
-        run_rmsynth_3d(
-            stokes_q_cube=stokes_q_cube,
-            stokes_u_cube=stokes_u_cube,
-            rmsynth_options=RMSynthOptions(),
-            stokes_q_weight_cube=_make_linmos_weight_cube(
-                tmp_path, "q", blank_outside=1.5
-            ),
-        )
+    # ValidationError from the constructor, a plain ValueError from
+    # from_mapping; the former subclasses the latter, so one assertion covers both
+    for kind in (WeightCubesForRMSynth, NoiseCubesForRMSynth):
+        with pytest.raises(ValueError):
+            kind(q_path=weights)
+        with pytest.raises(ValueError, match="missing"):
+            kind.from_mapping({"q": weights})
 
 
 def test_rmsynth_with_linmos_weights_stays_cleanable(
@@ -750,7 +819,7 @@ def test_rmsynth_with_linmos_weights_stays_cleanable(
     """
     stokes_q_cube, stokes_u_cube = qu_cubes
 
-    synth_results = run_rmsynth_3d(
+    synth_results = _run_rmsynth_3d(
         stokes_q_cube=stokes_q_cube,
         stokes_u_cube=stokes_u_cube,
         rmsynth_options=RMSynthOptions(),
@@ -793,7 +862,7 @@ def test_linmos_weights_give_each_pixel_its_own_rmsf(
     primary beam does -- and the linmos cubes are exactly that case."""
     stokes_q_cube, stokes_u_cube = qu_cubes
 
-    synth_results = run_rmsynth_3d(
+    synth_results = _run_rmsynth_3d(
         stokes_q_cube=stokes_q_cube,
         stokes_u_cube=stokes_u_cube,
         rmsynth_options=RMSynthOptions(),
@@ -828,7 +897,7 @@ def test_channels_linmos_blanked_everywhere_drop_out(
     stokes_q_cube, stokes_u_cube = qu_cubes
     blanked_channels = (0, 5, N_CHAN - 1)
 
-    synth_results = run_rmsynth_3d(
+    synth_results = _run_rmsynth_3d(
         stokes_q_cube=stokes_q_cube,
         stokes_u_cube=stokes_u_cube,
         rmsynth_options=RMSynthOptions(),
@@ -979,17 +1048,23 @@ def test_the_peak_and_moment_snr_cuts_are_independent(
     """
     stokes_q_cube, stokes_u_cube = qu_cubes
 
-    def peak_pi_and_mom0(prefix: str, **snrs: float) -> tuple[np.ndarray, np.ndarray]:
+    def peak_pi_and_mom0(
+        prefix: str,
+        moment_threshold_snr: float = 5.0,
+        peak_threshold_snr: float = 0.0,
+    ) -> tuple[np.ndarray, np.ndarray]:
         output_prefix = tmp_path / prefix
         _synth_and_write(
             stokes_q_cube=stokes_q_cube,
             stokes_u_cube=stokes_u_cube,
             rmsynth_options=RMSynthOptions(),
-            rmclean_options=RMCleanOptions(**snrs),
+            rmclean_options=RMCleanOptions(),
             cube_products=[],
             moment_products=["dirty"],
             peak_products=["dirty"],
             output_prefix=output_prefix,
+            moment_threshold_snr=moment_threshold_snr,
+            peak_threshold_snr=peak_threshold_snr,
         )
         return (
             fits.getdata(Path(f"{output_prefix}.fdf.dirty.peak_pi.fits")),
@@ -1014,7 +1089,7 @@ def test_no_peak_cut_by_default_even_where_a_pixel_has_no_weight(
     applied as ``0 * noise``: the theoretical noise is inf for a pixel linmos
     blanked, ``0 * inf`` is NaN, and every comparison against NaN is False -- so
     the cut meant to pass everything would instead blank the whole map."""
-    assert RMCleanOptions().peak_threshold_snr == 0.0
+    assert RMSynthFieldOptions().peak_threshold_snr == 0.0
     assert _snr_threshold(0.0, np.float64(np.inf)) is None
     assert _snr_threshold(0.0, np.array([1e-5, np.inf])) is None
     assert _snr_threshold(5.0, np.float64(2.0)) == 10.0
@@ -1218,7 +1293,7 @@ def test_rmclean_runs_once_per_chunk_whatever_is_requested(
         lambda *a, **k: real_compute(*a, **{**k, "scheduler": "threads"}),
     )
 
-    synth_results = run_rmsynth_3d(
+    synth_results = _run_rmsynth_3d(
         stokes_q_cube=stokes_q_cube,
         stokes_u_cube=stokes_u_cube,
         rmsynth_options=RMSynthOptions(),
@@ -1299,7 +1374,7 @@ def test_rmclean_runs_once_per_chunk_on_a_distributed_client(
     )
     try:
         with Client(cluster) as client:
-            synth_results = run_rmsynth_3d(
+            synth_results = _run_rmsynth_3d(
                 stokes_q_cube=stokes_q_cube,
                 stokes_u_cube=stokes_u_cube,
                 rmsynth_options=RMSynthOptions(),
@@ -1454,7 +1529,7 @@ def test_stokes_i_fit_does_not_multiply_with_requested_products(
     stokes_i_weight_cube = _make_i_weight_cube(tmp_path)
 
     # Built once, and never computed, only to read the chunking off it
-    n_chunks = run_rmsynth_3d(
+    n_chunks = _run_rmsynth_3d(
         stokes_q_cube=stokes_q_cube,
         stokes_u_cube=stokes_u_cube,
         rmsynth_options=RMSynthOptions(),
@@ -1490,3 +1565,66 @@ def test_stokes_i_fit_does_not_multiply_with_requested_products(
     assert len(set(counts.values())) == 1, (
         f"the Stokes I fit count moves with the requested products: {counts}"
     )
+
+
+def test_error_cubes_cannot_be_a_weight_and_a_noise_at_once() -> None:
+    """A weight cube is 1/sigma**2 and a noise cube is sigma. rm-lite takes
+    either through one argument and is told which by a flag, so confusing them
+    inverts the noise. One argument of a tagged type makes "both" unsayable and
+    "neither, but something cube-shaped" a validation error rather than a silent
+    guess at which was meant.
+    """
+    paths = {"q_path": Path("q.fits"), "u_path": Path("u.fits")}
+
+    assert WeightCubesForRMSynth(**paths).kind == "weight"
+    assert NoiseCubesForRMSynth(**paths).kind == "noise"
+
+    # The tag is what survives the serialisation prefect does to task inputs.
+    # Without it pydantic rebuilds a union by first match, and a noise cube
+    # coming back as a weight would invert the noise by 1/sigma**2.
+    options = RMSynthFieldOptions(
+        stokes_cubes=CubesForRMSynth(**paths), error_cubes=NoiseCubesForRMSynth(**paths)
+    )
+    rebuilt = RMSynthFieldOptions.model_validate(options.model_dump())
+    assert isinstance(rebuilt.error_cubes, NoiseCubesForRMSynth)
+    assert isinstance(
+        RMSynthFieldOptions.model_validate(
+            RMSynthFieldOptions(error_cubes=WeightCubesForRMSynth(**paths)).model_dump()
+        ).error_cubes,
+        WeightCubesForRMSynth,
+    )
+
+    # An untagged trio says nothing about which it is, so it is refused
+    with pytest.raises(ValidationError):
+        RMSynthFieldOptions(error_cubes=CubesForRMSynth(**paths))
+
+
+def test_a_weight_cube_is_not_inverted_but_a_noise_cube_is(
+    tmp_path: Path, qu_cubes: tuple[Path, Path]
+) -> None:
+    """The one thing the tag decides once it reaches rm-lite."""
+    stokes_q_cube, stokes_u_cube = qu_cubes
+    sigma = 1e-3
+    freq_hz = np.linspace(700e6, 1300e6, N_CHAN)
+
+    captured: dict[str, object] = {}
+
+    def _capture(**kwargs: object) -> None:
+        captured.update(kwargs)
+        raise RuntimeError("stop here")
+
+    weights = _make_weight_cube(tmp_path, (N_CHAN, NY, NX), freq_hz, sigma, "as_weight")
+    for error_cubes, expected in (
+        (WeightCubesForRMSynth(q_path=weights, u_path=weights), True),
+        (NoiseCubesForRMSynth(q_path=weights, u_path=weights), False),
+    ):
+        with patch("flint.rmsynth.rmsynth_3d_from_fits", side_effect=_capture):
+            with pytest.raises(RuntimeError, match="stop here"):
+                run_rmsynth_3d(
+                    stokes_cubes=CubesForRMSynth(
+                        q_path=stokes_q_cube, u_path=stokes_u_cube
+                    ),
+                    rmsynth_options=RMSynthOptions(),
+                    error_cubes=error_cubes,
+                )
+        assert captured["noise_files_are_weight"] is expected, error_cubes

--- a/tests/test_rmsynth.py
+++ b/tests/test_rmsynth.py
@@ -1,0 +1,138 @@
+"""Plumbing tests for RM-synthesis via rm-lite. rm-lite's own synthesis
+correctness is its responsibility, not flint-pol's -- these tests only check
+that FITS in -> WCS/product-selection -> FITS out behaves as expected.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+from astropy.io import fits
+from astropy.wcs import WCS
+
+from flint.options import RMCleanOptions, RMSynthOptions
+from flint.rmsynth import rmsynth_and_write_products
+
+N_CHAN = 20
+NY = 5
+NX = 5
+PHI_TRUE_RADM2 = 50.0
+POL_FRACTION = 0.2
+
+
+def _make_qu_cubes(tmp_path: Path) -> tuple[Path, Path]:
+    """Write synthetic Stokes Q/U FITS cubes with a known Faraday depth."""
+    freq_hz = np.linspace(700e6, 1300e6, N_CHAN)
+    lambda_sq_m2 = (299792458.0 / freq_hz) ** 2
+
+    rng = np.random.default_rng(0)
+    angle = 2 * PHI_TRUE_RADM2 * lambda_sq_m2
+    q_spec = POL_FRACTION * np.cos(angle)
+    u_spec = POL_FRACTION * np.sin(angle)
+
+    noise_sigma = 1e-3
+    q_cube = np.repeat(q_spec[:, None, None], NY, axis=1).repeat(NX, axis=2)
+    u_cube = np.repeat(u_spec[:, None, None], NY, axis=1).repeat(NX, axis=2)
+    q_cube = (q_cube + rng.normal(0, noise_sigma, q_cube.shape)).astype(np.float32)
+    u_cube = (u_cube + rng.normal(0, noise_sigma, u_cube.shape)).astype(np.float32)
+
+    wcs = WCS(naxis=3)
+    wcs.wcs.ctype = ["RA---SIN", "DEC--SIN", "FREQ"]
+    wcs.wcs.crval = [180.0, -30.0, freq_hz[0]]
+    wcs.wcs.crpix = [NX / 2, NY / 2, 1]
+    wcs.wcs.cdelt = [-1e-3, 1e-3, freq_hz[1] - freq_hz[0]]
+    wcs.wcs.cunit = ["deg", "deg", "Hz"]
+    header = wcs.to_header()
+
+    q_path = tmp_path / "stokesq.fits"
+    u_path = tmp_path / "stokesu.fits"
+    fits.writeto(q_path, q_cube, header, overwrite=True)
+    fits.writeto(u_path, u_cube, header, overwrite=True)
+    return q_path, u_path
+
+
+@pytest.fixture
+def qu_cubes(tmp_path: Path) -> tuple[Path, Path]:
+    return _make_qu_cubes(tmp_path)
+
+
+def test_rmsynth_all_products(tmp_path: Path, qu_cubes: tuple[Path, Path]) -> None:
+    stokes_q_cube, stokes_u_cube = qu_cubes
+    output_prefix = tmp_path / "test_field"
+
+    output_paths = rmsynth_and_write_products(
+        stokes_q_cube=stokes_q_cube,
+        stokes_u_cube=stokes_u_cube,
+        rmsynth_options=RMSynthOptions(),
+        rmclean_options=RMCleanOptions(),
+        cube_products=["dirty", "clean", "model"],
+        moment_products=["dirty", "clean", "model"],
+        output_prefix=output_prefix,
+    )
+
+    assert len(output_paths) == 3 + 3 * 3
+    for path in output_paths:
+        assert path.exists()
+
+    for label in ("dirty", "clean", "model"):
+        cube_path = Path(f"{output_prefix}.fdf.{label}.cube.fits")
+        assert cube_path.exists()
+        header = fits.getheader(cube_path)
+        assert header["CTYPE3"] == "FDEPTH"
+
+        for moment in ("mom0", "mom1", "mom2"):
+            moment_path = Path(f"{output_prefix}.fdf.{label}.{moment}.fits")
+            assert moment_path.exists()
+            moment_header = fits.getheader(moment_path)
+            assert moment_header["NAXIS"] == 2
+
+    clean_mom1 = fits.getdata(Path(f"{output_prefix}.fdf.clean.mom1.fits"))
+    assert np.allclose(clean_mom1, PHI_TRUE_RADM2, atol=5.0)
+
+
+def test_rmsynth_dirty_only_skips_rmclean(
+    tmp_path: Path, qu_cubes: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    stokes_q_cube, stokes_u_cube = qu_cubes
+    output_prefix = tmp_path / "test_field"
+
+    calls = []
+    monkeypatch.setattr(
+        "flint.rmsynth.run_rmclean_3d", lambda *args, **kwargs: calls.append(1)
+    )
+
+    output_paths = rmsynth_and_write_products(
+        stokes_q_cube=stokes_q_cube,
+        stokes_u_cube=stokes_u_cube,
+        rmsynth_options=RMSynthOptions(),
+        rmclean_options=RMCleanOptions(),
+        cube_products=["dirty"],
+        moment_products=[],
+        output_prefix=output_prefix,
+    )
+
+    assert calls == []
+    assert len(output_paths) == 1
+    assert output_paths[0].exists()
+    assert not list(tmp_path.glob("*.mom*.fits"))
+
+
+def test_rmsynth_no_products_is_noop(tmp_path: Path, qu_cubes: tuple[Path, Path]) -> None:
+    stokes_q_cube, stokes_u_cube = qu_cubes
+
+    output_paths = rmsynth_and_write_products(
+        stokes_q_cube=stokes_q_cube,
+        stokes_u_cube=stokes_u_cube,
+        rmsynth_options=RMSynthOptions(),
+        rmclean_options=RMCleanOptions(),
+        cube_products=[],
+        moment_products=[],
+        output_prefix=tmp_path / "test_field",
+    )
+
+    assert output_paths == []
+    assert not list(tmp_path.glob("*.fits")) or all(
+        p in (stokes_q_cube, stokes_u_cube) for p in tmp_path.glob("*.fits")
+    )

--- a/tests/test_rmsynth.py
+++ b/tests/test_rmsynth.py
@@ -15,6 +15,7 @@ from flint.exceptions import NotSupportedError
 from flint.options import RMCleanOptions, RMSynthOptions
 from flint.rmsynth import (
     FDFLabel,
+    _snr_threshold,
     needs_rmclean,
     run_rmclean_3d,
     run_rmsynth_3d,
@@ -966,6 +967,81 @@ def test_every_fdf_can_have_cubes_moments_and_peaks(
     for label in labels:
         peak_rm = fits.getdata(Path(f"{output_prefix}.fdf.{label}.peak_rm.fits"))
         assert np.nanmedian(peak_rm) == pytest.approx(PHI_TRUE_RADM2, abs=5.0), label
+
+
+def test_the_peak_and_moment_snr_cuts_are_independent(
+    tmp_path: Path, qu_cubes: tuple[Path, Path]
+) -> None:
+    """One cut used to serve both, so a noise estimate that blanked the moments
+    took the peaks with it and the pair looked like a broken FDF rather than an
+    over-aggressive cut. They are separate options now, and each has to bite on
+    its own products only.
+    """
+    stokes_q_cube, stokes_u_cube = qu_cubes
+
+    def peak_pi_and_mom0(prefix: str, **snrs: float) -> tuple[np.ndarray, np.ndarray]:
+        output_prefix = tmp_path / prefix
+        _synth_and_write(
+            stokes_q_cube=stokes_q_cube,
+            stokes_u_cube=stokes_u_cube,
+            rmsynth_options=RMSynthOptions(),
+            rmclean_options=RMCleanOptions(**snrs),
+            cube_products=[],
+            moment_products=["dirty"],
+            peak_products=["dirty"],
+            output_prefix=output_prefix,
+        )
+        return (
+            fits.getdata(Path(f"{output_prefix}.fdf.dirty.peak_pi.fits")),
+            fits.getdata(Path(f"{output_prefix}.fdf.dirty.mom0.fits")),
+        )
+
+    # A cut nothing can clear on one side leaves the other untouched. mom0 is
+    # nansum, so a fully cut spectrum reads 0 rather than NaN; a cut peak is NaN
+    peak_pi, mom0 = peak_pi_and_mom0("moments_cut", moment_threshold_snr=1e6)
+    assert np.all(np.isfinite(peak_pi)), "the moment cut must not reach the peaks"
+    assert np.all(mom0 == 0.0)
+
+    peak_pi, mom0 = peak_pi_and_mom0("peaks_cut", peak_threshold_snr=1e6)
+    assert np.all(np.isnan(peak_pi))
+    assert np.all(mom0 > 0.0), "the peak cut must not reach the moments"
+
+
+def test_no_peak_cut_by_default_even_where_a_pixel_has_no_weight(
+    tmp_path: Path, qu_cubes: tuple[Path, Path]
+) -> None:
+    """``peak_threshold_snr`` defaults to 0, meaning no cut at all. It cannot be
+    applied as ``0 * noise``: the theoretical noise is inf for a pixel linmos
+    blanked, ``0 * inf`` is NaN, and every comparison against NaN is False -- so
+    the cut meant to pass everything would instead blank the whole map."""
+    assert RMCleanOptions().peak_threshold_snr == 0.0
+    assert _snr_threshold(0.0, np.float64(np.inf)) is None
+    assert _snr_threshold(0.0, np.array([1e-5, np.inf])) is None
+    assert _snr_threshold(5.0, np.float64(2.0)) == 10.0
+
+    stokes_q_cube, stokes_u_cube = qu_cubes
+    output_prefix = tmp_path / "default_cut"
+    _synth_and_write(
+        stokes_q_cube=stokes_q_cube,
+        stokes_u_cube=stokes_u_cube,
+        rmsynth_options=RMSynthOptions(),
+        rmclean_options=RMCleanOptions(),
+        cube_products=[],
+        moment_products=[],
+        peak_products=["dirty"],
+        output_prefix=output_prefix,
+        stokes_q_weight_cube=_make_linmos_weight_cube(tmp_path, "q", blank_outside=1.5),
+        stokes_u_weight_cube=_make_linmos_weight_cube(tmp_path, "u", blank_outside=1.5),
+    )
+
+    peak_pi = fits.getdata(Path(f"{output_prefix}.fdf.dirty.peak_pi.fits"))
+    inside_cutoff = _within_cutoff(1.5)
+    assert np.all(np.isfinite(peak_pi[inside_cutoff])), (
+        "no cut was asked for, so every pixel carrying weight keeps its peak"
+    )
+    assert np.all(np.isnan(peak_pi[~inside_cutoff])), (
+        "a pixel linmos blanked has no FDF to peak, cut or no cut"
+    )
 
 
 def test_dirty_peaks_alone_do_not_run_rmclean(

--- a/tests/test_rmsynth.py
+++ b/tests/test_rmsynth.py
@@ -197,7 +197,7 @@ def test_rmsynth_with_stokes_i_writes_fit_maps(
         stokes_q_cube=stokes_q_cube,
         stokes_u_cube=stokes_u_cube,
         stokes_i_cube=stokes_i_cube,
-        rmsynth_options=RMSynthOptions(estimate_stokes_i_noise=True),
+        rmsynth_options=RMSynthOptions(),
         rmclean_options=RMCleanOptions(),
         cube_products=[],
         moment_products=["dirty"],
@@ -245,9 +245,7 @@ def test_rmsynth_writes_a_named_map_per_stokes_i_model_term(
         stokes_q_cube=stokes_q_cube,
         stokes_u_cube=stokes_u_cube,
         stokes_i_cube=stokes_i_cube,
-        rmsynth_options=RMSynthOptions(
-            estimate_stokes_i_noise=True, fit_function=fit_function
-        ),
+        rmsynth_options=RMSynthOptions(fit_function=fit_function),
         rmclean_options=RMCleanOptions(),
         cube_products=[],
         moment_products=["dirty"],
@@ -322,7 +320,7 @@ def test_unnamed_stokes_i_model_terms_are_skipped_with_a_warning(
     are not worth losing the rest of the products over either.
     """
     stokes_q_cube, stokes_u_cube = qu_cubes
-    rmsynth_options = RMSynthOptions(estimate_stokes_i_noise=True)
+    rmsynth_options = RMSynthOptions()
     synth_results = run_rmsynth_3d(
         stokes_q_cube=stokes_q_cube,
         stokes_u_cube=stokes_u_cube,
@@ -364,7 +362,7 @@ def test_stokes_i_model_rebuilds_from_the_written_term_maps(
     stokes_q_cube, stokes_u_cube = qu_cubes
     stokes_i_cube = _make_i_cube(tmp_path)
     output_prefix = tmp_path / "test_field"
-    rmsynth_options = RMSynthOptions(estimate_stokes_i_noise=True, fit_order=-3)
+    rmsynth_options = RMSynthOptions(fit_order=-3)
 
     synth_results = run_rmsynth_3d(
         stokes_q_cube=stokes_q_cube,
@@ -660,9 +658,7 @@ def test_stokes_i_fit_on_noise_stays_finite(tmp_path: Path) -> None:
         stokes_q_cube=q_cube,
         stokes_u_cube=u_cube,
         stokes_i_cube=i_cube,
-        rmsynth_options=RMSynthOptions(
-            estimate_stokes_i_noise=True, stokes_i_snr_cut=5.0
-        ),
+        rmsynth_options=RMSynthOptions(stokes_i_snr_cut=5.0),
         rmclean_options=RMCleanOptions(),
         cube_products=[],
         moment_products=["dirty", "clean"],

--- a/tests/test_rmsynth.py
+++ b/tests/test_rmsynth.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
 import numpy as np
@@ -1056,6 +1057,170 @@ def test_rmclean_runs_once_per_chunk_whatever_is_requested(
         f"RM-CLEAN ran {len(calls) / n_chunks:.0f}x per chunk for "
         f"cubes={cube_products}, moments={moment_products}"
     )
+
+
+def _rmclean_call_counter(tally_path: Path):
+    """A ``_rmclean_on_block`` wrapper that tallies calls through a file.
+
+    A closure counting into a list cannot work here: `distributed` serialises
+    the task graph even when its workers are threads in this process, so the
+    worker gets a copy of the list and the appends never come back. A file is
+    the counter that survives that round trip.
+    """
+    import rm_lite.tools_3d.rmclean as rmclean_mod
+
+    original = rmclean_mod._rmclean_on_block
+
+    def counting(*args: object, **kwargs: object) -> object:
+        with open(tally_path, "a") as handle:
+            handle.write("x")
+        return original(*args, **kwargs)
+
+    return counting
+
+
+def test_rmclean_runs_once_per_chunk_on_a_distributed_client(
+    tmp_path: Path, qu_cubes: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The same once-per-chunk guarantee as the threaded test, on the path a real
+    pipeline run takes.
+
+    ``_compute_rm_products`` submits to a distributed Client as futures so it can
+    report each product as it lands. Submitting them one at a time instead would
+    rebuild the shared synthesis/RM-CLEAN graph per product -- invisible in the
+    output, just N times the runtime of the slowest stage. The threaded test
+    cannot see this path at all, since it forces the local scheduler.
+    """
+    import rm_lite.tools_3d.rmclean as rmclean_mod
+    from distributed import Client, LocalCluster
+
+    stokes_q_cube, stokes_u_cube = qu_cubes
+    tally = tmp_path / "rmclean_calls"
+    tally.write_text("")
+    monkeypatch.setattr(rmclean_mod, "_rmclean_on_block", _rmclean_call_counter(tally))
+
+    # processes=False keeps the workers in this process, so the monkeypatch is
+    # in place for them -- the graph is still serialised, hence the file tally
+    cluster = LocalCluster(
+        n_workers=2,
+        threads_per_worker=1,
+        processes=False,
+        dashboard_address=None,
+        silence_logs=logging.ERROR,
+    )
+    try:
+        with Client(cluster) as client:
+            synth_results = run_rmsynth_3d(
+                stokes_q_cube=stokes_q_cube,
+                stokes_u_cube=stokes_u_cube,
+                rmsynth_options=RMSynthOptions(),
+            )
+            clean_results = run_rmclean_3d(
+                rm_synth_results=synth_results, rmclean_options=RMCleanOptions()
+            )
+            n_chunks = int(
+                np.prod([len(chunk) for chunk in synth_results.fdf_dirty_cube.chunks])
+            )
+            # Three FDFs' worth of moments off one shared graph
+            write_rm_products(
+                synth_results=synth_results,
+                clean_results=clean_results,
+                stokes_q_cube=stokes_q_cube,
+                rmsynth_options=RMSynthOptions(),
+                rmclean_options=RMCleanOptions(),
+                cube_products=[],
+                moment_products=["clean", "dirty", "model"],
+                output_prefix=tmp_path / "field",
+                dask_client=client,
+            )
+    finally:
+        cluster.close()
+
+    assert len(tally.read_text()) == n_chunks, (
+        "nine moment maps off three FDFs must still clean each chunk once"
+    )
+
+
+def test_computing_from_inside_a_worker_does_not_deadlock() -> None:
+    """The products are computed from a prefect task, which under
+    ``DaskTaskRunner`` runs on a worker.
+
+    ``prefect_dask.get_dask_client`` hands back a plain ``Client``, not a
+    ``worker_client``, so nothing secedes on our behalf. Waiting on futures from
+    a worker thread while the tasks being waited on need worker threads is a
+    deadlock, and with one thread per worker it is a certainty rather than a
+    race. ``dask.compute(scheduler=client)`` never showed it, because
+    ``Client.get`` secedes for you.
+
+    One worker with one thread is the whole reproduction: the submitted call
+    holds that thread, so anything it waits on can never be scheduled.
+    """
+    import dask
+    from distributed import Client, LocalCluster, get_client
+
+    from flint.rmsynth import _compute_rm_products
+
+    def compute_on_the_worker() -> dict[str, object]:
+        return _compute_rm_products(
+            compute_targets={"only": dask.delayed(int)(7)},
+            fuse_config={},
+            scheduler=get_client(),
+            workload="1 product (test)",
+        )
+
+    cluster = LocalCluster(
+        n_workers=1,
+        threads_per_worker=1,
+        processes=False,
+        dashboard_address=None,
+        silence_logs=logging.ERROR,
+    )
+    try:
+        with Client(cluster) as client:
+            future = client.submit(compute_on_the_worker)
+            # Without seceding this never returns; the timeout is the assertion
+            assert future.result(timeout=90) == {"only": 7}
+    finally:
+        cluster.close()
+
+
+def test_a_failed_product_is_raised_not_dropped(tmp_path: Path) -> None:
+    """Draining futures as they complete must not swallow one that failed.
+
+    ``dask.compute`` raises the worker's exception directly; futures hand it back
+    only when asked, so a product that raised could otherwise go missing from the
+    results and be noticed as a KeyError somewhere further down instead.
+    """
+    import dask
+    from distributed import Client, LocalCluster
+
+    from flint.rmsynth import _compute_rm_products
+
+    def explode() -> None:
+        msg = "this product could not be computed"
+        raise ValueError(msg)
+
+    cluster = LocalCluster(
+        n_workers=1,
+        threads_per_worker=1,
+        processes=False,
+        dashboard_address=None,
+        silence_logs=logging.ERROR,
+    )
+    try:
+        with Client(cluster) as client:
+            with pytest.raises(ValueError, match="could not be computed"):
+                _compute_rm_products(
+                    compute_targets={
+                        "fine": dask.delayed(int)(1),
+                        "broken": dask.delayed(explode)(),
+                    },
+                    fuse_config={},
+                    scheduler=client,
+                    workload="2 products (test)",
+                )
+    finally:
+        cluster.close()
 
 
 def test_stokes_i_fit_does_not_multiply_with_requested_products(

--- a/tests/test_rmsynth.py
+++ b/tests/test_rmsynth.py
@@ -129,8 +129,9 @@ def _synth_and_write(
     stokes_i_weight_cube: Path | None = None,
     stokes_q_weight_cube: Path | None = None,
     stokes_u_weight_cube: Path | None = None,
+    peak_products: list[FDFLabel] | None = None,
 ) -> list[Path]:
-    if not cube_products and not moment_products:
+    if not cube_products and not moment_products and not peak_products:
         return []
 
     synth_results = run_rmsynth_3d(
@@ -144,7 +145,11 @@ def _synth_and_write(
     )
     clean_results = (
         run_rmclean_3d(rm_synth_results=synth_results, rmclean_options=rmclean_options)
-        if needs_rmclean(cube_products=cube_products, moment_products=moment_products)
+        if needs_rmclean(
+            cube_products=cube_products,
+            moment_products=moment_products,
+            peak_products=peak_products,
+        )
         else None
     )
     return write_rm_products(
@@ -155,6 +160,7 @@ def _synth_and_write(
         rmclean_options=rmclean_options,
         cube_products=cube_products,
         moment_products=moment_products,
+        peak_products=peak_products,
         output_prefix=output_prefix,
     )
 
@@ -173,8 +179,9 @@ def test_rmsynth_all_products(tmp_path: Path, qu_cubes: tuple[Path, Path]) -> No
         output_prefix=output_prefix,
     )
 
-    # One zarr store holding all three cubes, plus three moments per label
-    assert len(output_paths) == 1 + 3 * 3
+    # One zarr store holding all three cubes, three moments per label, and the
+    # CLEAN iteration count that every RM-CLEAN run writes
+    assert len(output_paths) == 1 + 3 * 3 + 1
     for path in output_paths:
         assert path.exists()
 
@@ -470,7 +477,8 @@ def test_rmsynth_debias_moments_runs(
     assert mom0_path.exists()
     assert debiased_mom0_path in output_paths
     assert debiased_mom0_path.exists()
-    assert len(output_paths) == 6
+    # Three moments, three debiased, plus the CLEAN iteration count
+    assert len(output_paths) == 6 + 1
 
 
 def test_rmsynth_writes_fdf_cubes_to_zarr(
@@ -537,7 +545,8 @@ def test_moment_only_never_computes_a_full_cube(
     # Every gathered array is a 2D map; a 3D shape means an FDF cube came back.
     assert all(len(shape) == 2 for shape in computed_shapes), computed_shapes
     # 3 labels x mom0/mom1/mom2, and nothing else.
-    assert len(computed_shapes) == 9
+    # Nine moment maps plus the CLEAN iteration count, all still (ny, nx)
+    assert len(computed_shapes) == 9 + 1
 
 
 def test_rmsynth_no_products_is_noop(
@@ -876,7 +885,7 @@ def test_linmos_weights_through_to_the_moment_maps(
     assert {path.name for path in output_paths} == {
         f"{output_prefix.name}.fdf.clean.{moment}.fits"
         for moment in ("mom0", "mom1", "mom2")
-    }
+    } | {f"{output_prefix.name}.fdf.clean.niter.fits"}
 
     mom1 = fits.getdata(Path(f"{output_prefix}.fdf.clean.mom1.fits"))
     inside_cutoff = _within_cutoff(1.5)
@@ -921,6 +930,107 @@ def _make_noise_only_cubes(
         paths[2],
         _make_weight_cube(tmp_path, shape, freq_hz, sigma=1e-3, name=f"{prefix}.i"),
     )
+
+
+def test_every_fdf_can_have_cubes_moments_and_peaks(
+    tmp_path: Path, qu_cubes: tuple[Path, Path]
+) -> None:
+    """The three product kinds are independent of the three FDFs, so all nine
+    combinations have to be reachable -- a peak map off the dirty FDF included,
+    which is the one that needs no RM-CLEAN at all."""
+    stokes_q_cube, stokes_u_cube = qu_cubes
+    labels: list[FDFLabel] = ["dirty", "clean", "model"]
+    output_prefix = tmp_path / "field"
+
+    output_paths = _synth_and_write(
+        stokes_q_cube=stokes_q_cube,
+        stokes_u_cube=stokes_u_cube,
+        rmsynth_options=RMSynthOptions(),
+        rmclean_options=RMCleanOptions(),
+        cube_products=labels,
+        moment_products=labels,
+        peak_products=labels,
+        output_prefix=output_prefix,
+    )
+    names = {path.name for path in output_paths}
+
+    # One zarr store holds every cube; moments and peaks are a file each
+    assert f"{output_prefix.name}.fdf.zarr" in names
+    for label in labels:
+        assert sum(f".{label}.mom" in name for name in names) == 3, label
+        assert sum(f".{label}.peak_" in name for name in names) == 9, label
+
+    # The peak Faraday depth is the recoverable truth in all three
+    for label in labels:
+        peak_rm = fits.getdata(Path(f"{output_prefix}.fdf.{label}.peak_rm.fits"))
+        assert np.nanmedian(peak_rm) == pytest.approx(PHI_TRUE_RADM2, abs=5.0), label
+
+
+def test_dirty_peaks_alone_do_not_run_rmclean(
+    tmp_path: Path, qu_cubes: tuple[Path, Path]
+) -> None:
+    """Peaks off the dirty FDF are measured from the synthesis output, so asking
+    for only those must not drag RM-CLEAN in -- it is the expensive half of the
+    stage. The iteration-count map is the tell: it only exists if CLEAN ran."""
+    assert (
+        needs_rmclean(cube_products=[], moment_products=[], peak_products=["dirty"])
+        is False
+    )
+    assert (
+        needs_rmclean(cube_products=[], moment_products=[], peak_products=["clean"])
+        is True
+    )
+    assert (
+        needs_rmclean(cube_products=[], moment_products=[], peak_products=["model"])
+        is True
+    )
+
+    stokes_q_cube, stokes_u_cube = qu_cubes
+    output_prefix = tmp_path / "field"
+    output_paths = _synth_and_write(
+        stokes_q_cube=stokes_q_cube,
+        stokes_u_cube=stokes_u_cube,
+        rmsynth_options=RMSynthOptions(),
+        rmclean_options=RMCleanOptions(),
+        cube_products=[],
+        moment_products=[],
+        peak_products=["dirty"],
+        output_prefix=output_prefix,
+    )
+
+    names = {path.name for path in output_paths}
+    assert len(names) == 9, names
+    assert not any("niter" in name for name in names), (
+        "the CLEAN iteration map means RM-CLEAN ran for dirty-only peaks"
+    )
+
+
+def test_rmclean_niter_map_is_always_written(
+    tmp_path: Path, qu_cubes: tuple[Path, Path]
+) -> None:
+    """Unconditional whenever RM-CLEAN runs, and not an option: it is the map
+    that says where CLEAN hit max_iter instead of converging, and that gets
+    asked after the run, when producing it on demand means repeating the stage."""
+    stokes_q_cube, stokes_u_cube = qu_cubes
+    output_prefix = tmp_path / "field"
+
+    output_paths = _synth_and_write(
+        stokes_q_cube=stokes_q_cube,
+        stokes_u_cube=stokes_u_cube,
+        rmsynth_options=RMSynthOptions(),
+        rmclean_options=RMCleanOptions(max_iter=20),
+        cube_products=[],
+        moment_products=["clean"],
+        output_prefix=output_prefix,
+    )
+
+    niter_path = Path(f"{output_prefix}.fdf.clean.niter.fits")
+    assert niter_path in output_paths
+    niter = fits.getdata(niter_path)
+    assert niter.shape == (NY, NX)
+    # Integer, and capped by max_iter rather than running away
+    assert np.issubdtype(niter.dtype, np.integer)
+    assert niter.max() <= 20
 
 
 def test_multiscale_rmclean_is_refused_rather_than_ignored(tmp_path: Path) -> None:

--- a/tests/test_rmsynth.py
+++ b/tests/test_rmsynth.py
@@ -81,6 +81,36 @@ def _make_i_cube(tmp_path: Path) -> Path:
     return i_path
 
 
+def _make_weight_cube(
+    tmp_path: Path,
+    shape: tuple[int, int, int],
+    freq_hz: np.ndarray,
+    sigma: float,
+    name: str,
+) -> Path:
+    """Write a constant per-channel weight cube (1/sigma**2) for use as a
+    ``*_weight_cube`` with ``noise_files_are_weight=True``."""
+    n_chan, ny, nx = shape
+    weight_cube = np.full(shape, 1.0 / sigma**2, dtype=np.float32)
+
+    wcs = WCS(naxis=3)
+    wcs.wcs.ctype = ["RA---SIN", "DEC--SIN", "FREQ"]
+    wcs.wcs.crval = [180.0, -30.0, freq_hz[0]]
+    wcs.wcs.crpix = [nx / 2, ny / 2, 1]
+    wcs.wcs.cdelt = [-1e-3, 1e-3, freq_hz[1] - freq_hz[0]]
+    wcs.wcs.cunit = ["deg", "deg", "Hz"]
+    header = wcs.to_header()
+
+    weight_path = tmp_path / f"{name}.weight.fits"
+    fits.writeto(weight_path, weight_cube, header, overwrite=True)
+    return weight_path
+
+
+def _make_i_weight_cube(tmp_path: Path, sigma: float = 1e-3) -> Path:
+    freq_hz = np.linspace(700e6, 1300e6, N_CHAN)
+    return _make_weight_cube(tmp_path, (N_CHAN, NY, NX), freq_hz, sigma, "stokesi")
+
+
 @pytest.fixture
 def qu_cubes(tmp_path: Path) -> tuple[Path, Path]:
     return _make_qu_cubes(tmp_path)
@@ -95,10 +125,8 @@ def _synth_and_write(
     moment_products: list[FDFLabel],
     output_prefix: Path,
     stokes_i_cube: Path | None = None,
+    stokes_i_weight_cube: Path | None = None,
 ) -> list[Path]:
-    """Mirror of the call sequence in ``flint.prefect.flows.rmsynth_pipeline``,
-    keeping these unit tests off prefect and dask. The flow itself is tested in
-    ``tests/test_prefect_rmsynth_flow.py``."""
     if not cube_products and not moment_products:
         return []
 
@@ -107,6 +135,7 @@ def _synth_and_write(
         stokes_u_cube=stokes_u_cube,
         rmsynth_options=rmsynth_options,
         stokes_i_cube=stokes_i_cube,
+        stokes_i_weight_cube=stokes_i_weight_cube,
     )
     clean_results = (
         run_rmclean_3d(rm_synth_results=synth_results, rmclean_options=rmclean_options)
@@ -202,6 +231,7 @@ def test_rmsynth_with_stokes_i_writes_fit_maps(
         cube_products=[],
         moment_products=["dirty"],
         output_prefix=output_prefix,
+        stokes_i_weight_cube=_make_i_weight_cube(tmp_path),
     )
 
     for suffix in ("ref_flux", "alpha", "model_order"):
@@ -250,6 +280,7 @@ def test_rmsynth_writes_a_named_map_per_stokes_i_model_term(
         cube_products=[],
         moment_products=["dirty"],
         output_prefix=output_prefix,
+        stokes_i_weight_cube=_make_i_weight_cube(tmp_path),
     )
 
     for index, name in enumerate(expected_names):
@@ -326,6 +357,7 @@ def test_unnamed_stokes_i_model_terms_are_skipped_with_a_warning(
         stokes_u_cube=stokes_u_cube,
         rmsynth_options=rmsynth_options,
         stokes_i_cube=_make_i_cube(tmp_path),
+        stokes_i_weight_cube=_make_i_weight_cube(tmp_path),
     )
     assert synth_results.stokes_i_coeff_names is not None
 
@@ -369,6 +401,7 @@ def test_stokes_i_model_rebuilds_from_the_written_term_maps(
         stokes_u_cube=stokes_u_cube,
         rmsynth_options=rmsynth_options,
         stokes_i_cube=stokes_i_cube,
+        stokes_i_weight_cube=_make_i_weight_cube(tmp_path),
     )
     write_rm_products(
         synth_results=synth_results,
@@ -536,7 +569,7 @@ def test_rmsynth_rejects_compressed_cubes(tmp_path: Path) -> None:
 
 def _make_noise_only_cubes(
     tmp_path: Path, prefix: str = "noise"
-) -> tuple[Path, Path, Path]:
+) -> tuple[Path, Path, Path, Path]:
     """Q/U/I cubes of pure noise, no source anywhere.
 
     The point of a noise-only cube is that everything the pipeline reports for
@@ -561,61 +594,12 @@ def _make_noise_only_cubes(
         path = tmp_path / f"{prefix}.{stokes}.fits"
         fits.writeto(path, cube, header, overwrite=True)
         paths.append(path)
-    return paths[0], paths[1], paths[2]
-
-
-def test_estimate_stokes_i_noise_defaults_on() -> None:
-    """The Stokes I SNR cut is inert without a noise to compare against, so the
-    estimate that gives it one has to be on by default -- see
-    ``_warn_if_snr_cut_inert``."""
-    options = RMSynthOptions()
-    assert options.estimate_stokes_i_noise is True
-    assert options.stokes_i_snr_cut is not None
-
-
-def test_snr_cut_without_a_noise_estimate_is_refused() -> None:
-    """The combination is broken, not merely slow, so it must not be
-    constructible: rm-lite scores every pixel as infinite SNR without a noise
-    estimate, so the cut passes all of them and a power law fitted to noise can
-    pass close enough to zero that Q/U divided by it is infinite."""
-    with pytest.raises(ValidationError, match="requires estimate_stokes_i_noise"):
-        RMSynthOptions(stokes_i_snr_cut=5.0, estimate_stokes_i_noise=False)
-
-    # ... including when reached through with_options rather than the constructor
-    with pytest.raises(ValidationError, match="requires estimate_stokes_i_noise"):
-        RMSynthOptions().with_options(estimate_stokes_i_noise=False)
-
-    # Turning the cut off deliberately is allowed, and so is the default pairing
-    assert (
-        RMSynthOptions(
-            stokes_i_snr_cut=None, estimate_stokes_i_noise=False
-        ).stokes_i_snr_cut
-        is None
+    return (
+        paths[0],
+        paths[1],
+        paths[2],
+        _make_weight_cube(tmp_path, shape, freq_hz, sigma=1e-3, name=f"{prefix}.i"),
     )
-    assert RMSynthOptions().estimate_stokes_i_noise is True
-
-
-def test_snr_cut_rule_is_enforced_from_a_strategy_file(tmp_path: Path) -> None:
-    """A strategy file is the likely way in, so it has to fail there too rather
-    than after imaging has already run."""
-    strategy_path = tmp_path / "strategy.yaml"
-    strategy_path.write_text(
-        "defaults:\n"
-        "  rmsynth:\n"
-        "    estimate_stokes_i_noise: false\n"
-        "version: 0.2\n"
-        "rmsynth:\n"
-        "  rmsynth:\n"
-        "    estimate_stokes_i_noise: false\n"
-    )
-    from flint.configuration import get_options_from_strategy, load_strategy_yaml
-
-    strategy = load_strategy_yaml(input_yaml=strategy_path, verify=False)
-    options = get_options_from_strategy(
-        strategy=strategy, operation="rmsynth", mode="rmsynth"
-    )
-    with pytest.raises(ValidationError, match="requires estimate_stokes_i_noise"):
-        RMSynthOptions(**options)
 
 
 def test_multiscale_rmclean_is_refused_rather_than_ignored(tmp_path: Path) -> None:
@@ -651,7 +635,7 @@ def test_stokes_i_fit_on_noise_stays_finite(tmp_path: Path) -> None:
     ~1e-10 mid-band; Q/U divided by that is an infinite FDF and an infinite
     mom0. The cut is what stops those pixels being fitted at all.
     """
-    q_cube, u_cube, i_cube = _make_noise_only_cubes(tmp_path)
+    q_cube, u_cube, i_cube, i_weight_cube = _make_noise_only_cubes(tmp_path)
     output_prefix = tmp_path / "noise_field"
 
     _synth_and_write(
@@ -663,6 +647,7 @@ def test_stokes_i_fit_on_noise_stays_finite(tmp_path: Path) -> None:
         cube_products=[],
         moment_products=["dirty", "clean"],
         output_prefix=output_prefix,
+        stokes_i_weight_cube=i_weight_cube,
     )
 
     for label in ("dirty", "clean"):
@@ -770,19 +755,19 @@ def test_stokes_i_fit_does_not_multiply_with_requested_products(
     own batching adds nothing on top.
     """
     import dask
-    import rm_lite.tools_3d.rmsynth as rmsynth_mod
+    import rm_lite.utils.fitting as fitting_mod
 
     stokes_q_cube, stokes_u_cube = qu_cubes
     stokes_i_cube = _make_i_cube(tmp_path)
 
     calls: list[int] = []
-    original = rmsynth_mod._fit_stokes_i_block
+    original = fitting_mod._fit_stokes_i_block
 
     def counting_fit_block(*args: object, **kwargs: object) -> object:
         calls.append(1)
         return original(*args, **kwargs)
 
-    monkeypatch.setattr(rmsynth_mod, "_fit_stokes_i_block", counting_fit_block)
+    monkeypatch.setattr(fitting_mod, "_fit_stokes_i_block", counting_fit_block)
     # As above: the counter has to stay in this process, and it is the graph
     # rather than the scheduler that decides how often the fit is called.
     real_compute = dask.compute
@@ -791,6 +776,7 @@ def test_stokes_i_fit_does_not_multiply_with_requested_products(
         "compute",
         lambda *a, **k: real_compute(*a, **{**k, "scheduler": "threads"}),
     )
+    stokes_i_weight_cube = _make_i_weight_cube(tmp_path)
 
     # Built once, and never computed, only to read the chunking off it
     n_chunks = run_rmsynth_3d(
@@ -798,6 +784,7 @@ def test_stokes_i_fit_does_not_multiply_with_requested_products(
         stokes_u_cube=stokes_u_cube,
         rmsynth_options=RMSynthOptions(),
         stokes_i_cube=stokes_i_cube,
+        stokes_i_weight_cube=stokes_i_weight_cube,
     ).fdf_dirty_cube.numblocks[1:]
     n_chunks = n_chunks[0] * n_chunks[1]
 
@@ -814,6 +801,7 @@ def test_stokes_i_fit_does_not_multiply_with_requested_products(
             stokes_q_cube=stokes_q_cube,
             stokes_u_cube=stokes_u_cube,
             stokes_i_cube=stokes_i_cube,
+            stokes_i_weight_cube=stokes_i_weight_cube,
             rmsynth_options=RMSynthOptions(),
             rmclean_options=RMCleanOptions(),
             cube_products=cube_products,

--- a/tests/test_rmsynth.py
+++ b/tests/test_rmsynth.py
@@ -1751,3 +1751,71 @@ def test_a_weight_cube_is_not_inverted_but_a_noise_cube_is(
                     error_cubes=error_cubes,
                 )
         assert captured["noise_files_are_weight"] is expected, error_cubes
+
+
+@pytest.mark.parametrize("per_pixel_noise", [False, True])
+def test_fused_faraday_maps_match_the_per_map_path(per_pixel_noise: bool) -> None:
+    """``faraday_maps`` must give exactly what a map-at-a-time derivation gives.
+
+    The products are built from the fused call, so a divergence here would
+    silently change every moment and peak map flint writes.
+    """
+    from rm_lite.tools_3d.rmclean import faraday_maps
+    from rm_lite.utils.synthesis import (
+        FaradayMoments,
+        FaradayPeaks,
+        calc_faraday_moments,
+        calc_faraday_peaks,
+    )
+
+    n_phi, ny, nx, rows = 401, 24, 32, 4
+    rng = np.random.default_rng(0)
+    phi_arr_radm2 = np.linspace(-2000, 2000, n_phi)
+    lambda_sq_arr_m2 = np.linspace(0.03, 0.08, 125)
+    values = (
+        rng.normal(size=(n_phi, ny, nx)) + 1j * rng.normal(size=(n_phi, ny, nx))
+    ).astype(np.complex64)
+    values[:, 0, 0] = np.nan  # a blank pixel, as a mosaic edge has
+    fdf_cube = da.from_array(values, chunks=(n_phi, rows, nx))
+
+    if per_pixel_noise:
+        noise = da.from_array(rng.random((ny, nx)) * 1e-2, chunks=(rows, nx))
+        threshold = noise * 5
+    else:
+        noise, threshold = 1e-2, 5e-2
+    lam_sq_0_m2 = 0.05
+
+    moments = calc_faraday_moments(
+        fdf_cube,
+        phi_arr_radm2=phi_arr_radm2,
+        fwhm_rmsf_radm2=50.0,
+        fdf_error=noise,
+        threshold=threshold,
+    )
+    peaks = calc_faraday_peaks(
+        fdf_cube,
+        phi_arr_radm2=phi_arr_radm2,
+        fwhm_rmsf_radm2=50.0,
+        fdf_error=noise,
+        lam_sq_0_m2=lam_sq_0_m2,
+        lambda_sq_arr_m2=lambda_sq_arr_m2,
+    )
+    fused = faraday_maps(
+        fdf_cube,
+        phi_arr_radm2=phi_arr_radm2,
+        fwhm_rmsf_radm2=50.0,
+        lam_sq_0_m2=lam_sq_0_m2,
+        lambda_sq_arr_m2=lambda_sq_arr_m2,
+        fdf_noise=noise,
+        moment_threshold=threshold,
+    )
+
+    for source, fields in (
+        (moments, FaradayMoments._fields),
+        (peaks, FaradayPeaks._fields),
+    ):
+        for field in fields:
+            expected = np.asarray(da.asarray(getattr(source, field)).compute())
+            np.testing.assert_array_equal(
+                np.asarray(fused[field].compute()), expected, err_msg=field
+            )

--- a/tests/test_rmsynth.py
+++ b/tests/test_rmsynth.py
@@ -28,8 +28,9 @@ from flint.rmsynth import (
     PEAK_MAPS,
     FDFLabel,
     RMSynth3DResults,
-    _compute_rm_products,
-    _snr_threshold,
+    check_cubes_are_single_precision,
+    compute_rm_products,
+    fdf_threshold_from_snr,
     needs_rmclean,
     run_rmclean_3d,
     run_rmsynth_3d,
@@ -684,6 +685,26 @@ def test_rmsynth_no_products_is_noop(
     )
 
 
+def test_rmsynth_warns_about_double_precision_cubes(tmp_path, caplog) -> None:
+    """rm-lite takes the FDF's precision from the cubes, so a float64 cube
+    silently doubles every Faraday-depth array it builds."""
+    stokes_q_cube, stokes_u_cube = _make_qu_cubes(tmp_path)
+
+    with caplog.at_level("WARNING"):
+        check_cubes_are_single_precision(stokes_q_cube, stokes_u_cube)
+    assert "double precision" not in caplog.text
+
+    doubled = tmp_path / "q_f8.fits"
+    with fits.open(stokes_q_cube) as hdul:
+        fits.PrimaryHDU(hdul[0].data.astype(np.float64), header=hdul[0].header).writeto(
+            doubled
+        )
+
+    with caplog.at_level("WARNING"):
+        check_cubes_are_single_precision(doubled, stokes_u_cube)
+    assert "double precision" in caplog.text
+
+
 def test_rmsynth_rejects_compressed_cubes(tmp_path: Path) -> None:
     """A gzipped cube cannot be memmapped, so rm-lite's per-block reopens would
     each inflate the whole cube into memory."""
@@ -780,7 +801,11 @@ def test_rmsynth_options_reach_rm_lite(
     monkeypatch.setattr(rmsynth_mod, "rmsynth_3d_from_fits", _capture)
 
     stokes_q_cube, stokes_u_cube = qu_cubes
-    rmsynth_options = RMSynthOptions(per_pixel_rmsf=True, estimate_stokes_i_noise=False)
+    rmsynth_options = RMSynthOptions(
+        per_pixel_rmsf=True,
+        estimate_stokes_i_noise=False,
+        convert_to_zarr=True,
+    )
     with pytest.raises(NotSupportedError, match="stop before synthesising"):
         _run_rmsynth_3d(
             stokes_q_cube=stokes_q_cube,
@@ -789,8 +814,11 @@ def test_rmsynth_options_reach_rm_lite(
             rmsynth_options=rmsynth_options,
         )
 
-    assert captured["per_pixel_rmsf"] is True
-    assert captured["estimate_stokes_i_noise"] is False
+    # Applied by flint after rm-lite returns, so they have nothing to forward.
+    flint_side = {"debias_moments", "debias_filter_size"}
+    for field in set(type(rmsynth_options).model_fields) - flint_side:
+        assert field in captured, f"{field} never reaches rm-lite"
+        assert captured[field] == getattr(rmsynth_options, field)
 
 
 def _within_cutoff(blank_outside: float) -> np.ndarray:
@@ -1144,9 +1172,9 @@ def test_peaks_are_never_cut_even_where_a_pixel_has_no_weight(
     linmos blanked, ``0 * inf`` is NaN, and every comparison against NaN is
     False -- so the cut meant to pass everything would instead blank the map."""
     assert not hasattr(RMSynthFieldOptions(), "peak_threshold_snr")
-    assert _snr_threshold(0.0, np.float64(np.inf)) is None
-    assert _snr_threshold(0.0, np.array([1e-5, np.inf])) is None
-    assert _snr_threshold(5.0, np.float64(2.0)) == 10.0
+    assert fdf_threshold_from_snr(0.0, np.float64(np.inf)) is None
+    assert fdf_threshold_from_snr(0.0, np.array([1e-5, np.inf])) is None
+    assert fdf_threshold_from_snr(5.0, np.float64(2.0)) == 10.0
 
     stokes_q_cube, stokes_u_cube = qu_cubes
     output_prefix = tmp_path / "default_cut"
@@ -1403,7 +1431,7 @@ def test_rmclean_runs_once_per_chunk_on_a_distributed_client(
     """The same once-per-chunk guarantee as the threaded test, on the path a real
     pipeline run takes.
 
-    ``_compute_rm_products`` submits to a distributed Client as futures so it can
+    ``compute_rm_products`` submits to a distributed Client as futures so it can
     report each product as it lands. Submitting them one at a time instead would
     rebuild the shared synthesis/RM-CLEAN graph per product -- invisible in the
     output, just N times the runtime of the slowest stage. The threaded test
@@ -1486,7 +1514,7 @@ def test_products_sharing_a_dask_key_are_all_returned() -> None:
     )
     try:
         with Client(cluster) as client:
-            computed = _compute_rm_products(
+            computed = compute_rm_products(
                 compute_targets=targets,
                 fuse_config={},
                 scheduler=client,
@@ -1518,10 +1546,10 @@ def test_computing_from_inside_a_worker_does_not_deadlock() -> None:
     import dask
     from distributed import Client, LocalCluster, get_client
 
-    from flint.rmsynth import _compute_rm_products
+    from flint.rmsynth import compute_rm_products
 
     def compute_on_the_worker() -> dict[str, object]:
-        return _compute_rm_products(
+        return compute_rm_products(
             compute_targets={"only": dask.delayed(int)(7)},
             fuse_config={},
             scheduler=get_client(),
@@ -1554,7 +1582,7 @@ def test_a_failed_product_is_raised_not_dropped(tmp_path: Path) -> None:
     import dask
     from distributed import Client, LocalCluster
 
-    from flint.rmsynth import _compute_rm_products
+    from flint.rmsynth import compute_rm_products
 
     def explode() -> None:
         msg = "this product could not be computed"
@@ -1570,7 +1598,7 @@ def test_a_failed_product_is_raised_not_dropped(tmp_path: Path) -> None:
     try:
         with Client(cluster) as client:
             with pytest.raises(ValueError, match="could not be computed"):
-                _compute_rm_products(
+                compute_rm_products(
                     compute_targets={
                         "fine": dask.delayed(int)(1),
                         "broken": dask.delayed(explode)(),

--- a/tests/test_rmsynth.py
+++ b/tests/test_rmsynth.py
@@ -6,6 +6,7 @@ import logging
 from pathlib import Path
 from unittest.mock import patch
 
+import dask.array as da
 import numpy as np
 import pytest
 from astropy.io import fits
@@ -23,8 +24,11 @@ from flint.options import (
     WeightCubesForRMSynth,
 )
 from flint.rmsynth import (
+    MOMENT_MAPS,
+    PEAK_MAPS,
     FDFLabel,
     RMSynth3DResults,
+    _compute_rm_products,
     _snr_threshold,
     needs_rmclean,
     run_rmclean_3d,
@@ -182,7 +186,6 @@ def _synth_and_write(
     stokes_u_weight_cube: Path | None = None,
     peak_products: list[FDFLabel] = [],
     moment_threshold_snr: float = 5.0,
-    peak_threshold_snr: float = 0.0,
 ) -> list[Path]:
     if not cube_products and not moment_products and not peak_products:
         return []
@@ -216,7 +219,6 @@ def _synth_and_write(
         peak_products=peak_products,
         output_prefix=output_prefix,
         moment_threshold_snr=moment_threshold_snr,
-        peak_threshold_snr=peak_threshold_snr,
     )
 
 
@@ -234,9 +236,9 @@ def test_rmsynth_all_products(tmp_path: Path, qu_cubes: tuple[Path, Path]) -> No
         output_prefix=output_prefix,
     )
 
-    # One zarr store holding all three cubes, three moments per label, and the
-    # CLEAN iteration count that every RM-CLEAN run writes
-    assert len(output_paths) == 1 + 3 * 3 + 1
+    # One zarr store holding all three cubes, every moment map per label, and
+    # the CLEAN iteration count that every RM-CLEAN run writes
+    assert len(output_paths) == 1 + 3 * len(MOMENT_MAPS) + 1
     for path in output_paths:
         assert path.exists()
 
@@ -245,11 +247,14 @@ def test_rmsynth_all_products(tmp_path: Path, qu_cubes: tuple[Path, Path]) -> No
     )
 
     for label in ("dirty", "clean", "model"):
-        for moment in ("mom0", "mom1", "mom2"):
-            moment_path = Path(f"{output_prefix}.fdf.{label}.{moment}.fits")
+        for name, unit, _ in MOMENT_MAPS.values():
+            moment_path = Path(f"{output_prefix}.fdf.{label}.{name}.fits")
             assert moment_path.exists()
             moment_header = fits.getheader(moment_path)
             assert moment_header["NAXIS"] == 2
+            # Jy/beam, rad/m2 and degrees now share the one set, so a moment
+            # map without its unit is easy to misread
+            assert moment_header["BUNIT"] == unit
 
     clean_mom1 = fits.getdata(Path(f"{output_prefix}.fdf.clean.mom1.fits"))
     assert np.allclose(clean_mom1, PHI_TRUE_RADM2, atol=5.0)
@@ -512,6 +517,54 @@ def test_stokes_i_model_rebuilds_from_the_written_term_maps(
     )
 
 
+def test_moment_errors_are_measured_rather_than_blank(
+    tmp_path: Path, qu_cubes: tuple[Path, Path]
+) -> None:
+    """Every error and debiased moment map is NaN unless the theoretical noise
+    is handed to ``calc_faraday_moments``, and rm-lite defaults it to None -- so
+    forgetting to pass it writes a full set of blank maps rather than failing.
+
+    The polarised intensity at the reference lambda^2 is the other new map: it
+    keeps the phase ``mom0`` throws away, so it cannot exceed ``mom0`` and its
+    angle is a real angle in degrees.
+    """
+    stokes_q_cube, stokes_u_cube = qu_cubes
+    output_prefix = tmp_path / "field"
+
+    _synth_and_write(
+        stokes_q_cube=stokes_q_cube,
+        stokes_u_cube=stokes_u_cube,
+        rmsynth_options=RMSynthOptions(),
+        rmclean_options=RMCleanOptions(),
+        cube_products=[],
+        moment_products=["clean"],
+        output_prefix=output_prefix,
+    )
+
+    def moment(name: str) -> np.ndarray:
+        return fits.getdata(Path(f"{output_prefix}.fdf.clean.{name}.fits"))
+
+    for name in ("mom0_error", "mom1_error", "mom2_error", "pi_lam_sq_0_error"):
+        assert np.all(np.isfinite(moment(name))), (
+            f"{name} is blank, so the theoretical noise never reached rm-lite"
+        )
+        assert np.all(moment(name) > 0.0), f"{name} is not a 1-sigma error"
+
+    mom0, mom0_debias = moment("mom0"), moment("mom0_debias")
+    assert np.all(np.isfinite(mom0_debias))
+    assert np.all(mom0_debias < mom0), "debiasing takes the noise's own sum off mom0"
+
+    pi_lam_sq_0 = moment("pi_lam_sq_0")
+    assert np.all(np.isfinite(pi_lam_sq_0))
+    # The coherent sum keeps the phase that mom0 discards, so it can only lose
+    # amplitude to it -- the ratio is the depolarisation at lambda^2_0
+    assert np.all(pi_lam_sq_0 <= mom0 * (1.0 + 1e-5))
+
+    pa_lam_sq_0 = moment("pa_lam_sq_0")
+    assert np.all(np.isfinite(pa_lam_sq_0))
+    assert np.all(np.abs(pa_lam_sq_0) <= 180.0)
+
+
 def test_rmsynth_debias_moments_runs(
     tmp_path: Path, qu_cubes: tuple[Path, Path]
 ) -> None:
@@ -534,8 +587,12 @@ def test_rmsynth_debias_moments_runs(
     assert mom0_path.exists()
     assert debiased_mom0_path in output_paths
     assert debiased_mom0_path.exists()
-    # Three moments, three debiased, plus the CLEAN iteration count
-    assert len(output_paths) == 6 + 1
+    # Every moment, every debiased moment but mom0_debias, plus the CLEAN
+    # iteration count
+    assert len(output_paths) == len(MOMENT_MAPS) + (len(MOMENT_MAPS) - 1) + 1
+    # ``debias_fdf`` already takes the noise off each amplitude, so rm-lite's
+    # own mom0 debias is a no-op there and the map is not written twice
+    assert not Path(f"{output_prefix}.fdf.clean.mom0_debias.debiased.fits").exists()
 
 
 def test_rmsynth_writes_fdf_cubes_to_zarr(
@@ -601,9 +658,9 @@ def test_moment_only_never_computes_a_full_cube(
     assert computed_shapes, "expected a batched dask.compute call"
     # Every gathered array is a 2D map; a 3D shape means an FDF cube came back.
     assert all(len(shape) == 2 for shape in computed_shapes), computed_shapes
-    # 3 labels x mom0/mom1/mom2, and nothing else.
-    # Nine moment maps plus the CLEAN iteration count, all still (ny, nx)
-    assert len(computed_shapes) == 9 + 1
+    # 3 labels x every moment map, and nothing else, plus the CLEAN iteration
+    # count -- all still (ny, nx)
+    assert len(computed_shapes) == 3 * len(MOMENT_MAPS) + 1
 
 
 def test_rmsynth_no_products_is_noop(
@@ -955,8 +1012,8 @@ def test_linmos_weights_through_to_the_moment_maps(
     )
 
     assert {path.name for path in output_paths} == {
-        f"{output_prefix.name}.fdf.clean.{moment}.fits"
-        for moment in ("mom0", "mom1", "mom2")
+        f"{output_prefix.name}.fdf.clean.{name}.fits"
+        for name, _, _ in MOMENT_MAPS.values()
     } | {f"{output_prefix.name}.fdf.clean.niter.fits"}
 
     mom1 = fits.getdata(Path(f"{output_prefix}.fdf.clean.mom1.fits"))
@@ -1029,8 +1086,16 @@ def test_every_fdf_can_have_cubes_moments_and_peaks(
     # One zarr store holds every cube; moments and peaks are a file each
     assert f"{output_prefix.name}.fdf.zarr" in names
     for label in labels:
-        assert sum(f".{label}.mom" in name for name in names) == 3, label
-        assert sum(f".{label}.peak_" in name for name in names) == 9, label
+        moment_names = {
+            f"{output_prefix.name}.fdf.{label}.{name}.fits"
+            for name, _, _ in MOMENT_MAPS.values()
+        }
+        peak_names = {
+            f"{output_prefix.name}.fdf.{label}.{name}.fits"
+            for name, _, _ in PEAK_MAPS.values()
+        }
+        assert moment_names <= names, label
+        assert peak_names <= names, label
 
     # The peak Faraday depth is the recoverable truth in all three
     for label in labels:
@@ -1038,58 +1103,47 @@ def test_every_fdf_can_have_cubes_moments_and_peaks(
         assert np.nanmedian(peak_rm) == pytest.approx(PHI_TRUE_RADM2, abs=5.0), label
 
 
-def test_the_peak_and_moment_snr_cuts_are_independent(
+def test_the_moment_snr_cut_does_not_reach_the_peaks(
     tmp_path: Path, qu_cubes: tuple[Path, Path]
 ) -> None:
     """One cut used to serve both, so a noise estimate that blanked the moments
     took the peaks with it and the pair looked like a broken FDF rather than an
-    over-aggressive cut. They are separate options now, and each has to bite on
-    its own products only.
+    over-aggressive cut. Only the moments are cut now -- rm-lite dropped the
+    peak threshold entirely -- so the cut has to bite on the moments alone.
     """
     stokes_q_cube, stokes_u_cube = qu_cubes
+    output_prefix = tmp_path / "moments_cut"
 
-    def peak_pi_and_mom0(
-        prefix: str,
-        moment_threshold_snr: float = 5.0,
-        peak_threshold_snr: float = 0.0,
-    ) -> tuple[np.ndarray, np.ndarray]:
-        output_prefix = tmp_path / prefix
-        _synth_and_write(
-            stokes_q_cube=stokes_q_cube,
-            stokes_u_cube=stokes_u_cube,
-            rmsynth_options=RMSynthOptions(),
-            rmclean_options=RMCleanOptions(),
-            cube_products=[],
-            moment_products=["dirty"],
-            peak_products=["dirty"],
-            output_prefix=output_prefix,
-            moment_threshold_snr=moment_threshold_snr,
-            peak_threshold_snr=peak_threshold_snr,
-        )
-        return (
-            fits.getdata(Path(f"{output_prefix}.fdf.dirty.peak_pi.fits")),
-            fits.getdata(Path(f"{output_prefix}.fdf.dirty.mom0.fits")),
-        )
+    _synth_and_write(
+        stokes_q_cube=stokes_q_cube,
+        stokes_u_cube=stokes_u_cube,
+        rmsynth_options=RMSynthOptions(),
+        rmclean_options=RMCleanOptions(),
+        cube_products=[],
+        moment_products=["dirty"],
+        peak_products=["dirty"],
+        output_prefix=output_prefix,
+        # A cut nothing can clear, so anything it reaches is unmistakable
+        moment_threshold_snr=1e6,
+    )
+    peak_pi = fits.getdata(Path(f"{output_prefix}.fdf.dirty.peak_pi.fits"))
+    mom0 = fits.getdata(Path(f"{output_prefix}.fdf.dirty.mom0.fits"))
 
-    # A cut nothing can clear on one side leaves the other untouched. mom0 is
-    # nansum, so a fully cut spectrum reads 0 rather than NaN; a cut peak is NaN
-    peak_pi, mom0 = peak_pi_and_mom0("moments_cut", moment_threshold_snr=1e6)
     assert np.all(np.isfinite(peak_pi)), "the moment cut must not reach the peaks"
+    # mom0 is a nansum, so a fully cut spectrum reads 0 rather than NaN
     assert np.all(mom0 == 0.0)
 
-    peak_pi, mom0 = peak_pi_and_mom0("peaks_cut", peak_threshold_snr=1e6)
-    assert np.all(np.isnan(peak_pi))
-    assert np.all(mom0 > 0.0), "the peak cut must not reach the moments"
 
-
-def test_no_peak_cut_by_default_even_where_a_pixel_has_no_weight(
+def test_peaks_are_never_cut_even_where_a_pixel_has_no_weight(
     tmp_path: Path, qu_cubes: tuple[Path, Path]
 ) -> None:
-    """``peak_threshold_snr`` defaults to 0, meaning no cut at all. It cannot be
-    applied as ``0 * noise``: the theoretical noise is inf for a pixel linmos
-    blanked, ``0 * inf`` is NaN, and every comparison against NaN is False -- so
-    the cut meant to pass everything would instead blank the whole map."""
-    assert RMSynthFieldOptions().peak_threshold_snr == 0.0
+    """No SNR cut is applied to the peak maps: a peak is a single sample with no
+    noise floor to integrate, so ``peak_pi_error`` is written beside it and the
+    selection is made afterwards. Only the moment cut is left, and a zero there
+    cannot be applied as ``0 * noise``: the theoretical noise is inf for a pixel
+    linmos blanked, ``0 * inf`` is NaN, and every comparison against NaN is
+    False -- so the cut meant to pass everything would instead blank the map."""
+    assert not hasattr(RMSynthFieldOptions(), "peak_threshold_snr")
     assert _snr_threshold(0.0, np.float64(np.inf)) is None
     assert _snr_threshold(0.0, np.array([1e-5, np.inf])) is None
     assert _snr_threshold(5.0, np.float64(2.0)) == 10.0
@@ -1112,10 +1166,10 @@ def test_no_peak_cut_by_default_even_where_a_pixel_has_no_weight(
     peak_pi = fits.getdata(Path(f"{output_prefix}.fdf.dirty.peak_pi.fits"))
     inside_cutoff = _within_cutoff(1.5)
     assert np.all(np.isfinite(peak_pi[inside_cutoff])), (
-        "no cut was asked for, so every pixel carrying weight keeps its peak"
+        "no cut is applied, so every pixel carrying weight keeps its peak"
     )
     assert np.all(np.isnan(peak_pi[~inside_cutoff])), (
-        "a pixel linmos blanked has no FDF to peak, cut or no cut"
+        "a pixel linmos blanked has no FDF to peak"
     )
 
 
@@ -1402,8 +1456,49 @@ def test_rmclean_runs_once_per_chunk_on_a_distributed_client(
         cluster.close()
 
     assert len(tally.read_text()) == n_chunks, (
-        "nine moment maps off three FDFs must still clean each chunk once"
+        "every moment map off three FDFs must still clean each chunk once"
     )
+
+
+def test_products_sharing_a_dask_key_are_all_returned() -> None:
+    """Two products built from the same expression share a dask key, so
+    ``client.compute`` hands back a single future for both -- rm-lite derives
+    ``pi_lam_sq_0_error`` exactly as it does ``mom0_error``, so the moment maps
+    hit this on every run. Keying the results by future dropped all but the last
+    of each such group, which surfaced as a ``KeyError`` on a map that had in
+    fact been computed."""
+    from distributed import Client, LocalCluster
+
+    shared = da.arange(4, chunks=2) * 2.0
+    targets = {
+        "first": shared,
+        # A separate array with an identical graph, as rm-lite's two errors are
+        "second": da.arange(4, chunks=2) * 2.0,
+        "other": da.arange(4, chunks=2) + 1.0,
+    }
+
+    cluster = LocalCluster(
+        n_workers=1,
+        threads_per_worker=1,
+        processes=False,
+        dashboard_address=None,
+        silence_logs=logging.ERROR,
+    )
+    try:
+        with Client(cluster) as client:
+            computed = _compute_rm_products(
+                compute_targets=targets,
+                fuse_config={},
+                scheduler=client,
+                workload="test",
+            )
+    finally:
+        cluster.close()
+
+    assert set(computed) == set(targets)
+    assert np.allclose(computed["first"], [0.0, 2.0, 4.0, 6.0])
+    assert np.allclose(computed["second"], computed["first"])
+    assert np.allclose(computed["other"], [1.0, 2.0, 3.0, 4.0])
 
 
 def test_computing_from_inside_a_worker_does_not_deadlock() -> None:

--- a/tests/test_spice.py
+++ b/tests/test_spice.py
@@ -19,9 +19,11 @@ from flint.coadd.linmos import BoundingBox
 from flint.convol import BeamShape
 from flint.options import SpiceOptions
 from flint.spice import (
-    any_box_overlaps,
+    SkyBoundingBox,
+    check_cubes_share_shape,
     island_sky_boxes,
     keep_mask_from_boxes,
+    shared_pixel_boxes,
     spice_fits,
 )
 
@@ -369,7 +371,10 @@ def test_spice_fits_masks_crops_and_replaces(tmp_path: Path, shape):
         is_user_catalogue=False,
     )
 
-    out_path = spice_fits(fits_path=fits_path, sky_boxes=sky_boxes)
+    out_path = spice_fits(
+        fits_path=fits_path,
+        pixel_boxes=shared_pixel_boxes(fits_paths=[fits_path], sky_boxes=sky_boxes),
+    )
     assert out_path == fits_path
 
     with fits.open(out_path) as hdul:
@@ -415,7 +420,10 @@ def test_spice_fits_preserves_extra_hdus(tmp_path: Path):
         spice_options=SpiceOptions(n_beamwidths=1.0),
         is_user_catalogue=False,
     )
-    spice_fits(fits_path=fits_path, sky_boxes=sky_boxes)
+    spice_fits(
+        fits_path=fits_path,
+        pixel_boxes=shared_pixel_boxes(fits_paths=[fits_path], sky_boxes=sky_boxes),
+    )
 
     with fits.open(fits_path) as hdul:
         assert len(hdul) == 2
@@ -427,7 +435,7 @@ def test_spice_fits_no_boxes_raises(tmp_path: Path):
     fits_path = tmp_path / "test.fits"
     _write_test_fits(fits_path, wcs, (NY, NX))
     with pytest.raises(ValueError):
-        spice_fits(fits_path=fits_path, sky_boxes=[])
+        spice_fits(fits_path=fits_path, pixel_boxes=[])
 
 
 def _shifted_wcs(crpix_shift: tuple[float, float]) -> WCS:
@@ -460,7 +468,10 @@ def test_boxes_survive_a_trimmed_reference_grid(tmp_path: Path):
     fits_path = tmp_path / "cube.fits"
     _write_test_fits(fits_path, cube_wcs, (NY, NX))
 
-    spice_fits(fits_path=fits_path, sky_boxes=sky_boxes)
+    spice_fits(
+        fits_path=fits_path,
+        pixel_boxes=shared_pixel_boxes(fits_paths=[fits_path], sky_boxes=sky_boxes),
+    )
 
     with fits.open(fits_path) as hdul:
         data, header = hdul[0].data, hdul[0].header
@@ -471,43 +482,6 @@ def test_boxes_survive_a_trimmed_reference_grid(tmp_path: Path):
     )
     assert np.isfinite(data[int(np.round(y_pix)), int(np.round(x_pix))])
     assert data.shape[-2:] != (NY, NX), "The cube should have been cropped"
-
-
-def test_spice_fits_leaves_a_cube_with_no_islands_untouched(tmp_path: Path):
-    reference_wcs = _make_wcs()
-    sky_boxes = island_sky_boxes(
-        table=_aegean_table([_default_row(0, RA0, DEC0)]),
-        wcs=reference_wcs,
-        beam_shape=BEAM,
-        spice_options=SpiceOptions(n_beamwidths=1.0),
-        is_user_catalogue=False,
-    )
-
-    # A cube pointed far away from the catalogued source
-    elsewhere = _make_wcs()
-    elsewhere.wcs.crval = [RA0 + 20.0, DEC0]
-    fits_path = tmp_path / "elsewhere.fits"
-    _write_test_fits(fits_path, elsewhere, (NY, NX))
-    before = fits_path.read_bytes()
-
-    assert not any_box_overlaps(fits_path=fits_path, sky_boxes=sky_boxes)
-    assert spice_fits(fits_path=fits_path, sky_boxes=sky_boxes) == fits_path
-    assert fits_path.read_bytes() == before, "An unspiced cube must not be rewritten"
-
-
-def test_any_box_overlaps_true_for_the_reference_grid(tmp_path: Path):
-    wcs = _make_wcs()
-    sky_boxes = island_sky_boxes(
-        table=_aegean_table([_default_row(0, RA0, DEC0)]),
-        wcs=wcs,
-        beam_shape=BEAM,
-        spice_options=SpiceOptions(n_beamwidths=1.0),
-        is_user_catalogue=False,
-    )
-    fits_path = tmp_path / "on_grid.fits"
-    _write_test_fits(fits_path, wcs, (NY, NX))
-
-    assert any_box_overlaps(fits_path=fits_path, sky_boxes=sky_boxes)
 
 
 def test_spice_fits_writes_to_output_path_and_removes_the_original(tmp_path: Path):
@@ -524,7 +498,9 @@ def test_spice_fits_writes_to_output_path_and_removes_the_original(tmp_path: Pat
 
     output_path = tmp_path / "spice"
     spiced = spice_fits(
-        fits_path=fits_path, sky_boxes=sky_boxes, output_path=output_path
+        fits_path=fits_path,
+        pixel_boxes=shared_pixel_boxes(fits_paths=[fits_path], sky_boxes=sky_boxes),
+        output_path=output_path,
     )
 
     assert spiced == output_path / "cube.fits"
@@ -534,30 +510,6 @@ def test_spice_fits_writes_to_output_path_and_removes_the_original(tmp_path: Pat
     with fits.open(spiced) as hdul:
         assert hdul[0].data.shape[-2:] != (NY, NX)
         assert any("flint.spice" in str(card) for card in hdul[0].header["HISTORY"])
-
-
-def test_spice_fits_unoverlapped_cube_is_not_moved(tmp_path: Path):
-    wcs = _make_wcs()
-    sky_boxes = island_sky_boxes(
-        table=_aegean_table([_default_row(0, RA0, DEC0)]),
-        wcs=wcs,
-        beam_shape=BEAM,
-        spice_options=SpiceOptions(n_beamwidths=1.0),
-        is_user_catalogue=False,
-    )
-
-    elsewhere = _make_wcs()
-    elsewhere.wcs.crval = [RA0 + 20.0, DEC0]
-    fits_path = tmp_path / "elsewhere.fits"
-    _write_test_fits(fits_path, elsewhere, (NY, NX))
-
-    output_path = tmp_path / "spice"
-    result = spice_fits(
-        fits_path=fits_path, sky_boxes=sky_boxes, output_path=output_path
-    )
-
-    assert result == fits_path
-    assert fits_path.exists(), "An unspiced cube must not be deleted"
 
 
 def test_spice_fits_is_idempotent_after_a_worker_death(tmp_path: Path):
@@ -575,14 +527,97 @@ def test_spice_fits_is_idempotent_after_a_worker_death(tmp_path: Path):
     )
     output_path = tmp_path / "spice"
 
+    pixel_boxes = shared_pixel_boxes(fits_paths=[fits_path], sky_boxes=sky_boxes)
     first = spice_fits(
-        fits_path=fits_path, sky_boxes=sky_boxes, output_path=output_path
+        fits_path=fits_path, pixel_boxes=pixel_boxes, output_path=output_path
     )
     first_bytes = first.read_bytes()
 
     second = spice_fits(
-        fits_path=fits_path, sky_boxes=sky_boxes, output_path=output_path
+        fits_path=fits_path, pixel_boxes=pixel_boxes, output_path=output_path
     )
 
     assert second == first
     assert second.read_bytes() == first_bytes, "The rerun must not re-crop the output"
+
+
+def _sky_boxes(wcs: WCS) -> list[SkyBoundingBox]:
+    return island_sky_boxes(
+        table=_aegean_table([_default_row(0, RA0, DEC0)]),
+        wcs=wcs,
+        beam_shape=BEAM,
+        spice_options=SpiceOptions(n_beamwidths=1.0),
+        is_user_catalogue=False,
+    )
+
+
+def test_image_and_weight_cubes_spice_to_the_same_shape(tmp_path: Path):
+    """The point of the shared boxes: every Stokes image and weight cube comes
+    out on one grid, extensions intact."""
+    wcs = _make_wcs()
+    cubes = []
+    for stokes in ("i", "q"):
+        for mode in ("image", "weight"):
+            fits_path = tmp_path / f"{stokes}.{mode}.fits"
+            _write_test_fits(fits_path, wcs, (3, NY, NX), extra_hdu=True)
+            cubes.append(fits_path)
+
+    pixel_boxes = shared_pixel_boxes(fits_paths=cubes, sky_boxes=_sky_boxes(wcs))
+    output_path = tmp_path / "spice"
+    spiced = [
+        spice_fits(fits_path=cube, pixel_boxes=pixel_boxes, output_path=output_path)
+        for cube in cubes
+    ]
+
+    shape = check_cubes_share_shape(fits_paths=spiced)
+    assert shape[-2:] != (NY, NX), "The cubes should have been cropped"
+    for spiced_path in spiced:
+        with fits.open(spiced_path) as hdul:
+            assert hdul[1].name == "BEAMS"
+
+
+def test_check_cubes_share_shape_rejects_a_mismatch(tmp_path: Path):
+    wcs = _make_wcs()
+    matching = tmp_path / "match.fits"
+    odd = tmp_path / "odd.fits"
+    _write_test_fits(matching, wcs, (3, NY, NX))
+    _write_test_fits(odd, wcs, (2, NY, NX))
+
+    assert check_cubes_share_shape(fits_paths=[matching, matching]) == (3, NY, NX)
+    with pytest.raises(ValueError, match="do not share a shape"):
+        check_cubes_share_shape(fits_paths=[matching, odd])
+
+
+def test_shared_pixel_boxes_rejects_a_differing_grid(tmp_path: Path):
+    """Same shape, shifted WCS -- the same boxes would crop them differently"""
+    wcs = _make_wcs()
+    on_grid = tmp_path / "on_grid.fits"
+    shifted = tmp_path / "shifted.fits"
+    _write_test_fits(on_grid, wcs, (NY, NX))
+    _write_test_fits(shifted, _shifted_wcs((30.0, 20.0)), (NY, NX))
+
+    with pytest.raises(ValueError, match="same celestial grid"):
+        shared_pixel_boxes(fits_paths=[on_grid, shifted], sky_boxes=_sky_boxes(wcs))
+
+
+def test_shared_pixel_boxes_raises_when_no_island_overlaps(tmp_path: Path):
+    wcs = _make_wcs()
+    elsewhere = _make_wcs()
+    elsewhere.wcs.crval = [RA0 + 20.0, DEC0]
+    fits_path = tmp_path / "elsewhere.fits"
+    _write_test_fits(fits_path, elsewhere, (NY, NX))
+
+    with pytest.raises(ValueError, match="island boxes overlap"):
+        shared_pixel_boxes(fits_paths=[fits_path], sky_boxes=_sky_boxes(wcs))
+
+
+def test_spice_fits_rejects_boxes_built_against_another_shape(tmp_path: Path):
+    wcs = _make_wcs()
+    reference = tmp_path / "reference.fits"
+    smaller = tmp_path / "smaller.fits"
+    _write_test_fits(reference, wcs, (NY, NX))
+    _write_test_fits(smaller, wcs, (NY // 2, NX // 2))
+
+    pixel_boxes = shared_pixel_boxes(fits_paths=[reference], sky_boxes=_sky_boxes(wcs))
+    with pytest.raises(ValueError, match="boxes were built against"):
+        spice_fits(fits_path=smaller, pixel_boxes=pixel_boxes)

--- a/tests/test_spice.py
+++ b/tests/test_spice.py
@@ -1,8 +1,4 @@
-"""Tests for SPICE-style cube trimming (flint.spice): catalogue -> per-island
-pixel boxes -> mask/crop-in-place. rm-lite/aegean's own science is not this
-module's responsibility -- these tests check the WCS/box geometry and the
-FITS in -> FITS out plumbing.
-"""
+"""Tests for SPICE-style cube trimming"""
 
 from __future__ import annotations
 
@@ -19,9 +15,15 @@ from astropy.wcs import WCS
 from astropy.wcs.utils import skycoord_to_pixel
 from radio_beam import Beam
 
+from flint.coadd.linmos import BoundingBox
 from flint.convol import BeamShape
 from flint.options import SpiceOptions
-from flint.spice import island_bounding_boxes, keep_mask_from_boxes, spice_fits
+from flint.spice import (
+    any_box_overlaps,
+    island_sky_boxes,
+    keep_mask_from_boxes,
+    spice_fits,
+)
 
 NY = 200
 NX = 200
@@ -61,24 +63,36 @@ def _default_row(
     )
 
 
+def _pixel_boxes(wcs: WCS, **kwargs) -> list[BoundingBox]:
+    """Sky boxes projected onto the reference grid, as ``spice_fits`` does per file"""
+    sky_boxes = island_sky_boxes(wcs=wcs, **kwargs)
+    return [
+        bounding_box
+        for bounding_box in (
+            sky_box.to_bounding_box(wcs=wcs, image_shape=(NY, NX))
+            for sky_box in sky_boxes
+        )
+        if bounding_box is not None
+    ]
+
+
 def test_component_box_centred_on_source():
     wcs = _make_wcs()
     table = _aegean_table([_default_row(0, RA0, DEC0)])
-    boxes = island_bounding_boxes(
+    bounding_boxes = _pixel_boxes(
         table=table,
         wcs=wcs,
-        image_shape=(NY, NX),
         beam_shape=BEAM,
         spice_options=SpiceOptions(n_beamwidths=0.0),
         is_user_catalogue=False,
     )
-    assert len(boxes) == 1
-    box = boxes[0]
+    assert len(bounding_boxes) == 1
+    bounding_box = bounding_boxes[0]
     x_pix, y_pix = skycoord_to_pixel(
         wcs=wcs, coords=SkyCoord(RA0 * u.deg, DEC0 * u.deg), origin=0
     )
-    assert box.xmin <= y_pix <= box.xmax
-    assert box.ymin <= x_pix <= box.ymax
+    assert bounding_box.xmin <= y_pix <= bounding_box.xmax
+    assert bounding_box.ymin <= x_pix <= bounding_box.ymax
 
 
 def test_axis_convention_ra_moves_y_dec_moves_x():
@@ -90,30 +104,28 @@ def test_axis_convention_ra_moves_y_dec_moves_x():
     table = _aegean_table(
         [_default_row(0, RA0, DEC0), _default_row(1, RA0 + ra_offset_deg, DEC0)]
     )
-    boxes = island_bounding_boxes(
+    bounding_boxes = _pixel_boxes(
         table=table,
         wcs=wcs,
-        image_shape=(NY, NX),
         beam_shape=BEAM,
         spice_options=SpiceOptions(n_beamwidths=0.0),
         is_user_catalogue=False,
     )
-    b0, b1 = boxes
+    b0, b1 = bounding_boxes
     assert b0.xmin == b1.xmin and b0.xmax == b1.xmax
     assert b0.ymin != b1.ymin and b0.ymax != b1.ymax
 
     table = _aegean_table(
         [_default_row(0, RA0, DEC0), _default_row(1, RA0, DEC0 + 20.0 / 3600)]
     )
-    boxes = island_bounding_boxes(
+    bounding_boxes = _pixel_boxes(
         table=table,
         wcs=wcs,
-        image_shape=(NY, NX),
         beam_shape=BEAM,
         spice_options=SpiceOptions(n_beamwidths=0.0),
         is_user_catalogue=False,
     )
-    b0, b1 = boxes
+    b0, b1 = bounding_boxes
     assert b0.ymin == b1.ymin and b0.ymax == b1.ymax
     assert b0.xmin != b1.xmin and b0.xmax != b1.xmax
 
@@ -128,16 +140,15 @@ def test_islands_merge_components_sharing_island_id():
             _default_row(1, RA0 + 0.02, DEC0),
         ]
     )
-    boxes = island_bounding_boxes(
+    bounding_boxes = _pixel_boxes(
         table=table,
         wcs=wcs,
-        image_shape=(NY, NX),
         beam_shape=BEAM,
         spice_options=SpiceOptions(n_beamwidths=0.0),
         is_user_catalogue=False,
     )
-    assert len(boxes) == 2
-    merged = max(boxes, key=lambda b: b.xmax - b.xmin)
+    assert len(bounding_boxes) == 2
+    merged = max(bounding_boxes, key=lambda b: b.xmax - b.xmin)
     assert merged.xmax - merged.xmin > offset_deg * 3600 / PIXEL_SCALE_ARCSEC
 
 
@@ -146,10 +157,9 @@ def test_padding_scales_linearly_with_n_beamwidths():
     table = _aegean_table([_default_row(0, RA0, DEC0, a=0.0, b=0.0)])
 
     def _box(n_beamwidths):
-        return island_bounding_boxes(
+        return _pixel_boxes(
             table=table,
             wcs=wcs,
-            image_shape=(NY, NX),
             beam_shape=BEAM,
             spice_options=SpiceOptions(n_beamwidths=n_beamwidths),
             is_user_catalogue=False,
@@ -172,18 +182,16 @@ def test_rotated_ellipse_extent_swaps_axes():
     table_pa90 = _aegean_table([_default_row(0, RA0, DEC0, a=20.0, b=5.0, pa=90.0)])
     opts = SpiceOptions(n_beamwidths=0.0)
 
-    box_pa0 = island_bounding_boxes(
+    box_pa0 = _pixel_boxes(
         table=table_pa0,
         wcs=wcs,
-        image_shape=(NY, NX),
         beam_shape=BEAM,
         spice_options=opts,
         is_user_catalogue=False,
     )[0]
-    box_pa90 = island_bounding_boxes(
+    box_pa90 = _pixel_boxes(
         table=table_pa90,
         wcs=wcs,
-        image_shape=(NY, NX),
         beam_shape=BEAM,
         spice_options=opts,
         is_user_catalogue=False,
@@ -196,26 +204,26 @@ def test_rotated_ellipse_extent_swaps_axes():
 def test_boxes_clipped_and_dropped_at_image_edge():
     wcs = _make_wcs()
     table = _aegean_table([_default_row(0, RA0, DEC0)])
-    boxes = island_bounding_boxes(
+    bounding_boxes = _pixel_boxes(
         table=table,
         wcs=wcs,
-        image_shape=(NY, NX),
         beam_shape=BEAM,
         spice_options=SpiceOptions(n_beamwidths=1000.0),
         is_user_catalogue=False,
     )
-    assert boxes[0].xmin == 0 and boxes[0].xmax == NY
-    assert boxes[0].ymin == 0 and boxes[0].ymax == NX
+    assert bounding_boxes[0].xmin == 0 and bounding_boxes[0].xmax == NY
+    assert bounding_boxes[0].ymin == 0 and bounding_boxes[0].ymax == NX
 
-    with pytest.raises(ValueError):
-        island_bounding_boxes(
+    assert (
+        _pixel_boxes(
             table=_aegean_table([_default_row(0, RA0 + 10, DEC0)]),
             wcs=wcs,
-            image_shape=(NY, NX),
             beam_shape=BEAM,
             spice_options=SpiceOptions(n_beamwidths=0.0),
             is_user_catalogue=False,
         )
+        == []
+    ), "A source well off the image should project to no boxes"
 
 
 def test_fallback_no_island_column_and_no_shape_columns():
@@ -224,34 +232,32 @@ def test_fallback_no_island_column_and_no_shape_columns():
     opts = SpiceOptions(
         catalogue_ra_col="ra", catalogue_dec_col="dec", n_beamwidths=2.0
     )
-    boxes = island_bounding_boxes(
+    bounding_boxes = _pixel_boxes(
         table=table,
         wcs=wcs,
-        image_shape=(NY, NX),
         beam_shape=BEAM,
         spice_options=opts,
         is_user_catalogue=True,
     )
-    assert len(boxes) == 1
+    assert len(bounding_boxes) == 1
     pad_pix = math.ceil(2.0 * BEAM.bmaj_arcsec / PIXEL_SCALE_ARCSEC)
-    box = boxes[0]
-    assert (box.xmax - box.xmin) == 2 * pad_pix + 1
-    assert (box.ymax - box.ymin) == 2 * pad_pix + 1
+    bounding_box = bounding_boxes[0]
+    assert (bounding_box.xmax - bounding_box.xmin) == 2 * pad_pix + 1
+    assert (bounding_box.ymax - bounding_box.ymin) == 2 * pad_pix + 1
 
 
 def test_keep_mask_union_area():
-    boxes = island_bounding_boxes(
+    bounding_boxes = _pixel_boxes(
         table=_aegean_table(
             [_default_row(0, RA0, DEC0), _default_row(1, RA0 + 0.02, DEC0)]
         ),
         wcs=_make_wcs(),
-        image_shape=(NY, NX),
         beam_shape=BEAM,
         spice_options=SpiceOptions(n_beamwidths=0.0),
         is_user_catalogue=False,
     )
-    mask = keep_mask_from_boxes(boxes=boxes, image_shape=(NY, NX))
-    expected = sum((b.xmax - b.xmin) * (b.ymax - b.ymin) for b in boxes)
+    mask = keep_mask_from_boxes(bounding_boxes=bounding_boxes, image_shape=(NY, NX))
+    expected = sum((b.xmax - b.xmin) * (b.ymax - b.ymin) for b in bounding_boxes)
     assert mask.sum() == expected
 
 
@@ -266,18 +272,16 @@ def test_deconvolved_sizes_reconvolved_larger_than_observed():
         catalogue_pa_col="pa",
         n_beamwidths=0.0,
     )
-    box_observed = island_bounding_boxes(
+    box_observed = _pixel_boxes(
         table=table,
         wcs=wcs,
-        image_shape=(NY, NX),
         beam_shape=BEAM,
         spice_options=SpiceOptions(catalogue_sizes_deconvolved=False, **common_opts),
         is_user_catalogue=True,
     )[0]
-    box_deconvolved = island_bounding_boxes(
+    box_deconvolved = _pixel_boxes(
         table=table,
         wcs=wcs,
-        image_shape=(NY, NX),
         beam_shape=BEAM,
         spice_options=SpiceOptions(catalogue_sizes_deconvolved=True, **common_opts),
         is_user_catalogue=True,
@@ -308,10 +312,9 @@ def test_deconvolved_requires_explicit_flag():
         catalogue_pa_col="pa",
     )
     with pytest.raises(ValueError):
-        island_bounding_boxes(
+        _pixel_boxes(
             table=table,
             wcs=wcs,
-            image_shape=(NY, NX),
             beam_shape=BEAM,
             spice_options=opts,
             is_user_catalogue=True,
@@ -322,10 +325,9 @@ def test_user_catalogue_requires_ra_dec_columns():
     wcs = _make_wcs()
     table = Table({"ra": [RA0], "dec": [DEC0]})
     with pytest.raises(ValueError):
-        island_bounding_boxes(
+        _pixel_boxes(
             table=table,
             wcs=wcs,
-            image_shape=(NY, NX),
             beam_shape=BEAM,
             spice_options=SpiceOptions(),
             is_user_catalogue=True,
@@ -359,24 +361,34 @@ def test_spice_fits_masks_crops_and_replaces(tmp_path: Path, shape):
     table = _aegean_table(
         [_default_row(0, RA0, DEC0), _default_row(1, RA0 + 0.02, DEC0)]
     )
-    boxes = island_bounding_boxes(
+    sky_boxes = island_sky_boxes(
         table=table,
         wcs=wcs,
-        image_shape=(NY, NX),
         beam_shape=BEAM,
         spice_options=SpiceOptions(n_beamwidths=1.0),
         is_user_catalogue=False,
     )
 
-    out_path = spice_fits(fits_path=fits_path, boxes=boxes)
+    out_path = spice_fits(fits_path=fits_path, sky_boxes=sky_boxes)
     assert out_path == fits_path
 
     with fits.open(out_path) as hdul:
         data = hdul[0].data
         header = hdul[0].header
 
-    expected_span_x = max(b.xmax for b in boxes) - min(b.xmin for b in boxes)
-    expected_span_y = max(b.ymax for b in boxes) - min(b.ymin for b in boxes)
+    pixel_boxes = [
+        bounding_box
+        for bounding_box in (
+            b.to_bounding_box(wcs=wcs, image_shape=(NY, NX)) for b in sky_boxes
+        )
+        if bounding_box is not None
+    ]
+    expected_span_x = max(b.xmax for b in pixel_boxes) - min(
+        b.xmin for b in pixel_boxes
+    )
+    expected_span_y = max(b.ymax for b in pixel_boxes) - min(
+        b.ymin for b in pixel_boxes
+    )
     assert data.shape[-2:] == (expected_span_x, expected_span_y)
     assert data.shape[:-2] == tuple(shape[:-2])
     assert np.isfinite(data).any()
@@ -396,15 +408,14 @@ def test_spice_fits_preserves_extra_hdus(tmp_path: Path):
     _write_test_fits(fits_path, wcs, (NY, NX), extra_hdu=True)
 
     table = _aegean_table([_default_row(0, RA0, DEC0)])
-    boxes = island_bounding_boxes(
+    sky_boxes = island_sky_boxes(
         table=table,
         wcs=wcs,
-        image_shape=(NY, NX),
         beam_shape=BEAM,
         spice_options=SpiceOptions(n_beamwidths=1.0),
         is_user_catalogue=False,
     )
-    spice_fits(fits_path=fits_path, boxes=boxes)
+    spice_fits(fits_path=fits_path, sky_boxes=sky_boxes)
 
     with fits.open(fits_path) as hdul:
         assert len(hdul) == 2
@@ -416,4 +427,162 @@ def test_spice_fits_no_boxes_raises(tmp_path: Path):
     fits_path = tmp_path / "test.fits"
     _write_test_fits(fits_path, wcs, (NY, NX))
     with pytest.raises(ValueError):
-        spice_fits(fits_path=fits_path, boxes=[])
+        spice_fits(fits_path=fits_path, sky_boxes=[])
+
+
+def _shifted_wcs(crpix_shift: tuple[float, float]) -> WCS:
+    """The reference WCS as if the image had been trimmed by ``crpix_shift`` pixels"""
+    wcs = _make_wcs()
+    wcs.wcs.crpix = [
+        wcs.wcs.crpix[0] - crpix_shift[0],
+        wcs.wcs.crpix[1] - crpix_shift[1],
+    ]
+    return wcs
+
+
+def test_boxes_survive_a_trimmed_reference_grid(tmp_path: Path):
+    """Boxes built on one grid still land on a cube cropped to a different one.
+
+    This is the regression that dropping ``trim_linmos_fits=False`` exposed: the
+    reference image is trimmed while the cubes are not.
+    """
+    reference_wcs = _make_wcs()
+    table = _aegean_table([_default_row(0, RA0, DEC0)])
+    sky_boxes = island_sky_boxes(
+        table=table,
+        wcs=reference_wcs,
+        beam_shape=BEAM,
+        spice_options=SpiceOptions(n_beamwidths=1.0),
+        is_user_catalogue=False,
+    )
+
+    cube_wcs = _shifted_wcs((30.0, 20.0))
+    fits_path = tmp_path / "cube.fits"
+    _write_test_fits(fits_path, cube_wcs, (NY, NX))
+
+    spice_fits(fits_path=fits_path, sky_boxes=sky_boxes)
+
+    with fits.open(fits_path) as hdul:
+        data, header = hdul[0].data, hdul[0].header
+
+    # The source must still be inside the finite region of the spiced cube
+    x_pix, y_pix = skycoord_to_pixel(
+        wcs=WCS(header), coords=SkyCoord(RA0 * u.deg, DEC0 * u.deg), origin=0
+    )
+    assert np.isfinite(data[int(np.round(y_pix)), int(np.round(x_pix))])
+    assert data.shape[-2:] != (NY, NX), "The cube should have been cropped"
+
+
+def test_spice_fits_leaves_a_cube_with_no_islands_untouched(tmp_path: Path):
+    reference_wcs = _make_wcs()
+    sky_boxes = island_sky_boxes(
+        table=_aegean_table([_default_row(0, RA0, DEC0)]),
+        wcs=reference_wcs,
+        beam_shape=BEAM,
+        spice_options=SpiceOptions(n_beamwidths=1.0),
+        is_user_catalogue=False,
+    )
+
+    # A cube pointed far away from the catalogued source
+    elsewhere = _make_wcs()
+    elsewhere.wcs.crval = [RA0 + 20.0, DEC0]
+    fits_path = tmp_path / "elsewhere.fits"
+    _write_test_fits(fits_path, elsewhere, (NY, NX))
+    before = fits_path.read_bytes()
+
+    assert not any_box_overlaps(fits_path=fits_path, sky_boxes=sky_boxes)
+    assert spice_fits(fits_path=fits_path, sky_boxes=sky_boxes) == fits_path
+    assert fits_path.read_bytes() == before, "An unspiced cube must not be rewritten"
+
+
+def test_any_box_overlaps_true_for_the_reference_grid(tmp_path: Path):
+    wcs = _make_wcs()
+    sky_boxes = island_sky_boxes(
+        table=_aegean_table([_default_row(0, RA0, DEC0)]),
+        wcs=wcs,
+        beam_shape=BEAM,
+        spice_options=SpiceOptions(n_beamwidths=1.0),
+        is_user_catalogue=False,
+    )
+    fits_path = tmp_path / "on_grid.fits"
+    _write_test_fits(fits_path, wcs, (NY, NX))
+
+    assert any_box_overlaps(fits_path=fits_path, sky_boxes=sky_boxes)
+
+
+def test_spice_fits_writes_to_output_path_and_removes_the_original(tmp_path: Path):
+    wcs = _make_wcs()
+    fits_path = tmp_path / "cube.fits"
+    _write_test_fits(fits_path, wcs, (NY, NX))
+    sky_boxes = island_sky_boxes(
+        table=_aegean_table([_default_row(0, RA0, DEC0)]),
+        wcs=wcs,
+        beam_shape=BEAM,
+        spice_options=SpiceOptions(n_beamwidths=1.0),
+        is_user_catalogue=False,
+    )
+
+    output_path = tmp_path / "spice"
+    spiced = spice_fits(
+        fits_path=fits_path, sky_boxes=sky_boxes, output_path=output_path
+    )
+
+    assert spiced == output_path / "cube.fits"
+    assert spiced.exists()
+    assert not fits_path.exists(), "The unspiced cube should have been removed"
+
+    with fits.open(spiced) as hdul:
+        assert hdul[0].data.shape[-2:] != (NY, NX)
+        assert any("flint.spice" in str(card) for card in hdul[0].header["HISTORY"])
+
+
+def test_spice_fits_unoverlapped_cube_is_not_moved(tmp_path: Path):
+    wcs = _make_wcs()
+    sky_boxes = island_sky_boxes(
+        table=_aegean_table([_default_row(0, RA0, DEC0)]),
+        wcs=wcs,
+        beam_shape=BEAM,
+        spice_options=SpiceOptions(n_beamwidths=1.0),
+        is_user_catalogue=False,
+    )
+
+    elsewhere = _make_wcs()
+    elsewhere.wcs.crval = [RA0 + 20.0, DEC0]
+    fits_path = tmp_path / "elsewhere.fits"
+    _write_test_fits(fits_path, elsewhere, (NY, NX))
+
+    output_path = tmp_path / "spice"
+    result = spice_fits(
+        fits_path=fits_path, sky_boxes=sky_boxes, output_path=output_path
+    )
+
+    assert result == fits_path
+    assert fits_path.exists(), "An unspiced cube must not be deleted"
+
+
+def test_spice_fits_is_idempotent_after_a_worker_death(tmp_path: Path):
+    """A rerun must recognise the output it already wrote, not fail on the
+    input it already removed."""
+    wcs = _make_wcs()
+    fits_path = tmp_path / "cube.fits"
+    _write_test_fits(fits_path, wcs, (NY, NX))
+    sky_boxes = island_sky_boxes(
+        table=_aegean_table([_default_row(0, RA0, DEC0)]),
+        wcs=wcs,
+        beam_shape=BEAM,
+        spice_options=SpiceOptions(n_beamwidths=1.0),
+        is_user_catalogue=False,
+    )
+    output_path = tmp_path / "spice"
+
+    first = spice_fits(
+        fits_path=fits_path, sky_boxes=sky_boxes, output_path=output_path
+    )
+    first_bytes = first.read_bytes()
+
+    second = spice_fits(
+        fits_path=fits_path, sky_boxes=sky_boxes, output_path=output_path
+    )
+
+    assert second == first
+    assert second.read_bytes() == first_bytes, "The rerun must not re-crop the output"

--- a/tests/test_spice.py
+++ b/tests/test_spice.py
@@ -1,0 +1,419 @@
+"""Tests for SPICE-style cube trimming (flint.spice): catalogue -> per-island
+pixel boxes -> mask/crop-in-place. rm-lite/aegean's own science is not this
+module's responsibility -- these tests check the WCS/box geometry and the
+FITS in -> FITS out plumbing.
+"""
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+
+import astropy.units as u
+import numpy as np
+import pytest
+from astropy.coordinates import SkyCoord
+from astropy.io import fits
+from astropy.table import Table
+from astropy.wcs import WCS
+from astropy.wcs.utils import skycoord_to_pixel
+from radio_beam import Beam
+
+from flint.convol import BeamShape
+from flint.options import SpiceOptions
+from flint.spice import island_bounding_boxes, keep_mask_from_boxes, spice_fits
+
+NY = 200
+NX = 200
+RA0, DEC0 = 180.0, -45.0
+PIXEL_SCALE_ARCSEC = 1.0
+BEAM = BeamShape(bmaj_arcsec=10.0, bmin_arcsec=8.0, bpa_deg=0.0)
+
+
+def _make_wcs() -> WCS:
+    wcs = WCS(naxis=2)
+    wcs.wcs.crpix = [NX / 2, NY / 2]
+    wcs.wcs.cdelt = [-PIXEL_SCALE_ARCSEC / 3600, PIXEL_SCALE_ARCSEC / 3600]
+    wcs.wcs.crval = [RA0, DEC0]
+    wcs.wcs.ctype = ["RA---SIN", "DEC--SIN"]
+    return wcs
+
+
+def _aegean_table(rows: list[dict]) -> Table:
+    """Rows with island/ra/dec/a/b/pa/peak_flux/int_flux/local_rms -- matching
+    the built-in Aegean component table's contract exactly."""
+    return Table(rows=rows, names=list(rows[0].keys()))
+
+
+def _default_row(
+    island: int, ra: float, dec: float, a: float = 5.0, b: float = 5.0, pa: float = 0.0
+) -> dict:
+    return dict(
+        island=island,
+        ra=ra,
+        dec=dec,
+        a=a,
+        b=b,
+        pa=pa,
+        peak_flux=1.0,
+        int_flux=1.0,
+        local_rms=0.01,
+    )
+
+
+def test_component_box_centred_on_source():
+    wcs = _make_wcs()
+    table = _aegean_table([_default_row(0, RA0, DEC0)])
+    boxes = island_bounding_boxes(
+        table=table,
+        wcs=wcs,
+        image_shape=(NY, NX),
+        beam_shape=BEAM,
+        spice_options=SpiceOptions(n_beamwidths=0.0),
+        is_user_catalogue=False,
+    )
+    assert len(boxes) == 1
+    box = boxes[0]
+    x_pix, y_pix = skycoord_to_pixel(
+        wcs=wcs, coords=SkyCoord(RA0 * u.deg, DEC0 * u.deg), origin=0
+    )
+    assert box.xmin <= y_pix <= box.xmax
+    assert box.ymin <= x_pix <= box.ymax
+
+
+def test_axis_convention_ra_moves_y_dec_moves_x():
+    """The single highest-value test: RA offsets must only move ymin/ymax
+    (NAXIS1), Dec offsets must only move xmin/xmax (NAXIS2). A centred,
+    square test would not catch a transposition bug here."""
+    wcs = _make_wcs()
+    ra_offset_deg = 20.0 / 3600 / math.cos(math.radians(DEC0))
+    table = _aegean_table(
+        [_default_row(0, RA0, DEC0), _default_row(1, RA0 + ra_offset_deg, DEC0)]
+    )
+    boxes = island_bounding_boxes(
+        table=table,
+        wcs=wcs,
+        image_shape=(NY, NX),
+        beam_shape=BEAM,
+        spice_options=SpiceOptions(n_beamwidths=0.0),
+        is_user_catalogue=False,
+    )
+    b0, b1 = boxes
+    assert b0.xmin == b1.xmin and b0.xmax == b1.xmax
+    assert b0.ymin != b1.ymin and b0.ymax != b1.ymax
+
+    table = _aegean_table(
+        [_default_row(0, RA0, DEC0), _default_row(1, RA0, DEC0 + 20.0 / 3600)]
+    )
+    boxes = island_bounding_boxes(
+        table=table,
+        wcs=wcs,
+        image_shape=(NY, NX),
+        beam_shape=BEAM,
+        spice_options=SpiceOptions(n_beamwidths=0.0),
+        is_user_catalogue=False,
+    )
+    b0, b1 = boxes
+    assert b0.ymin == b1.ymin and b0.ymax == b1.ymax
+    assert b0.xmin != b1.xmin and b0.xmax != b1.xmax
+
+
+def test_islands_merge_components_sharing_island_id():
+    wcs = _make_wcs()
+    offset_deg = 10.0 / 3600
+    table = _aegean_table(
+        [
+            _default_row(0, RA0, DEC0),
+            _default_row(0, RA0, DEC0 + offset_deg),
+            _default_row(1, RA0 + 0.02, DEC0),
+        ]
+    )
+    boxes = island_bounding_boxes(
+        table=table,
+        wcs=wcs,
+        image_shape=(NY, NX),
+        beam_shape=BEAM,
+        spice_options=SpiceOptions(n_beamwidths=0.0),
+        is_user_catalogue=False,
+    )
+    assert len(boxes) == 2
+    merged = max(boxes, key=lambda b: b.xmax - b.xmin)
+    assert merged.xmax - merged.xmin > offset_deg * 3600 / PIXEL_SCALE_ARCSEC
+
+
+def test_padding_scales_linearly_with_n_beamwidths():
+    wcs = _make_wcs()
+    table = _aegean_table([_default_row(0, RA0, DEC0, a=0.0, b=0.0)])
+
+    def _box(n_beamwidths):
+        return island_bounding_boxes(
+            table=table,
+            wcs=wcs,
+            image_shape=(NY, NX),
+            beam_shape=BEAM,
+            spice_options=SpiceOptions(n_beamwidths=n_beamwidths),
+            is_user_catalogue=False,
+        )[0]
+
+    box0 = _box(0.0)
+    box2 = _box(2.0)
+    box4 = _box(4.0)
+    span0 = box0.xmax - box0.xmin
+    span2 = box2.xmax - box2.xmin
+    span4 = box4.xmax - box4.xmin
+    assert span2 > span0
+    # doubling the padding roughly doubles the extra span added beyond span0
+    assert math.isclose((span4 - span0), 2 * (span2 - span0), rel_tol=0.1)
+
+
+def test_rotated_ellipse_extent_swaps_axes():
+    wcs = _make_wcs()
+    table_pa0 = _aegean_table([_default_row(0, RA0, DEC0, a=20.0, b=5.0, pa=0.0)])
+    table_pa90 = _aegean_table([_default_row(0, RA0, DEC0, a=20.0, b=5.0, pa=90.0)])
+    opts = SpiceOptions(n_beamwidths=0.0)
+
+    box_pa0 = island_bounding_boxes(
+        table=table_pa0,
+        wcs=wcs,
+        image_shape=(NY, NX),
+        beam_shape=BEAM,
+        spice_options=opts,
+        is_user_catalogue=False,
+    )[0]
+    box_pa90 = island_bounding_boxes(
+        table=table_pa90,
+        wcs=wcs,
+        image_shape=(NY, NX),
+        beam_shape=BEAM,
+        spice_options=opts,
+        is_user_catalogue=False,
+    )[0]
+    # pa=0 -> major axis along Dec (x), pa=90 -> major axis along RA (y)
+    assert (box_pa0.xmax - box_pa0.xmin) > (box_pa0.ymax - box_pa0.ymin)
+    assert (box_pa90.ymax - box_pa90.ymin) > (box_pa90.xmax - box_pa90.xmin)
+
+
+def test_boxes_clipped_and_dropped_at_image_edge():
+    wcs = _make_wcs()
+    table = _aegean_table([_default_row(0, RA0, DEC0)])
+    boxes = island_bounding_boxes(
+        table=table,
+        wcs=wcs,
+        image_shape=(NY, NX),
+        beam_shape=BEAM,
+        spice_options=SpiceOptions(n_beamwidths=1000.0),
+        is_user_catalogue=False,
+    )
+    assert boxes[0].xmin == 0 and boxes[0].xmax == NY
+    assert boxes[0].ymin == 0 and boxes[0].ymax == NX
+
+    with pytest.raises(ValueError):
+        island_bounding_boxes(
+            table=_aegean_table([_default_row(0, RA0 + 10, DEC0)]),
+            wcs=wcs,
+            image_shape=(NY, NX),
+            beam_shape=BEAM,
+            spice_options=SpiceOptions(n_beamwidths=0.0),
+            is_user_catalogue=False,
+        )
+
+
+def test_fallback_no_island_column_and_no_shape_columns():
+    wcs = _make_wcs()
+    table = Table({"ra": [RA0], "dec": [DEC0]})
+    opts = SpiceOptions(
+        catalogue_ra_col="ra", catalogue_dec_col="dec", n_beamwidths=2.0
+    )
+    boxes = island_bounding_boxes(
+        table=table,
+        wcs=wcs,
+        image_shape=(NY, NX),
+        beam_shape=BEAM,
+        spice_options=opts,
+        is_user_catalogue=True,
+    )
+    assert len(boxes) == 1
+    pad_pix = math.ceil(2.0 * BEAM.bmaj_arcsec / PIXEL_SCALE_ARCSEC)
+    box = boxes[0]
+    assert (box.xmax - box.xmin) == 2 * pad_pix + 1
+    assert (box.ymax - box.ymin) == 2 * pad_pix + 1
+
+
+def test_keep_mask_union_area():
+    boxes = island_bounding_boxes(
+        table=_aegean_table(
+            [_default_row(0, RA0, DEC0), _default_row(1, RA0 + 0.02, DEC0)]
+        ),
+        wcs=_make_wcs(),
+        image_shape=(NY, NX),
+        beam_shape=BEAM,
+        spice_options=SpiceOptions(n_beamwidths=0.0),
+        is_user_catalogue=False,
+    )
+    mask = keep_mask_from_boxes(boxes=boxes, image_shape=(NY, NX))
+    expected = sum((b.xmax - b.xmin) * (b.ymax - b.ymin) for b in boxes)
+    assert mask.sum() == expected
+
+
+def test_deconvolved_sizes_reconvolved_larger_than_observed():
+    wcs = _make_wcs()
+    table = Table({"ra": [RA0], "dec": [DEC0], "maj": [5.0], "min": [5.0], "pa": [0.0]})
+    common_opts = dict(
+        catalogue_ra_col="ra",
+        catalogue_dec_col="dec",
+        catalogue_maj_col="maj",
+        catalogue_min_col="min",
+        catalogue_pa_col="pa",
+        n_beamwidths=0.0,
+    )
+    box_observed = island_bounding_boxes(
+        table=table,
+        wcs=wcs,
+        image_shape=(NY, NX),
+        beam_shape=BEAM,
+        spice_options=SpiceOptions(catalogue_sizes_deconvolved=False, **common_opts),
+        is_user_catalogue=True,
+    )[0]
+    box_deconvolved = island_bounding_boxes(
+        table=table,
+        wcs=wcs,
+        image_shape=(NY, NX),
+        beam_shape=BEAM,
+        spice_options=SpiceOptions(catalogue_sizes_deconvolved=True, **common_opts),
+        is_user_catalogue=True,
+    )[0]
+    assert (box_deconvolved.xmax - box_deconvolved.xmin) > (
+        box_observed.xmax - box_observed.xmin
+    )
+
+    expected = Beam(major=5 * u.arcsec, minor=5 * u.arcsec, pa=0 * u.deg).convolve(
+        Beam(
+            major=BEAM.bmaj_arcsec * u.arcsec,
+            minor=BEAM.bmin_arcsec * u.arcsec,
+            pa=BEAM.bpa_deg * u.deg,
+        )
+    )
+    expected_span = math.ceil(expected.major.to(u.arcsec).value) + 2
+    assert abs((box_deconvolved.xmax - box_deconvolved.xmin) - expected_span) <= 2
+
+
+def test_deconvolved_requires_explicit_flag():
+    wcs = _make_wcs()
+    table = Table({"ra": [RA0], "dec": [DEC0], "maj": [5.0], "min": [5.0], "pa": [0.0]})
+    opts = SpiceOptions(
+        catalogue_ra_col="ra",
+        catalogue_dec_col="dec",
+        catalogue_maj_col="maj",
+        catalogue_min_col="min",
+        catalogue_pa_col="pa",
+    )
+    with pytest.raises(ValueError):
+        island_bounding_boxes(
+            table=table,
+            wcs=wcs,
+            image_shape=(NY, NX),
+            beam_shape=BEAM,
+            spice_options=opts,
+            is_user_catalogue=True,
+        )
+
+
+def test_user_catalogue_requires_ra_dec_columns():
+    wcs = _make_wcs()
+    table = Table({"ra": [RA0], "dec": [DEC0]})
+    with pytest.raises(ValueError):
+        island_bounding_boxes(
+            table=table,
+            wcs=wcs,
+            image_shape=(NY, NX),
+            beam_shape=BEAM,
+            spice_options=SpiceOptions(),
+            is_user_catalogue=True,
+        )
+
+
+def _write_test_fits(
+    path: Path, wcs: WCS, shape: tuple[int, ...], extra_hdu: bool = False
+) -> None:
+    header = wcs.to_header()
+    header["BMAJ"] = BEAM.bmaj_arcsec / 3600
+    header["BMIN"] = BEAM.bmin_arcsec / 3600
+    header["BPA"] = BEAM.bpa_deg
+    data = np.arange(math.prod(shape), dtype=np.float32).reshape(shape)
+    hdus = [fits.PrimaryHDU(data=data, header=header)]
+    if extra_hdu:
+        hdus.append(
+            fits.BinTableHDU.from_columns(
+                [fits.Column(name="BMAJ", format="D", array=[1.0])], name="BEAMS"
+            )
+        )
+    fits.HDUList(hdus).writeto(path, overwrite=True)
+
+
+@pytest.mark.parametrize("shape", [(NY, NX), (3, 1, NY, NX)])
+def test_spice_fits_masks_crops_and_replaces(tmp_path: Path, shape):
+    wcs = _make_wcs()
+    fits_path = tmp_path / "test.fits"
+    _write_test_fits(fits_path, wcs, shape)
+
+    table = _aegean_table(
+        [_default_row(0, RA0, DEC0), _default_row(1, RA0 + 0.02, DEC0)]
+    )
+    boxes = island_bounding_boxes(
+        table=table,
+        wcs=wcs,
+        image_shape=(NY, NX),
+        beam_shape=BEAM,
+        spice_options=SpiceOptions(n_beamwidths=1.0),
+        is_user_catalogue=False,
+    )
+
+    out_path = spice_fits(fits_path=fits_path, boxes=boxes)
+    assert out_path == fits_path
+
+    with fits.open(out_path) as hdul:
+        data = hdul[0].data
+        header = hdul[0].header
+
+    expected_span_x = max(b.xmax for b in boxes) - min(b.xmin for b in boxes)
+    expected_span_y = max(b.ymax for b in boxes) - min(b.ymin for b in boxes)
+    assert data.shape[-2:] == (expected_span_x, expected_span_y)
+    assert data.shape[:-2] == tuple(shape[:-2])
+    assert np.isfinite(data).any()
+    assert not np.isfinite(data).all()
+
+    # WCS round-trip: a catalogued source must still land inside the finite region
+    out_wcs = WCS(header)
+    x_pix, y_pix = skycoord_to_pixel(
+        wcs=out_wcs, coords=SkyCoord(RA0 * u.deg, DEC0 * u.deg), origin=0
+    )
+    assert np.isfinite(data[..., int(np.round(y_pix)), int(np.round(x_pix))]).all()
+
+
+def test_spice_fits_preserves_extra_hdus(tmp_path: Path):
+    wcs = _make_wcs()
+    fits_path = tmp_path / "test.fits"
+    _write_test_fits(fits_path, wcs, (NY, NX), extra_hdu=True)
+
+    table = _aegean_table([_default_row(0, RA0, DEC0)])
+    boxes = island_bounding_boxes(
+        table=table,
+        wcs=wcs,
+        image_shape=(NY, NX),
+        beam_shape=BEAM,
+        spice_options=SpiceOptions(n_beamwidths=1.0),
+        is_user_catalogue=False,
+    )
+    spice_fits(fits_path=fits_path, boxes=boxes)
+
+    with fits.open(fits_path) as hdul:
+        assert len(hdul) == 2
+        assert hdul[1].name == "BEAMS"
+
+
+def test_spice_fits_no_boxes_raises(tmp_path: Path):
+    wcs = _make_wcs()
+    fits_path = tmp_path / "test.fits"
+    _write_test_fits(fits_path, wcs, (NY, NX))
+    with pytest.raises(ValueError):
+        spice_fits(fits_path=fits_path, boxes=[])

--- a/tests/test_wsclean.py
+++ b/tests/test_wsclean.py
@@ -616,6 +616,23 @@ def test_regex_stokes_wsclean_title():
     assert _rename_wsclean_title(name_str=name) == out_name
 
 
+def test_rename_wsclean_title_qu_joint_pol():
+    """The join_polarizations 'qu' tag should be folded into a single-letter
+    pol field per wsclean's own per-image -Q/-U suffix, for both per-channel
+    and MFS outputs."""
+    ex = "SB56289.RACS_1041+18.beam15.round1.qu-0000-Q-image.fits"
+    out_ex = "SB56289.RACS_1041+18.beam15.round1.q.0000.image.fits"
+    assert _rename_wsclean_title(name_str=ex) == out_ex
+
+    ex = "SB56289.RACS_1041+18.beam15.round1.qu-0000-U-image.fits"
+    out_ex = "SB56289.RACS_1041+18.beam15.round1.u.0000.image.fits"
+    assert _rename_wsclean_title(name_str=ex) == out_ex
+
+    ex = "SB56289.RACS_1041+18.beam15.round1.qu-MFS-Q-residual.fits"
+    out_ex = "SB56289.RACS_1041+18.beam15.round1.q.MFS.residual.fits"
+    assert _rename_wsclean_title(name_str=ex) == out_ex
+
+
 def test_combine_subbands_to_cube(tmpdir):
     """Load in example fits images to combine into a cube"""
     files = [

--- a/tests/test_wsclean.py
+++ b/tests/test_wsclean.py
@@ -856,6 +856,19 @@ def test_create_wsclean_command(ms_example):
     assert isinstance(command, WSCleanResult)
 
 
+def test_create_wsclean_command_excludes_flint_save_mfs_products(ms_example):
+    """flint_save_mfs_products is a flint-only field (like flint_name_suffix)
+    and should not leak into the generated wsclean command"""
+    wsclean_options = WSCleanOptions(flint_save_mfs_products=True)
+
+    command = create_wsclean_cmd(
+        ms_list=MS.cast(ms_example), wsclean_options=wsclean_options
+    )
+    assert isinstance(command, WSCleanResult)
+    assert "flint" not in command.cmd
+    assert "mfs" not in command.cmd.lower()
+
+
 def test_create_wsclean_command_with_list_ms(ms_example) -> None:
     """Test whether WSCleanOptions can be correctly cast to a command string
     when using a list of MS instance"""

--- a/tests/test_wsclean.py
+++ b/tests/test_wsclean.py
@@ -716,12 +716,14 @@ def test_create_wsclean_name_argument(ms_example):
 
     assert "/jack/sparrow/SB39400.RACS_0635-31.beam0.small.i" == str(name_argument_path)
 
-    wsclean_options_3 = WSCleanOptions(flint_name_suffix="pol")
-    name_argument_path = create_wsclean_name_argument(
-        wsclean_options=wsclean_options_3, ms=ms
-    )
+    # NOTE: I think that this may be a bad example of a test. I don't think that
+    # the `small` field conforms to what is considered a flint pcn.
+    # wsclean_options_3 = WSCleanOptions(flint_name_suffix="pol")
+    # name_argument_path = create_wsclean_name_argument(
+    #     wsclean_options=wsclean_options_3, ms=ms
+    # )
 
-    assert f"{parent}/SB39400.RACS_0635-31.beam0.small.i.pol" == str(name_argument_path)
+    # assert f"{parent}/SB39400.RACS_0635-31.project-pol.beam0.small.i" == str(name_argument_path)
 
 
 def test_create_wsclean_name_argument_with_list_mss(ms_example) -> None:

--- a/tests/test_wsclean.py
+++ b/tests/test_wsclean.py
@@ -1013,6 +1013,49 @@ def test_merge_image_sets():
     assert isinstance(merged.psf[0], Path)
 
 
+def test_merge_image_sets_with_source_list():
+    """Test merging image sets. The source list property of the ImageSet is not
+    a list type."""
+    source_list = get_wsclean_output_source_list_path(name_path="JackSparrow", pol="i")
+
+    image_set = get_wsclean_output_names(
+        prefix="JackSparrow", subbands=4, include_mfs=False
+    )
+    image_set = image_set.with_options(source_list=source_list)
+
+    image_set2 = get_wsclean_output_names(
+        prefix="JackSparrow", subbands=4, include_mfs=False
+    )
+    image_set2 = image_set2.with_options(source_list=source_list)
+
+    merged = merge_image_sets(image_sets=[image_set, image_set2])
+
+    assert isinstance(merged, ImageSet)
+    assert merged.prefix == "JackSparrow"
+    assert merged.source_list is not None
+    assert merged.source_list == source_list
+
+    assert merged.image is not None
+    assert len(merged.image) == 8
+    assert isinstance(merged.image[0], Path)
+
+    assert merged.dirty is not None
+    assert len(merged.dirty) == 8
+    assert isinstance(merged.dirty[0], Path)
+
+    assert merged.model is not None
+    assert len(merged.model) == 8
+    assert isinstance(merged.model[0], Path)
+
+    assert merged.residual is not None
+    assert len(merged.residual) == 8
+    assert isinstance(merged.residual[0], Path)
+
+    assert merged.psf is not None
+    assert len(merged.psf) == 8
+    assert isinstance(merged.psf[0], Path)
+
+
 def test_split_image_set():
     ms = Path("SB1234.FieldNme.beam00.round4.ms")
     i_prefix = create_imaging_name_prefix(ms, pol="i")

--- a/tests/test_wsclean.py
+++ b/tests/test_wsclean.py
@@ -616,6 +616,33 @@ def test_regex_stokes_wsclean_title():
     assert _rename_wsclean_title(name_str=name) == out_name
 
 
+@pytest.mark.parametrize(
+    "project",
+    [
+        "pol",
+        "image",
+        "dirty",
+        "model",
+        "residual",
+        "psf",
+        "MFS",
+        "i",
+        "q",
+        "jack",
+        "sparrow",
+    ],
+)
+def test_rename_wsclean_title_project_field_collision(project: str):
+    """The `project` field is a free-form token (e.g. `.project-<name>.`) that sits
+    ahead of the wsclean-appended suffix in the file name. If a project name happens
+    to collide with a reserved wsclean token (an image type, MFS, or a pol letter),
+    the wsclean suffix search must not match inside the project token instead of the
+    real trailing suffix."""
+    ex = f"SB56289.RACS_1041+18.project-{project}.beam15.round1.i-0000-image.fits"
+    out_ex = f"SB56289.RACS_1041+18.project-{project}.beam15.round1.i.0000.image.fits"
+    assert _rename_wsclean_title(name_str=ex) == out_ex
+
+
 def test_rename_wsclean_title_qu_joint_pol():
     """The join_polarizations 'qu' tag should be folded into a single-letter
     pol field per wsclean's own per-image -Q/-U suffix, for both per-channel

--- a/tests/test_wsclean.py
+++ b/tests/test_wsclean.py
@@ -387,6 +387,26 @@ def test_transpose_and_sort_channel_images() -> None:
         )
 
 
+def test_transpose_and_sort_channel_images_wsclean_raw_index() -> None:
+    """When channels are imaged individually without being grouped into a flint
+    ch<lo>-<hi> range, images only carry wsclean's own bare per-channel index
+    (e.g. ``.0000``). This must still be sortable/groupable rather than
+    raising - regression test for the "No channel range in path" crash."""
+    base = "SB56289.RACS_1041+18.beam{beam:02d}.round1.i.{idx:04d}.image.conv.fits"
+
+    def beam_list(beam: int, order: list[int]) -> list[Path]:
+        return [Path(base.format(beam=beam, idx=idx)) for idx in order]
+
+    beam_channel_images = [beam_list(0, [0, 1, 2]), beam_list(1, [2, 0, 1])]
+
+    channel_groups = transpose_and_sort_channel_images(beam_channel_images)
+
+    assert len(channel_groups) == 3
+    for idx, group in enumerate(channel_groups):
+        assert len(group) == 2
+        assert all(f".{idx:04d}.image" in str(p) for p in group)
+
+
 def test_get_cli_parser() -> None:
     """capn_crunch was throwing error over duplicated options being added to
     the argpase object. No conflicting options means the parser should just
@@ -569,6 +589,13 @@ def test_regex_rename_wsclean_title():
 
     ex = "SB39400.RACS_0635-31.beam33.i.ch109-110-i-MFS-image"
     out_ex = "SB39400.RACS_0635-31.beam33.i.ch109-110.i.MFS.image"
+    assert _rename_wsclean_title(name_str=ex) == out_ex
+
+    # wsclean's own bare per-channel index (no flint ch<lo>-<hi> range) must still
+    # be dot-converted rather than left as a stray hyphen - regression test for the
+    # negative lookbehind typo that previously left this as `i-0000-image`
+    ex = "SB56289.RACS_1041+18.beam00.round1.i-0000-image.fits"
+    out_ex = "SB56289.RACS_1041+18.beam00.round1.i.0000.image.fits"
     assert _rename_wsclean_title(name_str=ex) == out_ex
 
 

--- a/tests/test_wsclean.py
+++ b/tests/test_wsclean.py
@@ -721,9 +721,7 @@ def test_create_wsclean_name_argument(ms_example):
         wsclean_options=wsclean_options_3, ms=ms
     )
 
-    assert f"{parent}/SB39400.RACS_0635-31.beam0.small.i.pol" == str(
-        name_argument_path
-    )
+    assert f"{parent}/SB39400.RACS_0635-31.beam0.small.i.pol" == str(name_argument_path)
 
 
 def test_create_wsclean_name_argument_with_list_mss(ms_example) -> None:

--- a/tests/test_wsclean.py
+++ b/tests/test_wsclean.py
@@ -743,14 +743,14 @@ def test_create_wsclean_name_argument(ms_example):
 
     assert "/jack/sparrow/SB39400.RACS_0635-31.beam0.small.i" == str(name_argument_path)
 
-    # NOTE: I think that this may be a bad example of a test. I don't think that
-    # the `small` field conforms to what is considered a flint pcn.
-    # wsclean_options_3 = WSCleanOptions(flint_name_suffix="pol")
-    # name_argument_path = create_wsclean_name_argument(
-    #     wsclean_options=wsclean_options_3, ms=ms
-    # )
+    wsclean_options_3 = WSCleanOptions(flint_name_suffix="pol")
+    name_argument_path = create_wsclean_name_argument(
+        wsclean_options=wsclean_options_3, ms=ms
+    )
 
-    # assert f"{parent}/SB39400.RACS_0635-31.project-pol.beam0.small.i" == str(name_argument_path)
+    assert f"{parent}/SB39400.RACS_0635-31.project-pol.beam00.i" == str(
+        name_argument_path
+    )
 
 
 def test_create_wsclean_name_argument_with_list_mss(ms_example) -> None:

--- a/tests/test_wsclean.py
+++ b/tests/test_wsclean.py
@@ -692,14 +692,18 @@ def test_combine_subbands_to_cube(tmpdir):
     )
 
     new_image_set = combine_image_set_to_cube(
-        image_set=image_set, remove_original_images=False
+        image_set=image_set,
+        fitscube_options=FitsCubeOptions(remove_original_images=False),
     )
 
     assert new_image_set.prefix == image_set.prefix
     assert len(new_image_set.image) == 1
 
     with pytest.raises(TypeError):
-        _ = combine_image_set_to_cube(image_set=files, remove_original_images=False)  # type: ignore
+        _ = combine_image_set_to_cube(
+            image_set=files,  # type: ignore
+            fitscube_options=FitsCubeOptions(remove_original_images=False),
+        )
 
 
 def test_combine_subbands_to_cube2(tmpdir):
@@ -723,7 +727,8 @@ def test_combine_subbands_to_cube2(tmpdir):
     )
 
     new_image_set = combine_image_set_to_cube(
-        image_set=image_set, remove_original_images=True
+        image_set=image_set,
+        fitscube_options=FitsCubeOptions(remove_original_images=True),
     )
     assert all([not file.exists() for file in files])
     assert new_image_set.prefix == image_set.prefix

--- a/tests/test_wsclean.py
+++ b/tests/test_wsclean.py
@@ -716,6 +716,15 @@ def test_create_wsclean_name_argument(ms_example):
 
     assert "/jack/sparrow/SB39400.RACS_0635-31.beam0.small.i" == str(name_argument_path)
 
+    wsclean_options_3 = WSCleanOptions(flint_name_suffix="pol")
+    name_argument_path = create_wsclean_name_argument(
+        wsclean_options=wsclean_options_3, ms=ms
+    )
+
+    assert f"{parent}/SB39400.RACS_0635-31.beam0.small.i.pol" == str(
+        name_argument_path
+    )
+
 
 def test_create_wsclean_name_argument_with_list_mss(ms_example) -> None:
     """Ensure that the generated name argument behaves as expected.

--- a/tests/test_wsclean.py
+++ b/tests/test_wsclean.py
@@ -593,9 +593,20 @@ def test_regex_rename_wsclean_title():
 
     # wsclean's own bare per-channel index (no flint ch<lo>-<hi> range) must still
     # be dot-converted rather than left as a stray hyphen - regression test for the
-    # negative lookbehind typo that previously left this as `i-0000-image`
+    # negative lookbehind typo that previously left this as `i-0000-image`. It is
+    # also reformatted into flint's ch<lo>-<hi> range so it parses back out as a
+    # proper channel_range rather than an ambiguous bare index.
     ex = "SB56289.RACS_1041+18.beam00.round1.i-0000-image.fits"
-    out_ex = "SB56289.RACS_1041+18.beam00.round1.i.0000.image.fits"
+    out_ex = "SB56289.RACS_1041+18.beam00.round1.i.ch0000-0001.image.fits"
+    assert _rename_wsclean_title(name_str=ex) == out_ex
+
+
+def test_regex_rename_wsclean_title_timestep():
+    """wsclean's own `-t00005` timestep suffix (from interval-based imaging) must
+    be folded into flint's scan<lo>-<hi> range convention, not left as a bare
+    index or mislabelled as a multiscale term."""
+    ex = "SB56289.RACS_1041+18.beam00.round1.i-0000-t00005-image.fits"
+    out_ex = "SB56289.RACS_1041+18.beam00.round1.i.ch0000-0001.scan0005-0006.image.fits"
     assert _rename_wsclean_title(name_str=ex) == out_ex
 
 
@@ -639,7 +650,7 @@ def test_rename_wsclean_title_project_field_collision(project: str):
     the wsclean suffix search must not match inside the project token instead of the
     real trailing suffix."""
     ex = f"SB56289.RACS_1041+18.project-{project}.beam15.round1.i-0000-image.fits"
-    out_ex = f"SB56289.RACS_1041+18.project-{project}.beam15.round1.i.0000.image.fits"
+    out_ex = f"SB56289.RACS_1041+18.project-{project}.beam15.round1.i.ch0000-0001.image.fits"
     assert _rename_wsclean_title(name_str=ex) == out_ex
 
 
@@ -648,11 +659,11 @@ def test_rename_wsclean_title_qu_joint_pol():
     pol field per wsclean's own per-image -Q/-U suffix, for both per-channel
     and MFS outputs."""
     ex = "SB56289.RACS_1041+18.beam15.round1.qu-0000-Q-image.fits"
-    out_ex = "SB56289.RACS_1041+18.beam15.round1.q.0000.image.fits"
+    out_ex = "SB56289.RACS_1041+18.beam15.round1.q.ch0000-0001.image.fits"
     assert _rename_wsclean_title(name_str=ex) == out_ex
 
     ex = "SB56289.RACS_1041+18.beam15.round1.qu-0000-U-image.fits"
-    out_ex = "SB56289.RACS_1041+18.beam15.round1.u.0000.image.fits"
+    out_ex = "SB56289.RACS_1041+18.beam15.round1.u.ch0000-0001.image.fits"
     assert _rename_wsclean_title(name_str=ex) == out_ex
 
     ex = "SB56289.RACS_1041+18.beam15.round1.qu-MFS-Q-residual.fits"

--- a/tests/test_wsclean.py
+++ b/tests/test_wsclean.py
@@ -650,7 +650,9 @@ def test_rename_wsclean_title_project_field_collision(project: str):
     the wsclean suffix search must not match inside the project token instead of the
     real trailing suffix."""
     ex = f"SB56289.RACS_1041+18.project-{project}.beam15.round1.i-0000-image.fits"
-    out_ex = f"SB56289.RACS_1041+18.project-{project}.beam15.round1.i.ch0000-0001.image.fits"
+    out_ex = (
+        f"SB56289.RACS_1041+18.project-{project}.beam15.round1.i.ch0000-0001.image.fits"
+    )
     assert _rename_wsclean_title(name_str=ex) == out_ex
 
 

--- a/tests/test_wsclean.py
+++ b/tests/test_wsclean.py
@@ -7,11 +7,13 @@ import shutil
 from pathlib import Path
 from typing import Any
 
+import astropy.units as u
 import numpy as np
 import pytest
 from astropy.io import fits
 from fitscube.bounding_box import get_common_bounding_box
 from fitscube.extract import find_target_axis
+from radio_beam import Beams
 
 from flint.exceptions import (
     AttemptRerunException,
@@ -49,11 +51,16 @@ from flint.utils import get_packaged_resource_path
 
 
 def _write_channel_image(
-    path: Path, channel: int, shape: tuple[int, int], nan_border: int = 0
+    path: Path,
+    channel: int,
+    shape: tuple[int, int],
+    nan_border: int = 0,
+    bmaj: float = 0.01,
 ) -> Path:
     """A wsclean-like single channel image, with each pixel uniquely valued so
     that any scrambling of the data is detectable. A ``nan_border`` pixels wide
-    border of NaNs may be added to exercise bounding-box trimming."""
+    border of NaNs may be added to exercise bounding-box trimming. Vary ``bmaj``
+    across channels to have the cube carry a beam table."""
     ny, nx = shape
     data = (
         channel * 1000.0
@@ -68,7 +75,7 @@ def _write_channel_image(
     header = fits.Header(
         {
             "BUNIT": "JY/BEAM",
-            "BMAJ": 0.01,
+            "BMAJ": bmaj,
             "BMIN": 0.01,
             "BPA": 0.0,
             "CTYPE1": "RA---SIN",
@@ -354,6 +361,65 @@ def test_split_cube_into_planes(tmpdir) -> None:
 
     with pytest.raises(NamingException):
         split_cube_into_planes(cube=Path(shutil.copy(cube, Path(tmpdir) / "bad.fits")))
+
+
+def _write_varying_beam_cube(tmp_path: Path, channels: int) -> Path:
+    """A cube whose channels each have their own beam, so it carries a beam table"""
+    images = [
+        _write_channel_image(
+            tmp_path / f"SB1234.RACS_0000-00.beam00.round1-{channel:04d}-image.fits",
+            channel=channel,
+            shape=(6, 6),
+            bmaj=0.01 + channel * 1e-4,
+        )
+        for channel in range(channels)
+    ]
+    return combine_images_to_cube(
+        images=images,
+        prefix=f"{tmp_path}/SB1234.RACS_0000-00.beam00.round1",
+        mode="image",
+        fitscube_options=FitsCubeOptions(
+            invalidate_zeros=False, remove_original_images=False
+        ),
+    )
+
+
+def test_split_cube_into_planes_carries_channel_beams(tmp_path) -> None:
+    """A plane takes its own channel's beam out of the cube's beam table, and
+    stops claiming to carry a table of its own"""
+    channels = 5
+    cube = _write_varying_beam_cube(tmp_path=tmp_path, channels=channels)
+
+    with fits.open(cube) as open_fits:
+        assert open_fits[0].header["CASAMBM"], "Cube should carry a beam table"
+        beams = Beams.from_fits_bintable(open_fits["BEAMS"])
+
+    planes = split_cube_into_planes(cube=cube, output_path=tmp_path / "planes")
+
+    assert len(planes) == channels
+    for channel, plane in enumerate(planes):
+        header = fits.getheader(plane)
+        assert "CASAMBM" not in header
+        assert header["BMAJ"] == pytest.approx(beams[channel].major.to(u.deg).value)
+        assert header["BMIN"] == pytest.approx(beams[channel].minor.to(u.deg).value)
+        assert header["BPA"] == pytest.approx(beams[channel].pa.to(u.deg).value)
+
+
+def test_split_cube_into_planes_threaded_matches_serial(tmp_path) -> None:
+    """Spreading the plane writes over threads must not change what is written"""
+    cube = _write_varying_beam_cube(tmp_path=tmp_path, channels=5)
+
+    serial = split_cube_into_planes(
+        cube=cube, output_path=tmp_path / "serial", num_workers=1
+    )
+    threaded = split_cube_into_planes(
+        cube=cube, output_path=tmp_path / "threaded", num_workers=4
+    )
+
+    assert [plane.name for plane in serial] == [plane.name for plane in threaded]
+    for one, many in zip(serial, threaded):
+        assert np.array_equal(fits.getdata(one), fits.getdata(many))
+        assert fits.getheader(one).tostring() == fits.getheader(many).tostring()
 
 
 def test_transpose_and_sort_channel_images() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -275,8 +275,8 @@ requires-dist = [
     { name = "racs-tools", specifier = ">=4.2.1" },
     { name = "radio-beam", specifier = ">=0.3.4" },
     { name = "reproject" },
-    { name = "rm-lite", marker = "extra == 'all'", specifier = "==2026.8.3" },
-    { name = "rm-lite", marker = "extra == 'rmsynth'", specifier = "==2026.8.3" },
+    { name = "rm-lite", marker = "extra == 'all'", specifier = "==2026.8.4" },
+    { name = "rm-lite", marker = "extra == 'rmsynth'", specifier = "==2026.8.4" },
     { name = "ruff", marker = "extra == 'all'" },
     { name = "ruff", marker = "extra == 'dev'" },
     { name = "scikit-image" },
@@ -3490,7 +3490,7 @@ wheels = [
 
 [[package]]
 name = "rm-lite"
-version = "2026.8.3"
+version = "2026.8.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "astropy" },
@@ -3502,9 +3502,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "zarr" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9b/81/f7d9c06e603f86013d07caeaa83efdd6fe825bd35832b2fe817d3d17ec3b/rm_lite-2026.8.3.tar.gz", hash = "sha256:9a1b5c04999d44e12fd5f6f34afad88e8d8e08294e57b91ca5ac68cbb3a624a7", size = 418615, upload-time = "2026-08-24T22:49:05.563Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/71/4c/f8058080a16cf08e50b5d53d7bd209a458e436278e2854860b913c035b5a/rm_lite-2026.8.4.tar.gz", hash = "sha256:05b9b3a2e40e25eed5392861e2866e4b9946807ee0cab906faccacbfb7d92b49", size = 421985, upload-time = "2026-08-28T07:27:12.107Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/64/25/481efd0856453363dec50a56eea1e88b9297541f4a080aad40fd818226f6/rm_lite-2026.8.3-py3-none-any.whl", hash = "sha256:ec7517eb6c88754c7a63a3c0b4f69fb39ee21703624542370c9416450de934c0", size = 102638, upload-time = "2026-08-24T22:49:03.684Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/4d/2f79c7721eccf41b1ff2694d362c9097f375c1db731c78cbda9de0630fd8/rm_lite-2026.8.4-py3-none-any.whl", hash = "sha256:02a12f1c406af244574d96008348ec80b2c46b796a10510b9ab594b624ae0dae", size = 105928, upload-time = "2026-08-28T07:27:10.656Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -242,7 +242,7 @@ requires-dist = [
     { name = "configargparse", specifier = ">=1.7" },
     { name = "crystalball", specifier = ">=0.4.3" },
     { name = "dask-jobqueue" },
-    { name = "fitscube", extras = ["pgzip"], specifier = ">=2.5.1" },
+    { name = "fitscube", extras = ["pgzip"], specifier = ">=2.6" },
     { name = "fixms", marker = "extra == 'all'", specifier = ">=0.4.0" },
     { name = "fixms", marker = "extra == 'casa'", specifier = ">=0.4.0" },
     { name = "furo", marker = "extra == 'all'" },
@@ -275,8 +275,8 @@ requires-dist = [
     { name = "racs-tools", specifier = ">=4.2.1" },
     { name = "radio-beam", specifier = ">=0.3.4" },
     { name = "reproject" },
-    { name = "rm-lite", marker = "extra == 'all'", specifier = "==2026.8.6" },
-    { name = "rm-lite", marker = "extra == 'rmsynth'", specifier = "==2026.8.6" },
+    { name = "rm-lite", marker = "extra == 'all'", specifier = "==2026.8.7" },
+    { name = "rm-lite", marker = "extra == 'rmsynth'", specifier = "==2026.8.7" },
     { name = "ruff", marker = "extra == 'all'" },
     { name = "ruff", marker = "extra == 'dev'" },
     { name = "scikit-image" },
@@ -1253,7 +1253,7 @@ wheels = [
 
 [[package]]
 name = "fitscube"
-version = "2.5.1"
+version = "2.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "astropy" },
@@ -1261,9 +1261,9 @@ dependencies = [
     { name = "radio-beam" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8c/62/872a1ed7f41d46e3a27c7b0a5b290e3c18b7a98f32cffecd541aca590ba1/fitscube-2.5.1.tar.gz", hash = "sha256:8ad83bd5a02f9dda108785fcb00a5066ea582cfe81937067d47f52be673c56d0", size = 791105, upload-time = "2026-08-15T07:52:57.53Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e6/82/097d1f2c9441b07f91a75d57ddbe62a32dde8dba11f93968395c349523af/fitscube-2.6.0.tar.gz", hash = "sha256:d073194681e93a0b3069d7e430cf75f0c21882fefc5d54ef631c7c4654109c77", size = 794576, upload-time = "2026-08-31T08:06:08.977Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/35/5d/ec7c95e81adacce2575c3374caa019bbf4e7cda26445345825b2f16f6f30/fitscube-2.5.1-py3-none-any.whl", hash = "sha256:b70992229de4faaf221f7c76713b1fa6a6bdda432bd3d69d5951acdedd93d02d", size = 29316, upload-time = "2026-08-15T07:52:55.917Z" },
+    { url = "https://files.pythonhosted.org/packages/50/a3/010b81e2cca21ea4f362903eb181082aca6cb788597ef0441eea1f9cea5a/fitscube-2.6.0-py3-none-any.whl", hash = "sha256:6094a8af7dc52a0250549e67030398d5ce52e8d38a2a0cc0db0306b05fc33aac", size = 31194, upload-time = "2026-08-31T08:06:07.446Z" },
 ]
 
 [package.optional-dependencies]
@@ -3490,7 +3490,7 @@ wheels = [
 
 [[package]]
 name = "rm-lite"
-version = "2026.8.6"
+version = "2026.8.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "astropy" },
@@ -3502,9 +3502,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "zarr" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/dd/5f/da48831db8f482420cea4216b56d1cba0c3663e08dc4ae90cfc1a01541db/rm_lite-2026.8.6.tar.gz", hash = "sha256:a64af62d157bcae4a3fc7829ab249c86aa2e4b3e3d940f64f574ccb2be117076", size = 439671, upload-time = "2026-08-30T02:17:55.475Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/9f/c3d7d0260ae064d4e810b476aa4b7ce56298d0457617dc3b544a2a9611ab/rm_lite-2026.8.7.tar.gz", hash = "sha256:155519c3e4063bfa733c7da7f383001c9e47f6cdc5a51d9f33a6b8a06e60f68f", size = 447821, upload-time = "2026-08-31T02:52:55.402Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a4/9e/a9d6ab3800b931ca139987702d7f2ccbe69583dffb6fb94b843964fd76aa/rm_lite-2026.8.6-py3-none-any.whl", hash = "sha256:eca10f1a67e07c34830dd64a00fcb0dd2ec22df801bcff445b902d2434e81c57", size = 114375, upload-time = "2026-08-30T02:17:53.605Z" },
+    { url = "https://files.pythonhosted.org/packages/44/1d/92c36880b4b3deb64710951fd2232a586010f872c9b80363e4d994fe88fe/rm_lite-2026.8.7-py3-none-any.whl", hash = "sha256:bf1760d5ebaeead154fb5b24cd600e18fe5c742a7044411469b15d8316002e75", size = 117925, upload-time = "2026-08-31T02:52:54.139Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -217,7 +217,7 @@ requires-dist = [
     { name = "configargparse", specifier = ">=1.7" },
     { name = "crystalball", specifier = ">=0.4.3" },
     { name = "dask-jobqueue" },
-    { name = "fitscube", extras = ["pgzip"], specifier = ">=2.5.0" },
+    { name = "fitscube", extras = ["pgzip"], specifier = ">=2.5.1" },
     { name = "fixms", marker = "extra == 'casa'", specifier = ">=0.4.0" },
     { name = "furo", marker = "extra == 'dev'" },
     { name = "isort", marker = "extra == 'dev'" },
@@ -1191,7 +1191,7 @@ wheels = [
 
 [[package]]
 name = "fitscube"
-version = "2.5.0"
+version = "2.5.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "astropy" },
@@ -1199,9 +1199,9 @@ dependencies = [
     { name = "radio-beam" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/cc/a9/6dcae85ded6bfce8fad7955db9c5586053564086102cc718f88190090853/fitscube-2.5.0.tar.gz", hash = "sha256:f7627f131ecea0869939dbeb1d93321f295771b8426ae357e9e0a856f12040d1", size = 790605, upload-time = "2026-08-06T13:20:56.961Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/62/872a1ed7f41d46e3a27c7b0a5b290e3c18b7a98f32cffecd541aca590ba1/fitscube-2.5.1.tar.gz", hash = "sha256:8ad83bd5a02f9dda108785fcb00a5066ea582cfe81937067d47f52be673c56d0", size = 791105, upload-time = "2026-08-15T07:52:57.53Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/15/9e/5a2b8dd374a78e9214dea4a5391838c78c9e61eee5843f082931ee834208/fitscube-2.5.0-py3-none-any.whl", hash = "sha256:c9a2b0db147e4ad7b3301a3046c4831a991c750d92de1469d3126b9669a50a8b", size = 29255, upload-time = "2026-08-06T13:20:55.396Z" },
+    { url = "https://files.pythonhosted.org/packages/35/5d/ec7c95e81adacce2575c3374caa019bbf4e7cda26445345825b2f16f6f30/fitscube-2.5.1-py3-none-any.whl", hash = "sha256:b70992229de4faaf221f7c76713b1fa6a6bdda432bd3d69d5951acdedd93d02d", size = 29316, upload-time = "2026-08-15T07:52:55.917Z" },
 ]
 
 [package.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -275,8 +275,8 @@ requires-dist = [
     { name = "racs-tools", specifier = ">=4.2.1" },
     { name = "radio-beam", specifier = ">=0.3.4" },
     { name = "reproject" },
-    { name = "rm-lite", marker = "extra == 'all'", specifier = "==2026.8.5" },
-    { name = "rm-lite", marker = "extra == 'rmsynth'", specifier = "==2026.8.5" },
+    { name = "rm-lite", marker = "extra == 'all'", specifier = "==2026.8.6" },
+    { name = "rm-lite", marker = "extra == 'rmsynth'", specifier = "==2026.8.6" },
     { name = "ruff", marker = "extra == 'all'" },
     { name = "ruff", marker = "extra == 'dev'" },
     { name = "scikit-image" },
@@ -3490,7 +3490,7 @@ wheels = [
 
 [[package]]
 name = "rm-lite"
-version = "2026.8.5"
+version = "2026.8.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "astropy" },
@@ -3502,9 +3502,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "zarr" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4c/db/dd4530ba42d1a05b1c09cc87a16c7a34d783a6c32e4d3e07376f6fb2164d/rm_lite-2026.8.5.tar.gz", hash = "sha256:af91fa52e2da0db5fcf498cd953dc0ce660f8c353dc934305dcd86b1f52e45f7", size = 437936, upload-time = "2026-08-29T13:37:14.552Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/dd/5f/da48831db8f482420cea4216b56d1cba0c3663e08dc4ae90cfc1a01541db/rm_lite-2026.8.6.tar.gz", hash = "sha256:a64af62d157bcae4a3fc7829ab249c86aa2e4b3e3d940f64f574ccb2be117076", size = 439671, upload-time = "2026-08-30T02:17:55.475Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/da/4f/96a4b17f5d6b59b54c7604349e7777c11afafa0084344ad7d14b6c4498aa/rm_lite-2026.8.5-py3-none-any.whl", hash = "sha256:7b6675d1ddc7a5f194d97885591e1d942c60cb919ead58023a2812c481af9d92", size = 113418, upload-time = "2026-08-29T13:37:13.162Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/9e/a9d6ab3800b931ca139987702d7f2ccbe69583dffb6fb94b843964fd76aa/rm_lite-2026.8.6-py3-none-any.whl", hash = "sha256:eca10f1a67e07c34830dd64a00fcb0dd2ec22df801bcff445b902d2434e81c57", size = 114375, upload-time = "2026-08-30T02:17:53.605Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -275,8 +275,8 @@ requires-dist = [
     { name = "racs-tools", specifier = ">=4.2.1" },
     { name = "radio-beam", specifier = ">=0.3.4" },
     { name = "reproject" },
-    { name = "rm-lite", marker = "extra == 'all'", specifier = "==2026.8.4" },
-    { name = "rm-lite", marker = "extra == 'rmsynth'", specifier = "==2026.8.4" },
+    { name = "rm-lite", marker = "extra == 'all'", specifier = "==2026.8.5" },
+    { name = "rm-lite", marker = "extra == 'rmsynth'", specifier = "==2026.8.5" },
     { name = "ruff", marker = "extra == 'all'" },
     { name = "ruff", marker = "extra == 'dev'" },
     { name = "scikit-image" },
@@ -3490,7 +3490,7 @@ wheels = [
 
 [[package]]
 name = "rm-lite"
-version = "2026.8.4"
+version = "2026.8.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "astropy" },
@@ -3502,9 +3502,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "zarr" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/71/4c/f8058080a16cf08e50b5d53d7bd209a458e436278e2854860b913c035b5a/rm_lite-2026.8.4.tar.gz", hash = "sha256:05b9b3a2e40e25eed5392861e2866e4b9946807ee0cab906faccacbfb7d92b49", size = 421985, upload-time = "2026-08-28T07:27:12.107Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4c/db/dd4530ba42d1a05b1c09cc87a16c7a34d783a6c32e4d3e07376f6fb2164d/rm_lite-2026.8.5.tar.gz", hash = "sha256:af91fa52e2da0db5fcf498cd953dc0ce660f8c353dc934305dcd86b1f52e45f7", size = 437936, upload-time = "2026-08-29T13:37:14.552Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d8/4d/2f79c7721eccf41b1ff2694d362c9097f375c1db731c78cbda9de0630fd8/rm_lite-2026.8.4-py3-none-any.whl", hash = "sha256:02a12f1c406af244574d96008348ec80b2c46b796a10510b9ab594b624ae0dae", size = 105928, upload-time = "2026-08-28T07:27:10.656Z" },
+    { url = "https://files.pythonhosted.org/packages/da/4f/96a4b17f5d6b59b54c7604349e7777c11afafa0084344ad7d14b6c4498aa/rm_lite-2026.8.5-py3-none-any.whl", hash = "sha256:7b6675d1ddc7a5f194d97885591e1d942c60cb919ead58023a2812c481af9d92", size = 113418, upload-time = "2026-08-29T13:37:13.162Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -183,6 +183,28 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+all = [
+    { name = "fixms" },
+    { name = "furo" },
+    { name = "isort" },
+    { name = "mypy" },
+    { name = "myst-parser" },
+    { name = "pre-commit" },
+    { name = "pytest" },
+    { name = "pytest-cov" },
+    { name = "pytest-rerunfailures" },
+    { name = "pytest-xdist" },
+    { name = "python-casacore" },
+    { name = "rm-lite" },
+    { name = "ruff" },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "sphinx-argparse" },
+    { name = "sphinx-autoapi" },
+    { name = "sphinx-autodoc-typehints", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "sphinx-autodoc-typehints", version = "3.9.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "sphinx-copybutton" },
+]
 casa = [
     { name = "fixms" },
     { name = "python-casacore" },
@@ -221,39 +243,57 @@ requires-dist = [
     { name = "crystalball", specifier = ">=0.4.3" },
     { name = "dask-jobqueue" },
     { name = "fitscube", extras = ["pgzip"], specifier = ">=2.5.1" },
+    { name = "fixms", marker = "extra == 'all'", specifier = ">=0.4.0" },
     { name = "fixms", marker = "extra == 'casa'", specifier = ">=0.4.0" },
+    { name = "furo", marker = "extra == 'all'" },
     { name = "furo", marker = "extra == 'dev'" },
+    { name = "isort", marker = "extra == 'all'" },
     { name = "isort", marker = "extra == 'dev'" },
     { name = "jolly-roger", specifier = ">=0.10.1" },
     { name = "matplotlib" },
+    { name = "mypy", marker = "extra == 'all'" },
     { name = "mypy", marker = "extra == 'dev'" },
+    { name = "myst-parser", marker = "extra == 'all'" },
     { name = "myst-parser", marker = "extra == 'dev'" },
     { name = "numpy", specifier = ">=2.0.0" },
     { name = "pandas" },
+    { name = "pre-commit", marker = "extra == 'all'" },
     { name = "pre-commit", marker = "extra == 'dev'" },
     { name = "prefect", specifier = ">=3.4.7" },
     { name = "prefect-dask", specifier = ">=0.3.7" },
     { name = "pydantic", specifier = ">=2" },
+    { name = "pytest", marker = "extra == 'all'" },
     { name = "pytest", marker = "extra == 'dev'" },
+    { name = "pytest-cov", marker = "extra == 'all'" },
     { name = "pytest-cov", marker = "extra == 'dev'" },
+    { name = "pytest-rerunfailures", marker = "extra == 'all'" },
     { name = "pytest-rerunfailures", marker = "extra == 'dev'" },
+    { name = "pytest-xdist", marker = "extra == 'all'" },
     { name = "pytest-xdist", marker = "extra == 'dev'" },
+    { name = "python-casacore", marker = "extra == 'all'", specifier = ">=3.6.0" },
     { name = "python-casacore", marker = "extra == 'casa'", specifier = ">=3.6.0" },
     { name = "racs-tools", specifier = ">=4.2.1" },
     { name = "radio-beam", specifier = ">=0.3.4" },
     { name = "reproject" },
-    { name = "rm-lite", marker = "extra == 'rmsynth'", specifier = ">=2026.7.7" },
+    { name = "rm-lite", marker = "extra == 'all'", specifier = "==2026.8.3" },
+    { name = "rm-lite", marker = "extra == 'rmsynth'", specifier = "==2026.8.3" },
+    { name = "ruff", marker = "extra == 'all'" },
     { name = "ruff", marker = "extra == 'dev'" },
     { name = "scikit-image" },
     { name = "scipy" },
+    { name = "sphinx", marker = "extra == 'all'" },
     { name = "sphinx", marker = "extra == 'dev'" },
+    { name = "sphinx-argparse", marker = "extra == 'all'", specifier = ">=0.6.0" },
     { name = "sphinx-argparse", marker = "extra == 'dev'", specifier = ">=0.6.0" },
+    { name = "sphinx-autoapi", marker = "extra == 'all'" },
     { name = "sphinx-autoapi", marker = "extra == 'dev'" },
+    { name = "sphinx-autodoc-typehints", marker = "extra == 'all'" },
     { name = "sphinx-autodoc-typehints", marker = "extra == 'dev'" },
+    { name = "sphinx-copybutton", marker = "extra == 'all'" },
     { name = "sphinx-copybutton", marker = "extra == 'dev'" },
     { name = "spython", specifier = ">=0.3.1" },
 ]
-provides-extras = ["casa", "dev", "rmsynth"]
+provides-extras = ["all", "casa", "dev", "rmsynth"]
 
 [[package]]
 name = "asteval"
@@ -452,50 +492,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b0/1c6a16426d389813b48d95e26898aff79abbde42ad353958ad95cc8c9b21/beautifulsoup4-4.14.3.tar.gz", hash = "sha256:6292b1c5186d356bba669ef9f7f051757099565ad9ada5dd630bd9de5fa7fb86", size = 627737, upload-time = "2025-11-30T15:08:26.084Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl", hash = "sha256:0918bfe44902e6ad8d57732ba310582e98da931428d231a5ecb9e7c703a735bb", size = 107721, upload-time = "2025-11-30T15:08:24.087Z" },
-]
-
-[[package]]
-name = "bilby"
-version = "2.8.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "attrs" },
-    { name = "bilby-cython" },
-    { name = "corner" },
-    { name = "dill" },
-    { name = "dynesty" },
-    { name = "emcee" },
-    { name = "h5py" },
-    { name = "matplotlib" },
-    { name = "numpy" },
-    { name = "pandas" },
-    { name = "scipy" },
-    { name = "tqdm" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/3e/d0/f2e561f021315a653d38ba91b31a4ebf7623a591b4f6876aadc8be521f0c/bilby-2.8.1.tar.gz", hash = "sha256:12659775bb5c45b95c17fbd4488e226c91d198f5c76566f66a3a9df490785aef", size = 15876505, upload-time = "2026-06-29T15:07:55.589Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/64/18/70347ffc8f6c1039f535858495f62edb077178a031820b0cc468addf5120/bilby-2.8.1-py3-none-any.whl", hash = "sha256:38206ad49ff75feb288e177199a0f057d6b8ac602192b2b9f7d900d434c2e603", size = 2293391, upload-time = "2026-06-29T15:07:53.63Z" },
-]
-
-[[package]]
-name = "bilby-cython"
-version = "0.5.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "numpy" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5f/60/3a384798c7df2462343028d37e6adb9079eb0b155a50736b88bdd668d825/bilby_cython-0.5.4.tar.gz", hash = "sha256:34af013f232187f25308cbf25f096e8c2be1662da78c421b85ecceba4fb5358d", size = 255948, upload-time = "2026-04-02T14:44:25.732Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ca/18/448999d244b985582af77471f2bb1a0399b554ffa4bfe3554a813dd026c6/bilby_cython-0.5.4-cp311-cp311-macosx_13_0_x86_64.whl", hash = "sha256:a5ee0659d7896e91024650dfc77e304f5db43e307e452c91caa6864e4062e426", size = 364314, upload-time = "2026-04-02T14:44:00.504Z" },
-    { url = "https://files.pythonhosted.org/packages/66/ff/d7d033a7578c2b6030c86f2706bf1af051731a0b6aedd59475c18542f2c4/bilby_cython-0.5.4-cp311-cp311-macosx_15_0_arm64.whl", hash = "sha256:2526574d12ca7807bc5b7f19cf88829fc1b126a980de5e1969c027c1f11ccb34", size = 362569, upload-time = "2026-04-02T14:44:01.971Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/99/4b8ed531febe5aca745b5522d19d5d2e18744e4cb0d9cd83c0eaad464fd5/bilby_cython-0.5.4-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d2aff524c0603111d55b9b24215bb708acad53adaa177493862eaaa10ce39b85", size = 1036057, upload-time = "2026-04-02T14:44:03.219Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/32/960859bf3552f3d0e303924d1ce8b02470c6dbf683d985f7377fde41681c/bilby_cython-0.5.4-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:04945e17d0a9c31f896bec88d4a1bfd8951e4337c2cfc22ef227dd9ece383078", size = 357283, upload-time = "2026-04-02T14:44:04.795Z" },
-    { url = "https://files.pythonhosted.org/packages/57/2f/7bc651e30d1e9cea5ee4c35b92641c474d652471be49048e38c6512efbfb/bilby_cython-0.5.4-cp312-cp312-macosx_13_0_x86_64.whl", hash = "sha256:a059c40b5794f094a17c36e3034e5b84a8e92cfed965533577af576beaaff133", size = 363269, upload-time = "2026-04-02T14:44:05.978Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/0a/1584b9f60741fd045b9fa57576a524256f31ac9e00162b2c5355f7ef2c80/bilby_cython-0.5.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1599c1ed9f0f169370ab85a975c130447784c998f45f4a63418e0f677461d22f", size = 1068099, upload-time = "2026-04-02T14:44:07.201Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/ee/c371f1fa5963be4458acbeb6ac15d32fd07092234be871357069baad9535/bilby_cython-0.5.4-cp313-cp313-macosx_13_0_x86_64.whl", hash = "sha256:c9dd36128bfc48aacca3f0191babdbdf4ba17acc479c7bb2e24f5ba2d2a7f4c2", size = 362668, upload-time = "2026-04-02T14:44:08.464Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/78/956c0eff488ec23402bcd0ff169b72909e43cb4bc1b0a9d9f1a7cc195cc7/bilby_cython-0.5.4-cp313-cp313-macosx_15_0_arm64.whl", hash = "sha256:799ccc984e0eb88a20127dc0218866eb22517a1b9e71fc737a89cfc868a8f13d", size = 360622, upload-time = "2026-04-02T14:44:09.616Z" },
-    { url = "https://files.pythonhosted.org/packages/40/ff/062a65c322e0dd4225a78627243b2925ebc902d5a6282871506d1d6767fd/bilby_cython-0.5.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b28ff13b884eb727d91276d52220707162e4157258b15477a283c8936b156679", size = 1035074, upload-time = "2026-04-02T14:44:11.125Z" },
-    { url = "https://files.pythonhosted.org/packages/01/81/0b0b5558b2e86642fe6e980898745f0b0471ff895ce82e32800f3b23acdb/bilby_cython-0.5.4-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:92b7f985cf102d043d6ead018327f58e6bffc1166f2077dc4e2253cfd67a64c4", size = 1062321, upload-time = "2026-04-02T14:44:12.62Z" },
 ]
 
 [[package]]
@@ -824,18 +820,6 @@ wheels = [
 ]
 
 [[package]]
-name = "corner"
-version = "2.3.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "matplotlib" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/4f/06/0d045530fa994ab450f6a98b7ad9f74c90a8abf5271d3690f60d1aa933d8/corner-2.3.0.tar.gz", hash = "sha256:685ecb1e778809b78c6783f4a4691d023bbd9f781c9efda683c2b793878b561c", size = 6089474, upload-time = "2026-07-05T17:56:05.355Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d6/cb/17a130e548ee1777f2a66e09240c531a9bf79454add7ef1198fe1e41c412/corner-2.3.0-py3-none-any.whl", hash = "sha256:f93f0a4d77ff6852d6ddc80a6a99038117be64e3b5b49d96a82c9f5974cce126", size = 16954, upload-time = "2026-07-05T17:56:03.827Z" },
-]
-
-[[package]]
 name = "coverage"
 version = "7.13.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1116,18 +1100,6 @@ wheels = [
 ]
 
 [[package]]
-name = "deprecation"
-version = "2.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "packaging" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5a/d3/8ae2869247df154b64c1884d7346d412fed0c49df84db635aab2d1c40e62/deprecation-2.1.0.tar.gz", hash = "sha256:72b3bde64e5d778694b0cf68178aed03d15e15477116add3fb773e581f9518ff", size = 173788, upload-time = "2020-04-20T14:23:38.738Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/02/c3/253a89ee03fc9b9682f1541728eb66db7db22148cd94f89ab22528cd1e1b/deprecation-2.1.0-py2.py3-none-any.whl", hash = "sha256:a10811591210e1fb0e768a8c25517cabeabcba6f0bf96564f8ff45189f90b14a", size = 11178, upload-time = "2020-04-20T14:23:36.581Z" },
-]
-
-[[package]]
 name = "dill"
 version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1213,32 +1185,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/25/71/80cc718ff6d7abfbabacb1f57aaa42e9c1552bfdd01e64ddd704e4a03638/donfig-0.8.1.post1.tar.gz", hash = "sha256:3bef3413a4c1c601b585e8d297256d0c1470ea012afa6e8461dc28bfb7c23f52", size = 19506, upload-time = "2024-05-23T14:14:31.513Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/d5/c5db1ea3394c6e1732fb3286b3bd878b59507a8f77d32a2cebda7d7b7cd4/donfig-0.8.1.post1-py3-none-any.whl", hash = "sha256:2a3175ce74a06109ff9307d90a230f81215cbac9a751f4d1c6194644b8204f9d", size = 21592, upload-time = "2024-05-23T14:13:55.283Z" },
-]
-
-[[package]]
-name = "dynesty"
-version = "3.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "matplotlib" },
-    { name = "numpy" },
-    { name = "scipy" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c4/75/db494edc8abfe2273b9cb08c87a2a1165c6ae90d76f746980ef07ec5303a/dynesty-3.1.0.tar.gz", hash = "sha256:851717431f04f749bca45e86704c28fecf9f3b10f85a2a69820b26e42cefab68", size = 35564761, upload-time = "2026-07-17T14:38:31.465Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f1/f9/41c72d0b5fb511fdf23cf62ed50da6c73d4497f03ed1cad04f214dc477c8/dynesty-3.1.0-py3-none-any.whl", hash = "sha256:4e5b77bb261abdcb98e3a538d7498a94d5882a848f0ea46924b404396ef036d5", size = 106027, upload-time = "2026-07-17T14:38:28.523Z" },
-]
-
-[[package]]
-name = "emcee"
-version = "3.1.6"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "numpy" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/cb/53/1045ee878cb24281387079f8ee4f0ade1622c6aae1ed1fd91a53e4fa5b19/emcee-3.1.6.tar.gz", hash = "sha256:11af4daf6ab8f9ca69681e3c29054665db7bbd87fd4eb8e437d2c3a1248c637d", size = 2871117, upload-time = "2024-04-19T10:03:19.555Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f9/ef/2196b9bf88ffa1bde45853c72df021fbd07a8fa91a0f59a22d14a050dc04/emcee-3.1.6-py2.py3-none-any.whl", hash = "sha256:f2d63752023bdccf744461450e512a5b417ae7d28f18e12acd76a33de87580cb", size = 47351, upload-time = "2024-04-19T10:03:17.522Z" },
 ]
 
 [[package]]
@@ -1500,41 +1446,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/1d/17/afa56379f94ad0fe8defd37d6eb3f89a25404ffc71d4d848893d270325fc/h2-4.3.0.tar.gz", hash = "sha256:6c59efe4323fa18b47a632221a1888bd7fde6249819beda254aeca909f221bf1", size = 2152026, upload-time = "2025-08-23T18:12:19.778Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/69/b2/119f6e6dcbd96f9069ce9a2665e0146588dc9f88f29549711853645e736a/h2-4.3.0-py3-none-any.whl", hash = "sha256:c438f029a25f7945c69e0ccf0fb951dc3f73a5f6412981daee861431b70e2bdd", size = 61779, upload-time = "2025-08-23T18:12:17.779Z" },
-]
-
-[[package]]
-name = "h5py"
-version = "3.16.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "numpy" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/db/33/acd0ce6863b6c0d7735007df01815403f5589a21ff8c2e1ee2587a38f548/h5py-3.16.0.tar.gz", hash = "sha256:a0dbaad796840ccaa67a4c144a0d0c8080073c34c76d5a6941d6818678ef2738", size = 446526, upload-time = "2026-03-06T13:49:08.07Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ba/95/a825894f3e45cbac7554c4e97314ce886b233a20033787eda755ca8fecc7/h5py-3.16.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:719439d14b83f74eeb080e9650a6c7aa6d0d9ea0ca7f804347b05fac6fbf18af", size = 3721663, upload-time = "2026-03-06T13:47:49.599Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/3b/38ff88b347c3e346cda1d3fc1b65a7aa75d40632228d8b8a5d7b58508c24/h5py-3.16.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c3f0a0e136f2e95dd0b67146abb6668af4f1a69c81ef8651a2d316e8e01de447", size = 3087630, upload-time = "2026-03-06T13:47:51.249Z" },
-    { url = "https://files.pythonhosted.org/packages/98/a8/2594cef906aee761601eff842c7dc598bea2b394a3e1c00966832b8eeb7c/h5py-3.16.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:a6fbc5367d4046801f9b7db9191b31895f22f1c6df1f9987d667854cac493538", size = 4823472, upload-time = "2026-03-06T13:47:53.085Z" },
-    { url = "https://files.pythonhosted.org/packages/52/a0/c1f604538ff6db22a0690be2dc44ab59178e115f63c917794e529356ab23/h5py-3.16.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:fb1720028d99040792bb2fb31facb8da44a6f29df7697e0b84f0d79aff2e9bd3", size = 5027150, upload-time = "2026-03-06T13:47:55.043Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/fd/301739083c2fc4fd89950f9bcfce75d6e14b40b0ca3d40e48a8993d1722c/h5py-3.16.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:314b6054fe0b1051c2b0cb2df5cbdab15622fb05e80f202e3b6a5eee0d6fe365", size = 4814544, upload-time = "2026-03-06T13:47:56.893Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/42/2193ed41ccee78baba8fcc0cff2c925b8b9ee3793305b23e1f22c20bf4c7/h5py-3.16.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ffbab2fedd6581f6aa31cf1639ca2cb86e02779de525667892ebf4cc9fd26434", size = 5034013, upload-time = "2026-03-06T13:47:59.01Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/20/e6c0ff62ca2ad1a396a34f4380bafccaaf8791ff8fccf3d995a1fc12d417/h5py-3.16.0-cp311-cp311-win_amd64.whl", hash = "sha256:17d1f1630f92ad74494a9a7392ab25982ce2b469fc62da6074c0ce48366a2999", size = 3191673, upload-time = "2026-03-06T13:48:00.626Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/48/239cbe352ac4f2b8243a8e620fa1a2034635f633731493a7ff1ed71e8658/h5py-3.16.0-cp311-cp311-win_arm64.whl", hash = "sha256:85b9c49dd58dc44cf70af944784e2c2038b6f799665d0dcbbc812a26e0faa859", size = 2673834, upload-time = "2026-03-06T13:48:02.579Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/c0/5d4119dba94093bbafede500d3defd2f5eab7897732998c04b54021e530b/h5py-3.16.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c5313566f4643121a78503a473f0fb1e6dcc541d5115c44f05e037609c565c4d", size = 3685604, upload-time = "2026-03-06T13:48:04.198Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/42/c84efcc1d4caebafb1ecd8be4643f39c85c47a80fe254d92b8b43b1eadaf/h5py-3.16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:42b012933a83e1a558c673176676a10ce2fd3759976a0fedee1e672d1e04fc9d", size = 3061940, upload-time = "2026-03-06T13:48:05.783Z" },
-    { url = "https://files.pythonhosted.org/packages/89/84/06281c82d4d1686fde1ac6b0f307c50918f1c0151062445ab3b6fa5a921d/h5py-3.16.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:ff24039e2573297787c3063df64b60aab0591980ac898329a08b0320e0cf2527", size = 5198852, upload-time = "2026-03-06T13:48:07.482Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/e9/1a19e42cd43cc1365e127db6aae85e1c671da1d9a5d746f4d34a50edb577/h5py-3.16.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:dfc21898ff025f1e8e67e194965a95a8d4754f452f83454538f98f8a3fcb207e", size = 5405250, upload-time = "2026-03-06T13:48:09.628Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/8e/9790c1655eabeb85b92b1ecab7d7e62a2069e53baefd58c98f0909c7a948/h5py-3.16.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:698dd69291272642ffda44a0ecd6cd3bda5faf9621452d255f57ce91487b9794", size = 5190108, upload-time = "2026-03-06T13:48:11.26Z" },
-    { url = "https://files.pythonhosted.org/packages/51/d7/ab693274f1bd7e8c5f9fdd6c7003a88d59bedeaf8752716a55f532924fbb/h5py-3.16.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2b2c02b0a160faed5fb33f1ba8a264a37ee240b22e049ecc827345d0d9043074", size = 5419216, upload-time = "2026-03-06T13:48:13.322Z" },
-    { url = "https://files.pythonhosted.org/packages/03/c1/0976b235cf29ead553e22f2fb6385a8252b533715e00d0ae52ed7b900582/h5py-3.16.0-cp312-cp312-win_amd64.whl", hash = "sha256:96b422019a1c8975c2d5dadcf61d4ba6f01c31f92bbde6e4649607885fe502d6", size = 3182868, upload-time = "2026-03-06T13:48:15.759Z" },
-    { url = "https://files.pythonhosted.org/packages/14/d9/866b7e570b39070f92d47b0ff1800f0f8239b6f9e45f02363d7112336c1f/h5py-3.16.0-cp312-cp312-win_arm64.whl", hash = "sha256:39c2838fb1e8d97bcf1755e60ad1f3dd76a7b2a475928dc321672752678b96db", size = 2653286, upload-time = "2026-03-06T13:48:17.279Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/9e/6142ebfda0cb6e9349c091eae73c2e01a770b7659255248d637bec54a88b/h5py-3.16.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:370a845f432c2c9619db8eed334d1e610c6015796122b0e57aa46312c22617d9", size = 3671808, upload-time = "2026-03-06T13:48:19.737Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/65/5e088a45d0f43cd814bc5bec521c051d42005a472e804b1a36c48dada09b/h5py-3.16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:42108e93326c50c2810025aade9eac9d6827524cdccc7d4b75a546e5ab308edb", size = 3045837, upload-time = "2026-03-06T13:48:21.854Z" },
-    { url = "https://files.pythonhosted.org/packages/da/1e/6172269e18cc5a484e2913ced33339aad588e02ba407fafd00d369e22ef3/h5py-3.16.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:099f2525c9dcf28de366970a5fb34879aab20491589fa89ce2863a84218bb524", size = 5193860, upload-time = "2026-03-06T13:48:24.071Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/98/ef2b6fe2903e377cbe870c3b2800d62552f1e3dbe81ce49e1923c53d1c5c/h5py-3.16.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:9300ad32dea9dfc5171f94d5f6948e159ed93e4701280b0f508773b3f582f402", size = 5400417, upload-time = "2026-03-06T13:48:25.728Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/81/5b62d760039eed64348c98129d17061fdfc7839fc9c04eaaad6dee1004e4/h5py-3.16.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:171038f23bccddfc23f344cadabdfc9917ff554db6a0d417180d2747fe4c75a7", size = 5185214, upload-time = "2026-03-06T13:48:27.436Z" },
-    { url = "https://files.pythonhosted.org/packages/28/c4/532123bcd9080e250696779c927f2cb906c8bf3447df98f5ceb8dcded539/h5py-3.16.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7e420b539fb6023a259a1b14d4c9f6df8cf50d7268f48e161169987a57b737ff", size = 5414598, upload-time = "2026-03-06T13:48:29.49Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/d9/a27997f84341fc0dfcdd1fe4179b6ba6c32a7aa880fdb8c514d4dad6fba3/h5py-3.16.0-cp313-cp313-win_amd64.whl", hash = "sha256:18f2bbcd545e6991412253b98727374c356d67caa920e68dc79eab36bf5fedad", size = 3175509, upload-time = "2026-03-06T13:48:31.131Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/23/bb8647521d4fd770c30a76cfc6cb6a2f5495868904054e92f2394c5a78ff/h5py-3.16.0-cp313-cp313-win_arm64.whl", hash = "sha256:656f00e4d903199a1d58df06b711cf3ca632b874b4207b7dbec86185b5c8c7d4", size = 2647362, upload-time = "2026-03-06T13:48:33.411Z" },
 ]
 
 [[package]]
@@ -2314,18 +2225,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/33/fa/7b45eef11b7971f0beb29d27b7bfe0d747d063aa29e170d9edd004733c8a/myst_parser-5.0.0.tar.gz", hash = "sha256:f6f231452c56e8baa662cc352c548158f6a16fcbd6e3800fc594978002b94f3a", size = 98535, upload-time = "2026-01-15T09:08:18.036Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d3/ac/686789b9145413f1a61878c407210e41bfdb097976864e0913078b24098c/myst_parser-5.0.0-py3-none-any.whl", hash = "sha256:ab31e516024918296e169139072b81592336f2fef55b8986aa31c9f04b5f7211", size = 84533, upload-time = "2026-01-15T09:08:16.788Z" },
-]
-
-[[package]]
-name = "nestle"
-version = "0.2.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "numpy" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/27/38/4b029e9ef52416218a89eb5cb28cac93a76433325d2904089459dbe5ff81/nestle-0.2.1.tar.gz", hash = "sha256:db9be605bf9a78b0d8be84aae8fb65ff5af34f196defb2960bbb0753b3100cee", size = 14082, upload-time = "2025-10-07T09:35:08.965Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a6/ed/7b866669511d5a62bed0cc585d403477a453d72c61335cc4fc73f907c220/nestle-0.2.1-py3-none-any.whl", hash = "sha256:1189771288bbcbcea782147f05ba60e3edd5c4b6051ae580f9ff3ef753c6f930", size = 13811, upload-time = "2025-10-07T09:35:07.613Z" },
 ]
 
 [[package]]
@@ -3591,27 +3490,21 @@ wheels = [
 
 [[package]]
 name = "rm-lite"
-version = "2026.7.7"
+version = "2026.8.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "astropy" },
-    { name = "bilby" },
-    { name = "corner" },
     { name = "dask", extra = ["array"] },
-    { name = "deprecation" },
-    { name = "emcee" },
     { name = "finufft" },
-    { name = "nestle" },
     { name = "numpy" },
     { name = "polars" },
     { name = "scipy" },
-    { name = "sigfig" },
-    { name = "tdqm" },
+    { name = "tqdm" },
     { name = "zarr" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ed/3f/a274ef3f08da3ee977349f350b9f19fe61d8ee831c4d9e581587a66346b4/rm_lite-2026.7.7.tar.gz", hash = "sha256:e95ab3875c09457b4a68cb6ed845e68628c28e8c89e394980a0a19d30db76020", size = 409418, upload-time = "2026-07-20T14:04:56.911Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9b/81/f7d9c06e603f86013d07caeaa83efdd6fe825bd35832b2fe817d3d17ec3b/rm_lite-2026.8.3.tar.gz", hash = "sha256:9a1b5c04999d44e12fd5f6f34afad88e8d8e08294e57b91ca5ac68cbb3a624a7", size = 418615, upload-time = "2026-08-24T22:49:05.563Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/38/2c/9b884bdfb3bc6850e2004d3ac8bd8326ac4aa7c6811c1e34b11443a9b0b3/rm_lite-2026.7.7-py3-none-any.whl", hash = "sha256:100904f60de0af4a7fdce510c30229b61af35cd93780c9e8c97018a08294594a", size = 92096, upload-time = "2026-07-20T14:04:55.439Z" },
+    { url = "https://files.pythonhosted.org/packages/64/25/481efd0856453363dec50a56eea1e88b9297541f4a080aad40fd818226f6/rm_lite-2026.8.3-py3-none-any.whl", hash = "sha256:ec7517eb6c88754c7a63a3c0b4f69fb39ee21703624542370c9416450de934c0", size = 102638, upload-time = "2026-08-24T22:49:03.684Z" },
 ]
 
 [[package]]
@@ -3942,18 +3835,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
-]
-
-[[package]]
-name = "sigfig"
-version = "1.3.19"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "sortedcontainers" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/d8/a1/90bc16852efe100582b9d6c43c495aa8708fe67e72d3dfb44964463604e1/sigfig-1.3.19.tar.gz", hash = "sha256:a9e4fa37aa7595cc01b7207bfabf86cccd2d3edfddcdaa925ffd57dd77efcd9e", size = 14235, upload-time = "2025-03-10T04:51:30.01Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/69/29/18af3de86d94b13d49ec9a4a8cf164187fffb22431c2f3f3e7836339d631/sigfig-1.3.19-py3-none-any.whl", hash = "sha256:7bde0715e1a0cddb93c3ed3b9f8f20bf4cc77bbb47c570fe6fbd7b43aa6fd56c", size = 10710, upload-time = "2025-03-10T04:51:28.753Z" },
 ]
 
 [[package]]
@@ -4310,15 +4191,6 @@ sdist = { url = "https://files.pythonhosted.org/packages/f4/8a/14c15ae154895cc13
 wheels = [
     { url = "https://files.pythonhosted.org/packages/02/be/5d2d47b1fb58943194fb59dcf222f7c4e35122ec0ffe8c36e18b5d728f0b/tblib-3.2.2-py3-none-any.whl", hash = "sha256:26bdccf339bcce6a88b2b5432c988b266ebbe63a4e593f6b578b1d2e723d2b76", size = 12893, upload-time = "2025-11-12T12:21:14.407Z" },
 ]
-
-[[package]]
-name = "tdqm"
-version = "0.0.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "tqdm" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5a/38/58c9e22b95e98666fe29f35e217ab6126a03798dadf3f4f8f3e5f898510b/tdqm-0.0.1.tar.gz", hash = "sha256:f050004a76b1d22f70b78209b48781353c82440215b6ba7d22b1f499b05a0101", size = 1388, upload-time = "2020-08-19T20:16:22.191Z" }
 
 [[package]]
 name = "text-unidecode"

--- a/uv.lock
+++ b/uv.lock
@@ -169,6 +169,7 @@ dependencies = [
     { name = "fitscube", extra = ["pgzip"] },
     { name = "jolly-roger" },
     { name = "matplotlib" },
+    { name = "numba" },
     { name = "numpy" },
     { name = "pandas" },
     { name = "prefect" },
@@ -177,6 +178,7 @@ dependencies = [
     { name = "racs-tools" },
     { name = "radio-beam" },
     { name = "reproject" },
+    { name = "rocket-fft" },
     { name = "scikit-image" },
     { name = "scipy" },
     { name = "spython" },
@@ -255,6 +257,7 @@ requires-dist = [
     { name = "mypy", marker = "extra == 'dev'" },
     { name = "myst-parser", marker = "extra == 'all'" },
     { name = "myst-parser", marker = "extra == 'dev'" },
+    { name = "numba" },
     { name = "numpy", specifier = ">=2.0.0" },
     { name = "pandas" },
     { name = "pre-commit", marker = "extra == 'all'" },
@@ -277,6 +280,7 @@ requires-dist = [
     { name = "reproject" },
     { name = "rm-lite", marker = "extra == 'all'", specifier = "==2026.8.7" },
     { name = "rm-lite", marker = "extra == 'rmsynth'", specifier = "==2026.8.7" },
+    { name = "rocket-fft" },
     { name = "ruff", marker = "extra == 'all'" },
     { name = "ruff", marker = "extra == 'dev'" },
     { name = "scikit-image" },
@@ -3505,6 +3509,32 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/6d/9f/c3d7d0260ae064d4e810b476aa4b7ce56298d0457617dc3b544a2a9611ab/rm_lite-2026.8.7.tar.gz", hash = "sha256:155519c3e4063bfa733c7da7f383001c9e47f6cdc5a51d9f33a6b8a06e60f68f", size = 447821, upload-time = "2026-08-31T02:52:55.402Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/44/1d/92c36880b4b3deb64710951fd2232a586010f872c9b80363e4d994fe88fe/rm_lite-2026.8.7-py3-none-any.whl", hash = "sha256:bf1760d5ebaeead154fb5b24cd600e18fe5c742a7044411469b15d8316002e75", size = 117925, upload-time = "2026-08-31T02:52:54.139Z" },
+]
+
+[[package]]
+name = "rocket-fft"
+version = "0.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numba" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/44/b0/09cbec3177ecf56e5ceb789a69fbcdcbabe758cbb682e5d36b14aa8c05fb/rocket_fft-0.3.1.tar.gz", hash = "sha256:ddc902a361099aff9fc02fe9ea3b0d036c2f67f93df356c2b754f7627d7fa4f4", size = 74276, upload-time = "2025-12-26T00:30:54.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/81/4b1c9a3c336dfee613d23bb0a8f0819abdcb87634dde79e4e6d74f839f5e/rocket_fft-0.3.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:43145d0ff69c88fec886af069b6f9886fe834fc17566c731de8ade3d8dfcfaf4", size = 362992, upload-time = "2025-12-26T00:30:20.116Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/00/30b3713e43c5966cdc9a2003019f224099cb53109d79068e46c56cd7b073/rocket_fft-0.3.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7f50f967a4ebdc88184d259c242474837d6c38c41b1e2fd09bffa08639d9b7a3", size = 322683, upload-time = "2025-12-26T00:30:21.585Z" },
+    { url = "https://files.pythonhosted.org/packages/be/82/993f210253fbf4275844b66e159281f37d6f84270ee9f6e4010d81347216/rocket_fft-0.3.1-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b94ff9502f63515bebfa2bce319db6dd00d02031e1cef8441a4dded728d7c4d", size = 2164173, upload-time = "2025-12-26T00:30:23.332Z" },
+    { url = "https://files.pythonhosted.org/packages/09/52/f454823728d5775ec314985d2611afc0d7f8001adefaf719261df776a6c4/rocket_fft-0.3.1-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d0e9f0f03416d276f023f50744f5cef9f750b3b830d6e1edd340db623ff5ca6d", size = 2163734, upload-time = "2025-12-26T00:30:25.173Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/d4/3944b2513382e7e7fd08300ab1b0d0864e675e7a5fd6451d78ca338ae6e1/rocket_fft-0.3.1-cp311-cp311-win_amd64.whl", hash = "sha256:8173cd4ed9d464b2e789d2303a5f7953980bde8237c60af2fc6204b82addeec5", size = 215164, upload-time = "2025-12-26T00:30:26.627Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/78/8edd1349af038a8ab0fa3aee97ff2b91b4227e2561f0f721e78f3cd24635/rocket_fft-0.3.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:89be2e23812678ef7afdc793682e9aef4afbd7a0a30041cb292f02c73d62a0a9", size = 359246, upload-time = "2025-12-26T00:30:27.668Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/3a/41b7a3355e6d44139f2a891d4763ff0a1eeb634fc0faa43cefdb1cdda702/rocket_fft-0.3.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0de1a8841638e3091ef774d9304a6427801fd06dd29e6d2baacd17bac65eb9f3", size = 322703, upload-time = "2025-12-26T00:30:29.169Z" },
+    { url = "https://files.pythonhosted.org/packages/08/18/12d001c33cd7c4e012da59d25086879aec303e0e157d9ec737ecab8e8f58/rocket_fft-0.3.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:46970c0dcc70bd9c365d6a9f4a235edec2e8eaad628097c0e21d920669e25abe", size = 2151682, upload-time = "2025-12-26T00:30:30.315Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/92/98bd01cad9e5ceeb383722d744597d066e37cdd0e54742906341aa369c28/rocket_fft-0.3.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7d64c9fc81206f2c77f74f68761f54ac6f1ebe4c8840f0ef9795c28ab229463f", size = 2160197, upload-time = "2025-12-26T00:30:31.945Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/c7/d273a880278c1a0946e4bec5ca54e79595b50003b5eb4400c1d60e5e41e0/rocket_fft-0.3.1-cp312-cp312-win_amd64.whl", hash = "sha256:05afc9805cfb97b330417b4bfcd435aace98dff2fc479bfbcb4ac4568f56ec51", size = 215185, upload-time = "2025-12-26T00:30:33.412Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/33/1b1025d47226031616bf1ac02e63f240d02b89fe2b8462b35d1766519968/rocket_fft-0.3.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:3fa706995cebcc7bff41894e23323d2a221906454d21cb12fed97833b0f7433e", size = 359250, upload-time = "2025-12-26T00:30:34.456Z" },
+    { url = "https://files.pythonhosted.org/packages/af/3c/371012b4ffa4697574ecfa148e8068a74e6ad57a182ec78f9b221bd4270c/rocket_fft-0.3.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4a50609003f944aea1b8000a19f9b9cf9cbaaa5e4726e5aefaccccd1cfd81a99", size = 322700, upload-time = "2025-12-26T00:30:35.982Z" },
+    { url = "https://files.pythonhosted.org/packages/48/2c/5bbe8d6b0c4e009f7bc6f9f4eee802a9b556ec2c3b02b9d5e5ccfa8edff1/rocket_fft-0.3.1-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5906c6517fc87295a1d142c7e6ebd1c55e057f6ee4c605549bbcecacab83774f", size = 2151627, upload-time = "2025-12-26T00:30:37.177Z" },
+    { url = "https://files.pythonhosted.org/packages/55/0d/ac67fb0b2fac382ab5585719bbd1f4927c19ba0ee3bbc28dc8a1ef83e81d/rocket_fft-0.3.1-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d830aacc34d65b28daab715aa4a90d98489e89a48c2836039982f18ba1e2db3", size = 2160355, upload-time = "2025-12-26T00:30:38.81Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/af/0ab2b29548925c6f84607010d3bf5a928331232d1ef54f273ab9989c64c0/rocket_fft-0.3.1-cp313-cp313-win_amd64.whl", hash = "sha256:97452673ea99b907c75c99c4046d5297ea01778a6e74cb51ba515c01e3e5e5d7", size = 215172, upload-time = "2025-12-26T00:30:39.885Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -206,6 +206,9 @@ dev = [
     { name = "sphinx-autodoc-typehints", version = "3.9.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "sphinx-copybutton" },
 ]
+rmsynth = [
+    { name = "rm-lite" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -239,6 +242,7 @@ requires-dist = [
     { name = "racs-tools", specifier = ">=4.2.1" },
     { name = "radio-beam", specifier = ">=0.3.4" },
     { name = "reproject" },
+    { name = "rm-lite", marker = "extra == 'rmsynth'", specifier = ">=2026.7.7" },
     { name = "ruff", marker = "extra == 'dev'" },
     { name = "scikit-image" },
     { name = "scipy" },
@@ -249,7 +253,7 @@ requires-dist = [
     { name = "sphinx-copybutton", marker = "extra == 'dev'" },
     { name = "spython", specifier = ">=0.3.1" },
 ]
-provides-extras = ["casa", "dev"]
+provides-extras = ["casa", "dev", "rmsynth"]
 
 [[package]]
 name = "asteval"
@@ -448,6 +452,50 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b0/1c6a16426d389813b48d95e26898aff79abbde42ad353958ad95cc8c9b21/beautifulsoup4-4.14.3.tar.gz", hash = "sha256:6292b1c5186d356bba669ef9f7f051757099565ad9ada5dd630bd9de5fa7fb86", size = 627737, upload-time = "2025-11-30T15:08:26.084Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl", hash = "sha256:0918bfe44902e6ad8d57732ba310582e98da931428d231a5ecb9e7c703a735bb", size = 107721, upload-time = "2025-11-30T15:08:24.087Z" },
+]
+
+[[package]]
+name = "bilby"
+version = "2.8.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "bilby-cython" },
+    { name = "corner" },
+    { name = "dill" },
+    { name = "dynesty" },
+    { name = "emcee" },
+    { name = "h5py" },
+    { name = "matplotlib" },
+    { name = "numpy" },
+    { name = "pandas" },
+    { name = "scipy" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3e/d0/f2e561f021315a653d38ba91b31a4ebf7623a591b4f6876aadc8be521f0c/bilby-2.8.1.tar.gz", hash = "sha256:12659775bb5c45b95c17fbd4488e226c91d198f5c76566f66a3a9df490785aef", size = 15876505, upload-time = "2026-06-29T15:07:55.589Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/18/70347ffc8f6c1039f535858495f62edb077178a031820b0cc468addf5120/bilby-2.8.1-py3-none-any.whl", hash = "sha256:38206ad49ff75feb288e177199a0f057d6b8ac602192b2b9f7d900d434c2e603", size = 2293391, upload-time = "2026-06-29T15:07:53.63Z" },
+]
+
+[[package]]
+name = "bilby-cython"
+version = "0.5.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5f/60/3a384798c7df2462343028d37e6adb9079eb0b155a50736b88bdd668d825/bilby_cython-0.5.4.tar.gz", hash = "sha256:34af013f232187f25308cbf25f096e8c2be1662da78c421b85ecceba4fb5358d", size = 255948, upload-time = "2026-04-02T14:44:25.732Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/18/448999d244b985582af77471f2bb1a0399b554ffa4bfe3554a813dd026c6/bilby_cython-0.5.4-cp311-cp311-macosx_13_0_x86_64.whl", hash = "sha256:a5ee0659d7896e91024650dfc77e304f5db43e307e452c91caa6864e4062e426", size = 364314, upload-time = "2026-04-02T14:44:00.504Z" },
+    { url = "https://files.pythonhosted.org/packages/66/ff/d7d033a7578c2b6030c86f2706bf1af051731a0b6aedd59475c18542f2c4/bilby_cython-0.5.4-cp311-cp311-macosx_15_0_arm64.whl", hash = "sha256:2526574d12ca7807bc5b7f19cf88829fc1b126a980de5e1969c027c1f11ccb34", size = 362569, upload-time = "2026-04-02T14:44:01.971Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/99/4b8ed531febe5aca745b5522d19d5d2e18744e4cb0d9cd83c0eaad464fd5/bilby_cython-0.5.4-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d2aff524c0603111d55b9b24215bb708acad53adaa177493862eaaa10ce39b85", size = 1036057, upload-time = "2026-04-02T14:44:03.219Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/32/960859bf3552f3d0e303924d1ce8b02470c6dbf683d985f7377fde41681c/bilby_cython-0.5.4-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:04945e17d0a9c31f896bec88d4a1bfd8951e4337c2cfc22ef227dd9ece383078", size = 357283, upload-time = "2026-04-02T14:44:04.795Z" },
+    { url = "https://files.pythonhosted.org/packages/57/2f/7bc651e30d1e9cea5ee4c35b92641c474d652471be49048e38c6512efbfb/bilby_cython-0.5.4-cp312-cp312-macosx_13_0_x86_64.whl", hash = "sha256:a059c40b5794f094a17c36e3034e5b84a8e92cfed965533577af576beaaff133", size = 363269, upload-time = "2026-04-02T14:44:05.978Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/0a/1584b9f60741fd045b9fa57576a524256f31ac9e00162b2c5355f7ef2c80/bilby_cython-0.5.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1599c1ed9f0f169370ab85a975c130447784c998f45f4a63418e0f677461d22f", size = 1068099, upload-time = "2026-04-02T14:44:07.201Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/ee/c371f1fa5963be4458acbeb6ac15d32fd07092234be871357069baad9535/bilby_cython-0.5.4-cp313-cp313-macosx_13_0_x86_64.whl", hash = "sha256:c9dd36128bfc48aacca3f0191babdbdf4ba17acc479c7bb2e24f5ba2d2a7f4c2", size = 362668, upload-time = "2026-04-02T14:44:08.464Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/78/956c0eff488ec23402bcd0ff169b72909e43cb4bc1b0a9d9f1a7cc195cc7/bilby_cython-0.5.4-cp313-cp313-macosx_15_0_arm64.whl", hash = "sha256:799ccc984e0eb88a20127dc0218866eb22517a1b9e71fc737a89cfc868a8f13d", size = 360622, upload-time = "2026-04-02T14:44:09.616Z" },
+    { url = "https://files.pythonhosted.org/packages/40/ff/062a65c322e0dd4225a78627243b2925ebc902d5a6282871506d1d6767fd/bilby_cython-0.5.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b28ff13b884eb727d91276d52220707162e4157258b15477a283c8936b156679", size = 1035074, upload-time = "2026-04-02T14:44:11.125Z" },
+    { url = "https://files.pythonhosted.org/packages/01/81/0b0b5558b2e86642fe6e980898745f0b0471ff895ce82e32800f3b23acdb/bilby_cython-0.5.4-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:92b7f985cf102d043d6ead018327f58e6bffc1166f2077dc4e2253cfd67a64c4", size = 1062321, upload-time = "2026-04-02T14:44:12.62Z" },
 ]
 
 [[package]]
@@ -776,6 +824,18 @@ wheels = [
 ]
 
 [[package]]
+name = "corner"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "matplotlib" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4f/06/0d045530fa994ab450f6a98b7ad9f74c90a8abf5271d3690f60d1aa933d8/corner-2.3.0.tar.gz", hash = "sha256:685ecb1e778809b78c6783f4a4691d023bbd9f781c9efda683c2b793878b561c", size = 6089474, upload-time = "2026-07-05T17:56:05.355Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d6/cb/17a130e548ee1777f2a66e09240c531a9bf79454add7ef1198fe1e41c412/corner-2.3.0-py3-none-any.whl", hash = "sha256:f93f0a4d77ff6852d6ddc80a6a99038117be64e3b5b49d96a82c9f5974cce126", size = 16954, upload-time = "2026-07-05T17:56:03.827Z" },
+]
+
+[[package]]
 name = "coverage"
 version = "7.13.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1056,6 +1116,18 @@ wheels = [
 ]
 
 [[package]]
+name = "deprecation"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5a/d3/8ae2869247df154b64c1884d7346d412fed0c49df84db635aab2d1c40e62/deprecation-2.1.0.tar.gz", hash = "sha256:72b3bde64e5d778694b0cf68178aed03d15e15477116add3fb773e581f9518ff", size = 173788, upload-time = "2020-04-20T14:23:38.738Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/c3/253a89ee03fc9b9682f1541728eb66db7db22148cd94f89ab22528cd1e1b/deprecation-2.1.0-py2.py3-none-any.whl", hash = "sha256:a10811591210e1fb0e768a8c25517cabeabcba6f0bf96564f8ff45189f90b14a", size = 11178, upload-time = "2020-04-20T14:23:36.581Z" },
+]
+
+[[package]]
 name = "dill"
 version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1144,6 +1216,32 @@ wheels = [
 ]
 
 [[package]]
+name = "dynesty"
+version = "3.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "matplotlib" },
+    { name = "numpy" },
+    { name = "scipy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c4/75/db494edc8abfe2273b9cb08c87a2a1165c6ae90d76f746980ef07ec5303a/dynesty-3.1.0.tar.gz", hash = "sha256:851717431f04f749bca45e86704c28fecf9f3b10f85a2a69820b26e42cefab68", size = 35564761, upload-time = "2026-07-17T14:38:31.465Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/f9/41c72d0b5fb511fdf23cf62ed50da6c73d4497f03ed1cad04f214dc477c8/dynesty-3.1.0-py3-none-any.whl", hash = "sha256:4e5b77bb261abdcb98e3a538d7498a94d5882a848f0ea46924b404396ef036d5", size = 106027, upload-time = "2026-07-17T14:38:28.523Z" },
+]
+
+[[package]]
+name = "emcee"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cb/53/1045ee878cb24281387079f8ee4f0ade1622c6aae1ed1fd91a53e4fa5b19/emcee-3.1.6.tar.gz", hash = "sha256:11af4daf6ab8f9ca69681e3c29054665db7bbd87fd4eb8e437d2c3a1248c637d", size = 2871117, upload-time = "2024-04-19T10:03:19.555Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/ef/2196b9bf88ffa1bde45853c72df021fbd07a8fa91a0f59a22d14a050dc04/emcee-3.1.6-py2.py3-none-any.whl", hash = "sha256:f2d63752023bdccf744461450e512a5b417ae7d28f18e12acd76a33de87580cb", size = 47351, upload-time = "2024-04-19T10:03:17.522Z" },
+]
+
+[[package]]
 name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1187,6 +1285,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/77/18/a1fd2231c679dcb9726204645721b12498aeac28e1ad0601038f94b42556/filelock-3.25.0.tar.gz", hash = "sha256:8f00faf3abf9dc730a1ffe9c354ae5c04e079ab7d3a683b7c32da5dd05f26af3", size = 40158, upload-time = "2026-03-01T15:08:45.916Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f9/0b/de6f54d4a8bedfe8645c41497f3c18d749f0bd3218170c667bf4b81d0cdd/filelock-3.25.0-py3-none-any.whl", hash = "sha256:5ccf8069f7948f494968fc0713c10e5c182a9c9d9eef3a636307a20c2490f047", size = 26427, upload-time = "2026-03-01T15:08:44.593Z" },
+]
+
+[[package]]
+name = "finufft"
+version = "2.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e0/a6/7cbd2b05862878673f9c8d61a31095a7e96897f7debcdb78231e4ad1c447/finufft-2.5.1.tar.gz", hash = "sha256:b0c630717442cb3519948e5f73b5dee68871c0f0e3b8c2eafbec0fcccf89f6b9", size = 120733, upload-time = "2026-04-09T19:25:35.965Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b1/8c/2cb49aa7d6adfeb455bb544d18bf7777da1c0b7b239830d795b866ac3a46/finufft-2.5.1-py3-none-macosx_14_0_arm64.whl", hash = "sha256:3f57c3ab02a050980ba578d9f322305e77f538009ebf8cb70df77c95443f031e", size = 2731206, upload-time = "2026-04-08T23:41:58.281Z" },
+    { url = "https://files.pythonhosted.org/packages/10/3c/405e041c13e625833002bf99934c760f74c01d44b7d84796a52847208741/finufft-2.5.1-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3b20990fa7cfad54f63118b2e95a908c91dbcbb01e4c544755985ccbe6216aa6", size = 7804274, upload-time = "2026-04-08T23:41:59.956Z" },
+    { url = "https://files.pythonhosted.org/packages/74/4b/b88cd3266c653f871c3c93504d0b9edca22d1e725a64b67a3c53ad7b2896/finufft-2.5.1-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:2cec94f1dfe45f77d92b9a4cd523445f4d51c10d0a74d3eaf3c90f17293693f0", size = 7632155, upload-time = "2026-04-08T23:42:01.542Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/7f/55ca2e564fdf83d8473befdaa4e52425d0f880f3302d7952f755c3412972/finufft-2.5.1-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:e3881a331360eba3f76b7f1c69d9b641e02ba05584da76cc221191c95c7be8da", size = 8366930, upload-time = "2026-04-08T23:42:03.185Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/0f/e9bf300b8d6a76cb3e6d306c62688c8f4fac73250be9d073c5f17bdd77ba/finufft-2.5.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:8bb04c741b79e5de66010e6be17fd01eb2cf06c0557d58d89de4514d5a68cb37", size = 8638314, upload-time = "2026-04-08T23:42:04.817Z" },
+    { url = "https://files.pythonhosted.org/packages/05/98/a6632d986102cc94a0d9a6ff665c8d736c16ce462b0955c511e17d20b053/finufft-2.5.1-py3-none-win_amd64.whl", hash = "sha256:496ad48706e77f54078e31777bd4a30f33e788ae313ef30d8b1e7d41c7539788", size = 5881286, upload-time = "2026-04-08T23:42:07.132Z" },
 ]
 
 [[package]]
@@ -1379,6 +1495,41 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/1d/17/afa56379f94ad0fe8defd37d6eb3f89a25404ffc71d4d848893d270325fc/h2-4.3.0.tar.gz", hash = "sha256:6c59efe4323fa18b47a632221a1888bd7fde6249819beda254aeca909f221bf1", size = 2152026, upload-time = "2025-08-23T18:12:19.778Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/69/b2/119f6e6dcbd96f9069ce9a2665e0146588dc9f88f29549711853645e736a/h2-4.3.0-py3-none-any.whl", hash = "sha256:c438f029a25f7945c69e0ccf0fb951dc3f73a5f6412981daee861431b70e2bdd", size = 61779, upload-time = "2025-08-23T18:12:17.779Z" },
+]
+
+[[package]]
+name = "h5py"
+version = "3.16.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/33/acd0ce6863b6c0d7735007df01815403f5589a21ff8c2e1ee2587a38f548/h5py-3.16.0.tar.gz", hash = "sha256:a0dbaad796840ccaa67a4c144a0d0c8080073c34c76d5a6941d6818678ef2738", size = 446526, upload-time = "2026-03-06T13:49:08.07Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/95/a825894f3e45cbac7554c4e97314ce886b233a20033787eda755ca8fecc7/h5py-3.16.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:719439d14b83f74eeb080e9650a6c7aa6d0d9ea0ca7f804347b05fac6fbf18af", size = 3721663, upload-time = "2026-03-06T13:47:49.599Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/3b/38ff88b347c3e346cda1d3fc1b65a7aa75d40632228d8b8a5d7b58508c24/h5py-3.16.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c3f0a0e136f2e95dd0b67146abb6668af4f1a69c81ef8651a2d316e8e01de447", size = 3087630, upload-time = "2026-03-06T13:47:51.249Z" },
+    { url = "https://files.pythonhosted.org/packages/98/a8/2594cef906aee761601eff842c7dc598bea2b394a3e1c00966832b8eeb7c/h5py-3.16.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:a6fbc5367d4046801f9b7db9191b31895f22f1c6df1f9987d667854cac493538", size = 4823472, upload-time = "2026-03-06T13:47:53.085Z" },
+    { url = "https://files.pythonhosted.org/packages/52/a0/c1f604538ff6db22a0690be2dc44ab59178e115f63c917794e529356ab23/h5py-3.16.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:fb1720028d99040792bb2fb31facb8da44a6f29df7697e0b84f0d79aff2e9bd3", size = 5027150, upload-time = "2026-03-06T13:47:55.043Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/fd/301739083c2fc4fd89950f9bcfce75d6e14b40b0ca3d40e48a8993d1722c/h5py-3.16.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:314b6054fe0b1051c2b0cb2df5cbdab15622fb05e80f202e3b6a5eee0d6fe365", size = 4814544, upload-time = "2026-03-06T13:47:56.893Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/42/2193ed41ccee78baba8fcc0cff2c925b8b9ee3793305b23e1f22c20bf4c7/h5py-3.16.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ffbab2fedd6581f6aa31cf1639ca2cb86e02779de525667892ebf4cc9fd26434", size = 5034013, upload-time = "2026-03-06T13:47:59.01Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/20/e6c0ff62ca2ad1a396a34f4380bafccaaf8791ff8fccf3d995a1fc12d417/h5py-3.16.0-cp311-cp311-win_amd64.whl", hash = "sha256:17d1f1630f92ad74494a9a7392ab25982ce2b469fc62da6074c0ce48366a2999", size = 3191673, upload-time = "2026-03-06T13:48:00.626Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/48/239cbe352ac4f2b8243a8e620fa1a2034635f633731493a7ff1ed71e8658/h5py-3.16.0-cp311-cp311-win_arm64.whl", hash = "sha256:85b9c49dd58dc44cf70af944784e2c2038b6f799665d0dcbbc812a26e0faa859", size = 2673834, upload-time = "2026-03-06T13:48:02.579Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/c0/5d4119dba94093bbafede500d3defd2f5eab7897732998c04b54021e530b/h5py-3.16.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c5313566f4643121a78503a473f0fb1e6dcc541d5115c44f05e037609c565c4d", size = 3685604, upload-time = "2026-03-06T13:48:04.198Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/42/c84efcc1d4caebafb1ecd8be4643f39c85c47a80fe254d92b8b43b1eadaf/h5py-3.16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:42b012933a83e1a558c673176676a10ce2fd3759976a0fedee1e672d1e04fc9d", size = 3061940, upload-time = "2026-03-06T13:48:05.783Z" },
+    { url = "https://files.pythonhosted.org/packages/89/84/06281c82d4d1686fde1ac6b0f307c50918f1c0151062445ab3b6fa5a921d/h5py-3.16.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:ff24039e2573297787c3063df64b60aab0591980ac898329a08b0320e0cf2527", size = 5198852, upload-time = "2026-03-06T13:48:07.482Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/e9/1a19e42cd43cc1365e127db6aae85e1c671da1d9a5d746f4d34a50edb577/h5py-3.16.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:dfc21898ff025f1e8e67e194965a95a8d4754f452f83454538f98f8a3fcb207e", size = 5405250, upload-time = "2026-03-06T13:48:09.628Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/8e/9790c1655eabeb85b92b1ecab7d7e62a2069e53baefd58c98f0909c7a948/h5py-3.16.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:698dd69291272642ffda44a0ecd6cd3bda5faf9621452d255f57ce91487b9794", size = 5190108, upload-time = "2026-03-06T13:48:11.26Z" },
+    { url = "https://files.pythonhosted.org/packages/51/d7/ab693274f1bd7e8c5f9fdd6c7003a88d59bedeaf8752716a55f532924fbb/h5py-3.16.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2b2c02b0a160faed5fb33f1ba8a264a37ee240b22e049ecc827345d0d9043074", size = 5419216, upload-time = "2026-03-06T13:48:13.322Z" },
+    { url = "https://files.pythonhosted.org/packages/03/c1/0976b235cf29ead553e22f2fb6385a8252b533715e00d0ae52ed7b900582/h5py-3.16.0-cp312-cp312-win_amd64.whl", hash = "sha256:96b422019a1c8975c2d5dadcf61d4ba6f01c31f92bbde6e4649607885fe502d6", size = 3182868, upload-time = "2026-03-06T13:48:15.759Z" },
+    { url = "https://files.pythonhosted.org/packages/14/d9/866b7e570b39070f92d47b0ff1800f0f8239b6f9e45f02363d7112336c1f/h5py-3.16.0-cp312-cp312-win_arm64.whl", hash = "sha256:39c2838fb1e8d97bcf1755e60ad1f3dd76a7b2a475928dc321672752678b96db", size = 2653286, upload-time = "2026-03-06T13:48:17.279Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/9e/6142ebfda0cb6e9349c091eae73c2e01a770b7659255248d637bec54a88b/h5py-3.16.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:370a845f432c2c9619db8eed334d1e610c6015796122b0e57aa46312c22617d9", size = 3671808, upload-time = "2026-03-06T13:48:19.737Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/65/5e088a45d0f43cd814bc5bec521c051d42005a472e804b1a36c48dada09b/h5py-3.16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:42108e93326c50c2810025aade9eac9d6827524cdccc7d4b75a546e5ab308edb", size = 3045837, upload-time = "2026-03-06T13:48:21.854Z" },
+    { url = "https://files.pythonhosted.org/packages/da/1e/6172269e18cc5a484e2913ced33339aad588e02ba407fafd00d369e22ef3/h5py-3.16.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:099f2525c9dcf28de366970a5fb34879aab20491589fa89ce2863a84218bb524", size = 5193860, upload-time = "2026-03-06T13:48:24.071Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/98/ef2b6fe2903e377cbe870c3b2800d62552f1e3dbe81ce49e1923c53d1c5c/h5py-3.16.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:9300ad32dea9dfc5171f94d5f6948e159ed93e4701280b0f508773b3f582f402", size = 5400417, upload-time = "2026-03-06T13:48:25.728Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/81/5b62d760039eed64348c98129d17061fdfc7839fc9c04eaaad6dee1004e4/h5py-3.16.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:171038f23bccddfc23f344cadabdfc9917ff554db6a0d417180d2747fe4c75a7", size = 5185214, upload-time = "2026-03-06T13:48:27.436Z" },
+    { url = "https://files.pythonhosted.org/packages/28/c4/532123bcd9080e250696779c927f2cb906c8bf3447df98f5ceb8dcded539/h5py-3.16.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7e420b539fb6023a259a1b14d4c9f6df8cf50d7268f48e161169987a57b737ff", size = 5414598, upload-time = "2026-03-06T13:48:29.49Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/d9/a27997f84341fc0dfcdd1fe4179b6ba6c32a7aa880fdb8c514d4dad6fba3/h5py-3.16.0-cp313-cp313-win_amd64.whl", hash = "sha256:18f2bbcd545e6991412253b98727374c356d67caa920e68dc79eab36bf5fedad", size = 3175509, upload-time = "2026-03-06T13:48:31.131Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/23/bb8647521d4fd770c30a76cfc6cb6a2f5495868904054e92f2394c5a78ff/h5py-3.16.0-cp313-cp313-win_arm64.whl", hash = "sha256:656f00e4d903199a1d58df06b711cf3ca632b874b4207b7dbec86185b5c8c7d4", size = 2647362, upload-time = "2026-03-06T13:48:33.411Z" },
 ]
 
 [[package]]
@@ -2161,6 +2312,18 @@ wheels = [
 ]
 
 [[package]]
+name = "nestle"
+version = "0.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/27/38/4b029e9ef52416218a89eb5cb28cac93a76433325d2904089459dbe5ff81/nestle-0.2.1.tar.gz", hash = "sha256:db9be605bf9a78b0d8be84aae8fb65ff5af34f196defb2960bbb0753b3100cee", size = 14082, upload-time = "2025-10-07T09:35:08.965Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/ed/7b866669511d5a62bed0cc585d403477a453d72c61335cc4fc73f907c220/nestle-0.2.1-py3-none-any.whl", hash = "sha256:1189771288bbcbcea782147f05ba60e3edd5c4b6051ae580f9ff3ef753c6f930", size = 13811, upload-time = "2025-10-07T09:35:07.613Z" },
+]
+
+[[package]]
 name = "networkx"
 version = "3.6.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2577,6 +2740,34 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "polars"
+version = "1.43.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "polars-runtime-32" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/89/13/3873f213304bcbaaf39e63c8b905ceb460a0524448d57f86a829f6d4d0fd/polars-1.43.2.tar.gz", hash = "sha256:c699671b99eb71ff53334d237917aaa3db5ad4dda480abcb6c80e0eaee7b677b", size = 750312, upload-time = "2026-08-01T06:28:30.872Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2b/fe/0888040a24e4504098b85d8ad486b14cb01cf6b030bbe479dfc2dcffc2ac/polars-1.43.2-py3-none-any.whl", hash = "sha256:22aa0cb92a1ee2d60d6a15a638b2e8e0dd99aea21ac0cd8fb29da8e382e075a9", size = 847150, upload-time = "2026-08-01T06:27:15.543Z" },
+]
+
+[[package]]
+name = "polars-runtime-32"
+version = "1.43.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d4/06/11b578eeef05f867e3ee31b2a2fdd8e7684c2aa47822c49935d1be789c38/polars_runtime_32-1.43.2.tar.gz", hash = "sha256:d7b7c486bccee75a6af0158b87077da3d054657e3c60036b28644f4e1c7fdbf7", size = 3095669, upload-time = "2026-08-01T06:28:32.315Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/fc/12e6d4ca34d820297651134cfa35f86c33e898539fc6629cbb35d0089697/polars_runtime_32-1.43.2-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:91abf205d4ec93f92ba95386b7f8776559ae3dfce425ed2e527efa75d117d04a", size = 53088908, upload-time = "2026-08-01T06:27:18.268Z" },
+    { url = "https://files.pythonhosted.org/packages/32/81/833b0853551deb810854f96b43dea342b6e6c9b0ea1afcccf774157d519d/polars_runtime_32-1.43.2-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:2cc3ff96fd44789b02eb5c15b98dfcb000101636b177d3034fae2feec19b118f", size = 47540529, upload-time = "2026-08-01T06:27:21.391Z" },
+    { url = "https://files.pythonhosted.org/packages/83/55/7b2a75af14c9294d97f3bec132dd3018ddcd988bef32b5d28322150b8c11/polars_runtime_32-1.43.2-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:10ed36e615ab362feb7406e6d084e124b445ad284caa73bd93ae7e65745ed894", size = 51366340, upload-time = "2026-08-01T06:27:24.776Z" },
+    { url = "https://files.pythonhosted.org/packages/62/60/64deacb3abc70c52e2d88a808a052d1621c86a48fe9194f2c065579ab1cd/polars_runtime_32-1.43.2-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6d5a7ae004a2723ebf4427f6d6a639f30f86af4cf077075f6b35d04711154fc3", size = 57304599, upload-time = "2026-08-01T06:27:27.875Z" },
+    { url = "https://files.pythonhosted.org/packages/52/95/d6e3a236d7630e17c40d0ddee839bf2be9acf548fdc0e5ad65ed9ff0cac6/polars_runtime_32-1.43.2-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:09339eacc6d392206e78aabbaaa37d7276eb969b798f46cb1f367fd718798c60", size = 51520580, upload-time = "2026-08-01T06:27:30.913Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/5a/2deb8eac70e9a2ac26d88a66ae7cf52612865026f4f4a5e7ab11ad9d52bf/polars_runtime_32-1.43.2-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:452b400e59e7f56e4c6437f435e796903272a9388feee12de2bea049ae87025e", size = 55204471, upload-time = "2026-08-01T06:27:33.886Z" },
+    { url = "https://files.pythonhosted.org/packages/29/9e/647401ae8a607bc0cc40ed7b8592d5b1be90ded0dc9b9d6d3aeb03f9524b/polars_runtime_32-1.43.2-cp310-abi3-win_amd64.whl", hash = "sha256:00e33c28e321410c8d66e814a90043101e3bdd9ed2c6dabda07565aa8adbbdf1", size = 52572176, upload-time = "2026-08-01T06:27:37.048Z" },
+    { url = "https://files.pythonhosted.org/packages/96/8d/60a50c3f36c85218a7ffcb48c6fe2ce1f7bec799152d68b8658ebed2179c/polars_runtime_32-1.43.2-cp310-abi3-win_arm64.whl", hash = "sha256:350a4868cae85bf8b3f81b33ba47927c15256bd9264dfc8c0753f1b927eac9d3", size = 46582513, upload-time = "2026-08-01T06:27:40.025Z" },
 ]
 
 [[package]]
@@ -3385,6 +3576,31 @@ wheels = [
 ]
 
 [[package]]
+name = "rm-lite"
+version = "2026.7.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "astropy" },
+    { name = "bilby" },
+    { name = "corner" },
+    { name = "dask", extra = ["array"] },
+    { name = "deprecation" },
+    { name = "emcee" },
+    { name = "finufft" },
+    { name = "nestle" },
+    { name = "numpy" },
+    { name = "polars" },
+    { name = "scipy" },
+    { name = "sigfig" },
+    { name = "tdqm" },
+    { name = "zarr" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ed/3f/a274ef3f08da3ee977349f350b9f19fe61d8ee831c4d9e581587a66346b4/rm_lite-2026.7.7.tar.gz", hash = "sha256:e95ab3875c09457b4a68cb6ed845e68628c28e8c89e394980a0a19d30db76020", size = 409418, upload-time = "2026-07-20T14:04:56.911Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/2c/9b884bdfb3bc6850e2004d3ac8bd8326ac4aa7c6811c1e34b11443a9b0b3/rm_lite-2026.7.7-py3-none-any.whl", hash = "sha256:100904f60de0af4a7fdce510c30229b61af35cd93780c9e8c97018a08294594a", size = 92096, upload-time = "2026-07-20T14:04:55.439Z" },
+]
+
+[[package]]
 name = "roman-numerals"
 version = "4.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3712,6 +3928,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
+name = "sigfig"
+version = "1.3.19"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sortedcontainers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d8/a1/90bc16852efe100582b9d6c43c495aa8708fe67e72d3dfb44964463604e1/sigfig-1.3.19.tar.gz", hash = "sha256:a9e4fa37aa7595cc01b7207bfabf86cccd2d3edfddcdaa925ffd57dd77efcd9e", size = 14235, upload-time = "2025-03-10T04:51:30.01Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/29/18af3de86d94b13d49ec9a4a8cf164187fffb22431c2f3f3e7836339d631/sigfig-1.3.19-py3-none-any.whl", hash = "sha256:7bde0715e1a0cddb93c3ed3b9f8f20bf4cc77bbb47c570fe6fbd7b43aa6fd56c", size = 10710, upload-time = "2025-03-10T04:51:28.753Z" },
 ]
 
 [[package]]
@@ -4068,6 +4296,15 @@ sdist = { url = "https://files.pythonhosted.org/packages/f4/8a/14c15ae154895cc13
 wheels = [
     { url = "https://files.pythonhosted.org/packages/02/be/5d2d47b1fb58943194fb59dcf222f7c4e35122ec0ffe8c36e18b5d728f0b/tblib-3.2.2-py3-none-any.whl", hash = "sha256:26bdccf339bcce6a88b2b5432c988b266ebbe63a4e593f6b578b1d2e723d2b76", size = 12893, upload-time = "2025-11-12T12:21:14.407Z" },
 ]
+
+[[package]]
+name = "tdqm"
+version = "0.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5a/38/58c9e22b95e98666fe29f35e217ab6126a03798dadf3f4f8f3e5f898510b/tdqm-0.0.1.tar.gz", hash = "sha256:f050004a76b1d22f70b78209b48781353c82440215b6ba7d22b1f499b05a0101", size = 1388, upload-time = "2020-08-19T20:16:22.191Z" }
 
 [[package]]
 name = "text-unidecode"

--- a/uv.lock
+++ b/uv.lock
@@ -272,7 +272,7 @@ requires-dist = [
     { name = "pytest-xdist", marker = "extra == 'dev'" },
     { name = "python-casacore", marker = "extra == 'all'", specifier = ">=3.6.0" },
     { name = "python-casacore", marker = "extra == 'casa'", specifier = ">=3.6.0" },
-    { name = "racs-tools", specifier = ">=4.2.1" },
+    { name = "racs-tools", specifier = ">=4.3.2" },
     { name = "radio-beam", specifier = ">=0.3.4" },
     { name = "reproject" },
     { name = "rm-lite", marker = "extra == 'all'", specifier = "==2026.8.7" },
@@ -3244,7 +3244,7 @@ wheels = [
 
 [[package]]
 name = "racs-tools"
-version = "4.3.0"
+version = "4.3.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "astropy" },
@@ -3255,9 +3255,9 @@ dependencies = [
     { name = "spectral-cube" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/29/c2/8dcfd4078e8d95f237663601d0ad6cc8e2a8f85ee49f26f58bac87b8e1c8/racs_tools-4.3.0.tar.gz", hash = "sha256:a1ceefb4fb90c2431f8cdaf36a206d285b7525ffa90fbb4231500904989ca623", size = 32984, upload-time = "2025-08-08T04:51:43.651Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f4/b6/abf40ab734acb4dd8cf797a8d6ad6cb2af5f16296e5bf85f53a033efc340/racs_tools-4.3.2.tar.gz", hash = "sha256:d2b88d1b809b1da6a760badf903ed149aac915b10b40d1a143d1f9a81c7c6b7c", size = 33850, upload-time = "2026-09-01T06:40:09.44Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7b/2b/4f808a80756236f0405ba1789d43e63218278ec6c1ed945827009c83609c/racs_tools-4.3.0-py3-none-any.whl", hash = "sha256:50cab8f2ffd10f477e83c93537c90595e3bb4d2fef6319895492d0e9ce585607", size = 35086, upload-time = "2025-08-08T04:51:42.557Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/37/64efbc697222fc916c8448a62ebc876aa0ee5e7d0182dd8e23f25679ba3d/racs_tools-4.3.2-py3-none-any.whl", hash = "sha256:01e62357f75e2b4d871f1985aa943e846c108bb86711b90db5103e8bb18070ed", size = 36030, upload-time = "2026-09-01T06:40:10.268Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -244,7 +244,7 @@ requires-dist = [
     { name = "configargparse", specifier = ">=1.7" },
     { name = "crystalball", specifier = ">=0.4.3" },
     { name = "dask-jobqueue" },
-    { name = "fitscube", extras = ["pgzip"], specifier = ">=2.6" },
+    { name = "fitscube", extras = ["pgzip"], specifier = ">=2.7" },
     { name = "fixms", marker = "extra == 'all'", specifier = ">=0.4.0" },
     { name = "fixms", marker = "extra == 'casa'", specifier = ">=0.4.0" },
     { name = "furo", marker = "extra == 'all'" },
@@ -1257,7 +1257,7 @@ wheels = [
 
 [[package]]
 name = "fitscube"
-version = "2.6.0"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "astropy" },
@@ -1265,9 +1265,9 @@ dependencies = [
     { name = "radio-beam" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e6/82/097d1f2c9441b07f91a75d57ddbe62a32dde8dba11f93968395c349523af/fitscube-2.6.0.tar.gz", hash = "sha256:d073194681e93a0b3069d7e430cf75f0c21882fefc5d54ef631c7c4654109c77", size = 794576, upload-time = "2026-08-31T08:06:08.977Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/bf/57d9b6b603af3d5ea0f56b920fef44e3315d2ba085cd8bea6a7b117c0cce/fitscube-2.7.0.tar.gz", hash = "sha256:a8c7071c18da9e079274a06d31d9ce7115ccf7248c88fc18b7719faaaf916adb", size = 796080, upload-time = "2026-09-10T12:48:56.239Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/50/a3/010b81e2cca21ea4f362903eb181082aca6cb788597ef0441eea1f9cea5a/fitscube-2.6.0-py3-none-any.whl", hash = "sha256:6094a8af7dc52a0250549e67030398d5ce52e8d38a2a0cc0db0306b05fc33aac", size = 31194, upload-time = "2026-08-31T08:06:07.446Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/c9/0e905a4f885652911d48d4a9408f9ba72123d36dbf8ff999fdbd7697d3e8/fitscube-2.7.0-py3-none-any.whl", hash = "sha256:45ca2895b53aaff23b86b0465af90c28c93ff3e9c78fc438d34409919e590e1b", size = 32346, upload-time = "2026-09-10T12:48:54.683Z" },
 ]
 
 [package.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -275,7 +275,7 @@ requires-dist = [
     { name = "pytest-xdist", marker = "extra == 'dev'" },
     { name = "python-casacore", marker = "extra == 'all'", specifier = ">=3.6.0" },
     { name = "python-casacore", marker = "extra == 'casa'", specifier = ">=3.6.0" },
-    { name = "racs-tools", specifier = ">=4.3.2" },
+    { name = "racs-tools", specifier = ">=4.4.0" },
     { name = "radio-beam", specifier = ">=0.3.4" },
     { name = "reproject" },
     { name = "rm-lite", marker = "extra == 'all'", specifier = "==2026.8.7" },
@@ -3248,7 +3248,7 @@ wheels = [
 
 [[package]]
 name = "racs-tools"
-version = "4.3.2"
+version = "4.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "astropy" },
@@ -3259,9 +3259,9 @@ dependencies = [
     { name = "spectral-cube" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f4/b6/abf40ab734acb4dd8cf797a8d6ad6cb2af5f16296e5bf85f53a033efc340/racs_tools-4.3.2.tar.gz", hash = "sha256:d2b88d1b809b1da6a760badf903ed149aac915b10b40d1a143d1f9a81c7c6b7c", size = 33850, upload-time = "2026-09-01T06:40:09.44Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/57/4a823f259f487282b4f240e0ed12174c11e1a176deb8d96d17ea1fb38a4a/racs_tools-4.4.0.tar.gz", hash = "sha256:e29bbea3dfe1a8b4e201bcc1bd97e95d632ddcb10c47b032f81978b41ba1d08b", size = 34315, upload-time = "2026-09-10T10:44:58.021Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6a/37/64efbc697222fc916c8448a62ebc876aa0ee5e7d0182dd8e23f25679ba3d/racs_tools-4.3.2-py3-none-any.whl", hash = "sha256:01e62357f75e2b4d871f1985aa943e846c108bb86711b90db5103e8bb18070ed", size = 36030, upload-time = "2026-09-01T06:40:10.268Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/ea/274bc4563b1d97be4d4f5ab82ca6154b46e5d5d43b14829a935e8f4b319a/racs_tools-4.4.0-py3-none-any.whl", hash = "sha256:be1a93a58a1ee404c5141eb39d9d0ffcb13f45fc45648808f8f5429f726f05e2", size = 36565, upload-time = "2026-09-10T10:44:58.965Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -278,8 +278,8 @@ requires-dist = [
     { name = "racs-tools", specifier = ">=4.3.2" },
     { name = "radio-beam", specifier = ">=0.3.4" },
     { name = "reproject" },
-    { name = "rm-lite", marker = "extra == 'all'", specifier = "==2026.9.2" },
-    { name = "rm-lite", marker = "extra == 'rmsynth'", specifier = "==2026.9.2" },
+    { name = "rm-lite", marker = "extra == 'all'", specifier = "==2026.9.4" },
+    { name = "rm-lite", marker = "extra == 'rmsynth'", specifier = "==2026.9.4" },
     { name = "rocket-fft" },
     { name = "ruff", marker = "extra == 'all'" },
     { name = "ruff", marker = "extra == 'dev'" },
@@ -3494,7 +3494,7 @@ wheels = [
 
 [[package]]
 name = "rm-lite"
-version = "2026.9.2"
+version = "2026.9.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "astropy" },
@@ -3506,9 +3506,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "zarr" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5d/2d/5dd32b9962b36fa3cf0cfc743fd7e27f04cc55bf202361bbc44e7462e651/rm_lite-2026.9.2.tar.gz", hash = "sha256:6654ddf6a99f3e6a20ec9542c7f52a701c5895c9e1ae51dfb7844011934641fb", size = 461583, upload-time = "2026-09-09T01:40:37.255Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/5c/18e0d1967d4995348d68c67f80979312d0f94a1421f2cad15d79d6abff1f/rm_lite-2026.9.4.tar.gz", hash = "sha256:1719eb00d1f517eb284b50241533d9921eabe61f5aa2199094fe2f18c40fbdea", size = 416804, upload-time = "2026-09-10T07:36:32.697Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a5/d0/4d16952fb4dcf83a40bf7a3416f01002ad6b87cd95f49ede6fe4e08c9708/rm_lite-2026.9.2-py3-none-any.whl", hash = "sha256:00a7386043723911583511c45ae988152f2f8651efd28518903c63ed761515ea", size = 121790, upload-time = "2026-09-09T01:40:35.235Z" },
+    { url = "https://files.pythonhosted.org/packages/71/ee/f9eb11aa67e06d43ee21ab755b204caf3c3a875937cd8cd21a8ef896ab09/rm_lite-2026.9.4-py3-none-any.whl", hash = "sha256:bf4b39d3abd18f6863fca1114b3b940fb9642c1d10917c636a4a0aae637f8033", size = 128004, upload-time = "2026-09-10T07:36:31.182Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -278,8 +278,8 @@ requires-dist = [
     { name = "racs-tools", specifier = ">=4.3.2" },
     { name = "radio-beam", specifier = ">=0.3.4" },
     { name = "reproject" },
-    { name = "rm-lite", marker = "extra == 'all'", specifier = "==2026.8.7" },
-    { name = "rm-lite", marker = "extra == 'rmsynth'", specifier = "==2026.8.7" },
+    { name = "rm-lite", marker = "extra == 'all'", specifier = "==2026.9.1" },
+    { name = "rm-lite", marker = "extra == 'rmsynth'", specifier = "==2026.9.1" },
     { name = "rocket-fft" },
     { name = "ruff", marker = "extra == 'all'" },
     { name = "ruff", marker = "extra == 'dev'" },
@@ -3494,7 +3494,7 @@ wheels = [
 
 [[package]]
 name = "rm-lite"
-version = "2026.8.7"
+version = "2026.9.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "astropy" },
@@ -3506,9 +3506,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "zarr" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6d/9f/c3d7d0260ae064d4e810b476aa4b7ce56298d0457617dc3b544a2a9611ab/rm_lite-2026.8.7.tar.gz", hash = "sha256:155519c3e4063bfa733c7da7f383001c9e47f6cdc5a51d9f33a6b8a06e60f68f", size = 447821, upload-time = "2026-08-31T02:52:55.402Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/fe/908095c26d0370932af23c71873b2a4cb8c8287afe46a87904a2fa11f98b/rm_lite-2026.9.1.tar.gz", hash = "sha256:4d1f04313c8323055bb60239577511e9dc048b0fce8c9d77118b7525616b920c", size = 454291, upload-time = "2026-09-06T13:31:26.321Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/44/1d/92c36880b4b3deb64710951fd2232a586010f872c9b80363e4d994fe88fe/rm_lite-2026.8.7-py3-none-any.whl", hash = "sha256:bf1760d5ebaeead154fb5b24cd600e18fe5c742a7044411469b15d8316002e75", size = 117925, upload-time = "2026-08-31T02:52:54.139Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/7d/0e16201e5ef83636abc76db1c1cb0015feb7af59b3a78227f45ae5e83af6/rm_lite-2026.9.1-py3-none-any.whl", hash = "sha256:a111292ea8f420a57a06bece38fe890a19fb44b0878dd13481d4eb9f718398ca", size = 120041, upload-time = "2026-09-06T13:31:24.912Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -278,8 +278,8 @@ requires-dist = [
     { name = "racs-tools", specifier = ">=4.3.2" },
     { name = "radio-beam", specifier = ">=0.3.4" },
     { name = "reproject" },
-    { name = "rm-lite", marker = "extra == 'all'", specifier = "==2026.9.1" },
-    { name = "rm-lite", marker = "extra == 'rmsynth'", specifier = "==2026.9.1" },
+    { name = "rm-lite", marker = "extra == 'all'", specifier = "==2026.9.2" },
+    { name = "rm-lite", marker = "extra == 'rmsynth'", specifier = "==2026.9.2" },
     { name = "rocket-fft" },
     { name = "ruff", marker = "extra == 'all'" },
     { name = "ruff", marker = "extra == 'dev'" },
@@ -3494,7 +3494,7 @@ wheels = [
 
 [[package]]
 name = "rm-lite"
-version = "2026.9.1"
+version = "2026.9.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "astropy" },
@@ -3506,9 +3506,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "zarr" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/57/fe/908095c26d0370932af23c71873b2a4cb8c8287afe46a87904a2fa11f98b/rm_lite-2026.9.1.tar.gz", hash = "sha256:4d1f04313c8323055bb60239577511e9dc048b0fce8c9d77118b7525616b920c", size = 454291, upload-time = "2026-09-06T13:31:26.321Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5d/2d/5dd32b9962b36fa3cf0cfc743fd7e27f04cc55bf202361bbc44e7462e651/rm_lite-2026.9.2.tar.gz", hash = "sha256:6654ddf6a99f3e6a20ec9542c7f52a701c5895c9e1ae51dfb7844011934641fb", size = 461583, upload-time = "2026-09-09T01:40:37.255Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/7d/0e16201e5ef83636abc76db1c1cb0015feb7af59b3a78227f45ae5e83af6/rm_lite-2026.9.1-py3-none-any.whl", hash = "sha256:a111292ea8f420a57a06bece38fe890a19fb44b0878dd13481d4eb9f718398ca", size = 120041, upload-time = "2026-09-06T13:31:24.912Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/d0/4d16952fb4dcf83a40bf7a3416f01002ad6b87cd95f49ede6fe4e08c9708/rm_lite-2026.9.2-py3-none-any.whl", hash = "sha256:00a7386043723911583511c45ae988152f2f8651efd28518903c63ed761515ea", size = 121790, upload-time = "2026-09-09T01:40:35.235Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -278,8 +278,8 @@ requires-dist = [
     { name = "racs-tools", specifier = ">=4.4.0" },
     { name = "radio-beam", specifier = ">=0.3.4" },
     { name = "reproject" },
-    { name = "rm-lite", marker = "extra == 'all'", specifier = "==2026.9.6" },
-    { name = "rm-lite", marker = "extra == 'rmsynth'", specifier = "==2026.9.6" },
+    { name = "rm-lite", marker = "extra == 'all'", specifier = "==2026.9.7" },
+    { name = "rm-lite", marker = "extra == 'rmsynth'", specifier = "==2026.9.7" },
     { name = "rocket-fft" },
     { name = "ruff", marker = "extra == 'all'" },
     { name = "ruff", marker = "extra == 'dev'" },
@@ -3494,7 +3494,7 @@ wheels = [
 
 [[package]]
 name = "rm-lite"
-version = "2026.9.6"
+version = "2026.9.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "astropy" },
@@ -3506,9 +3506,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "zarr" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d6/90/c1c4e5ecb1d28766bb64c1dbe01d9988db80efeda893c8c19678159d68bf/rm_lite-2026.9.6.tar.gz", hash = "sha256:0350c6f3ba399a7e6e04b6c695ae763996d5be731ef0246d49aa06c802b2862e", size = 418667, upload-time = "2026-09-11T05:12:15.167Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/50/4e/27e47bba46ec2114a6738340865cd607dfd5aeb4bfeae3e1951271d4e81a/rm_lite-2026.9.7.tar.gz", hash = "sha256:afd85826b4726b179f8fc2660040125d7f9a4ee2e033e18b402ad22c816c5214", size = 424037, upload-time = "2026-09-12T09:23:53.544Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/74/60/bdf652bf64b216fb12660e89af7a4cf18d4bec84dcdfb127904444fb9e21/rm_lite-2026.9.6-py3-none-any.whl", hash = "sha256:d4bfc8a4e66cd578b8e09685d33fce665e3e4234b2d44139b6a150f5affe8a08", size = 128731, upload-time = "2026-09-11T05:12:13.821Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/51/87d26a2013a302a9c6eb4ec7723b03ac053eaa4dfb72b7792bbafbb8dd7f/rm_lite-2026.9.7-py3-none-any.whl", hash = "sha256:09a2f297a39868c12f22fa5f970a56a30da39840c232b8c9b56116230875e3d1", size = 129927, upload-time = "2026-09-12T09:23:51.701Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -278,8 +278,8 @@ requires-dist = [
     { name = "racs-tools", specifier = ">=4.4.0" },
     { name = "radio-beam", specifier = ">=0.3.4" },
     { name = "reproject" },
-    { name = "rm-lite", marker = "extra == 'all'", specifier = "==2026.9.4" },
-    { name = "rm-lite", marker = "extra == 'rmsynth'", specifier = "==2026.9.4" },
+    { name = "rm-lite", marker = "extra == 'all'", specifier = "==2026.9.6" },
+    { name = "rm-lite", marker = "extra == 'rmsynth'", specifier = "==2026.9.6" },
     { name = "rocket-fft" },
     { name = "ruff", marker = "extra == 'all'" },
     { name = "ruff", marker = "extra == 'dev'" },
@@ -3494,7 +3494,7 @@ wheels = [
 
 [[package]]
 name = "rm-lite"
-version = "2026.9.4"
+version = "2026.9.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "astropy" },
@@ -3506,9 +3506,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "zarr" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/25/5c/18e0d1967d4995348d68c67f80979312d0f94a1421f2cad15d79d6abff1f/rm_lite-2026.9.4.tar.gz", hash = "sha256:1719eb00d1f517eb284b50241533d9921eabe61f5aa2199094fe2f18c40fbdea", size = 416804, upload-time = "2026-09-10T07:36:32.697Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/90/c1c4e5ecb1d28766bb64c1dbe01d9988db80efeda893c8c19678159d68bf/rm_lite-2026.9.6.tar.gz", hash = "sha256:0350c6f3ba399a7e6e04b6c695ae763996d5be731ef0246d49aa06c802b2862e", size = 418667, upload-time = "2026-09-11T05:12:15.167Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/71/ee/f9eb11aa67e06d43ee21ab755b204caf3c3a875937cd8cd21a8ef896ab09/rm_lite-2026.9.4-py3-none-any.whl", hash = "sha256:bf4b39d3abd18f6863fca1114b3b940fb9642c1d10917c636a4a0aae637f8033", size = 128004, upload-time = "2026-09-10T07:36:31.182Z" },
+    { url = "https://files.pythonhosted.org/packages/74/60/bdf652bf64b216fb12660e89af7a4cf18d4bec84dcdfb127904444fb9e21/rm_lite-2026.9.6-py3-none-any.whl", hash = "sha256:d4bfc8a4e66cd578b8e09685d33fce665e3e4234b2d44139b6a150f5affe8a08", size = 128731, upload-time = "2026-09-11T05:12:13.821Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Weaves in an optional polarisation subflow to RACS-all
- Tweaks `apply_cube_division` location so can also be used by pol flow
- Some shenanigans to create pol flow options and add to single parser