### PR TITLE
Adjusts FITS header write out and calls the channel interval creation code

### DIFF
--- a/flint/imager/wsclean.py
+++ b/flint/imager/wsclean.py
@@ -1089,7 +1089,7 @@ def rotate_cube(output_cube_path: str | Path, inplace: bool = True) -> Path:
         if f"CTYPE{b}" not in tmp_header:
             continue
 
-        for key in ("CTYPE", "CRPIX", "CRVAL", "CDELT", "CUNIT"):
+        for key in ("NAXIS", "CTYPE", "CRPIX", "CRVAL", "CDELT", "CUNIT"):
             # A key absent on the source axis (e.g. CUNIT on STOKES) has to be
             # removed from the destination, else a stale value is left behind
             if f"{key}{b}" in tmp_header:

--- a/flint/imager/wsclean.py
+++ b/flint/imager/wsclean.py
@@ -1101,11 +1101,21 @@ def rotate_cube(output_cube_path: str | Path, inplace: bool = True) -> Path:
     # moveaxis is a contiguous view of the memmap and nothing is read into memory.
     # Reading a whole cube in is enough to blow a worker's memory budget
     if header["NAXIS"] == 4 and min(header["NAXIS3"], header["NAXIS4"]) == 1:
-        logger.info(f"Rotating {output_path.name} via a view of the memmap")
-        with fits.open(output_path, mode="update", memmap=True) as hdul:
-            hdul[0].data = np.moveaxis(hdul[0].data, 1, 0)
-            hdul[0].header = header
-            hdul.flush()
+        logger.info(f"Rotating {output_path.name} via a header rewrite only")
+        original_header = fits.getheader(output_path)
+        original_header_string = original_header.tostring()
+        new_header_string = header.tostring()
+        logger.info(
+            f"Old header length {len(original_header_string)} bytes, new header length {len(new_header_string)} bytes"
+        )
+        assert len(original_header_string) == len(new_header_string), (
+            f"Header length mismatch: {len(original_header_string)} != {len(new_header_string)}. "
+            "This should not happen, and indicates a bug in the header rotation code."
+        )
+        logger.info("Writing new header to FITS cube in place")
+        with open(output_path, mode="r+b") as f:
+            f.write(new_header_string.encode("ascii"))
+
         return output_path
 
     # Move data axis: (pol, chan, dec, ra) → (chan, pol, dec, ra)

--- a/flint/prefect/flows/racs_all_continuum_selfcal.py
+++ b/flint/prefect/flows/racs_all_continuum_selfcal.py
@@ -400,15 +400,22 @@ def process_racs_all_field(
                     update_potato_peel_options=unmapped(potato_peel_options),
                 )
 
+            update_wsclean_options = get_options_from_strategy(
+                strategy=strategy,
+                mode="wsclean",
+                round_info=0,
+                operation="selfcal",
+            )
+            if cube_division is not None:
+                update_wsclean_options = _apply_cube_division(
+                    update_wsclean_options=update_wsclean_options,
+                    cube_division=cube_division,
+                )
+
             wsclean_result = task_wsclean_imager.submit(
                 in_ms=preprocess_science_mss,
                 wsclean_container=racs_all_options.wsclean_container,
-                update_wsclean_options=get_options_from_strategy(
-                    strategy=strategy,
-                    mode="wsclean",
-                    round_info=0,
-                    operation="selfcal",
-                ),
+                update_wsclean_options=update_wsclean_options,
             )
             imaging_results[0].append(
                 LoopFutures(
@@ -491,7 +498,7 @@ def process_racs_all_field(
                     round_info=current_round,
                     operation="selfcal",
                 )
-                if final_round and cube_division is not None:
+                if cube_division is not None:
                     update_wsclean_options = _apply_cube_division(
                         update_wsclean_options=update_wsclean_options,
                         cube_division=cube_division,


### PR DESCRIPTION
I noticed some strange errors when rerunning the racs-all pipeline, experimenting with the linmos cube utility. During this the earliest rounds of wsclean (before self-cal) started failing. Specifically the stage of the imaging task that forms a fits cube was blowing up. I thought at first that the rotation was the issue, as there were tasks that would start attempting this then failing. 

It turned out though that the root cause was that the new channel out option added to help ensure consistent and predictable fitscube outputs was only being used on the final round of self-cal imaging results. I did hav it patched in for all rounds, but must not have committed it. 

In anycase, I think it is only a good thing to use if for all rounds. At the very least it would prevent fitscube from inserting too many blank planes, increasing the output file size 10x. If we only want to run this on the final round of imaging then we should consider deleting the cubes as we go to preserve disk space. They get hefty quickly when a single cube is 15GB (note that were becoming 150GB when the channel interval override is not provided). 