### PR TITLE
Refactor cube convolution

### DIFF
--- a/flint/coadd/linmos.py
+++ b/flint/coadd/linmos.py
@@ -190,30 +190,6 @@ def _merge_bound_boxes(bounding_boxes: Collection[BoundingBox]) -> BoundingBox:
     )
 
 
-def common_bound_box(images: Collection[Path]) -> BoundingBox:
-    """Construct the bounding box that encloses the valid pixels of every image.
-
-    Images are read one at a time so that a set of planes destined for a cube
-    may be trimmed onto a common pixel grid without holding the cube in memory.
-
-    Args:
-        images (Collection[Path]): The FITS images to consider
-
-    Returns:
-        BoundingBox: The box enclosing the valid pixels of all ``images``
-    """
-    logger.info(f"Constructing a common bounding box over {len(images)} images")
-
-    bounding_boxes = []
-    for image in images:
-        data = np.squeeze(fits.getdata(image))
-        # 0.0 is not a real number, and is how linmos denotes blanked pixels
-        data[data == 0.0] = np.nan
-        bounding_boxes.append(create_bound_box(image_data=data, is_masked=False))
-
-    return _merge_bound_boxes(bounding_boxes=bounding_boxes)
-
-
 class TrimImageResult(NamedTuple):
     """The constructed path and the bounding box"""
 

--- a/flint/imager/wsclean.py
+++ b/flint/imager/wsclean.py
@@ -265,6 +265,7 @@ def combine_images_to_cube(
     mode: str,
     remove_original_images: bool = False,
     inplace: bool = True,
+    invalidate_zeros: bool = False,
 ) -> Path:
     """Combine wsclean subband channel images into a cube. Each collection attribute
     of the input `image_set` will be inspected. The MFS images will be ignored.
@@ -276,6 +277,8 @@ def combine_images_to_cube(
         remove_original_images (bool, optional): If True, images that went into the cube are removed. Defaults to False.
         inplace (bool, optional): If True, modify the file in-place. If False, write to a temporary file and
         then replace the original. Default True
+        invalidate_zeros (bool, optional): If True, any zero-valued pixels in the cube will be set to NaN. This is useful for linmos co-addition. Defaults to False.
+
     Returns:
         ImageSet: Updated iamgeset describing the new outputs
     """
@@ -286,7 +289,9 @@ def combine_images_to_cube(
     output_cube_name = create_image_cube_name(image_prefix=Path(prefix), mode=mode)
 
     logger.info(f"Combining {len(images)} images. {images=}")
-    freqs = combine_fits(file_list=images, out_cube=output_cube_name)
+    freqs = combine_fits(
+        file_list=images, out_cube=output_cube_name, invalidate_zeros=invalidate_zeros
+    )
     rotate_cube(output_cube_name, inplace=inplace)
 
     # Write out the hdu to preserve the beam table constructed in fitscube

--- a/flint/imager/wsclean.py
+++ b/flint/imager/wsclean.py
@@ -22,7 +22,7 @@ from collections.abc import Collection
 from glob import glob
 from numbers import Number
 from pathlib import Path
-from typing import Any, NamedTuple
+from typing import Any, Literal, NamedTuple
 
 import numpy as np
 from astropy.io import fits
@@ -31,7 +31,8 @@ from capn_crunch import (
     create_options_from_parser,
     options_to_dict,
 )
-from fitscube.combine_fits import combine_fits
+from fitscube.bounding_box import BoundingBox
+from fitscube.combine_fits import combine_fits, compress_cube
 from fitscube.exceptions import TargetAxisMissingException
 from fitscube.extract import ExtractOptions, extract_plane_from_cube, find_target_axis
 
@@ -207,6 +208,10 @@ class WSCleanOptions(BaseOptions):
     # Options below here are not added to wsclean command
     flint_make_cube_inplace: bool = True
     """Rotate the cube for the linmos axis ordering in place, or do it via a temporary file that then gets deleted. Good thing to turn off when getting weird OSErrors on file writing"""
+    flint_make_cube_compress: bool = False
+    """Gzip-compress the subband cube once formed. Defaults to False."""
+    flint_make_cube_compress_method: Literal["gzip", "pgzip"] = "pgzip"
+    """The compression backend to use when ``flint_make_cube_compress`` is set. Defaults to 'pgzip'."""
     flint_no_log_wsclean_output: bool = False
     """If True do not log the wsclean output"""
 
@@ -266,6 +271,9 @@ def combine_images_to_cube(
     remove_original_images: bool = False,
     inplace: bool = True,
     invalidate_zeros: bool = False,
+    bounding_box: bool | BoundingBox = False,
+    compress: bool = False,
+    compress_method: Literal["gzip", "pgzip"] = "pgzip",
 ) -> Path:
     """Combine wsclean subband channel images into a cube. Each collection attribute
     of the input `image_set` will be inspected. The MFS images will be ignored.
@@ -278,6 +286,9 @@ def combine_images_to_cube(
         inplace (bool, optional): If True, modify the file in-place. If False, write to a temporary file and
         then replace the original. Default True
         invalidate_zeros (bool, optional): If True, any zero-valued pixels in the cube will be set to NaN. This is useful for linmos co-addition. Defaults to False.
+        bounding_box (bool | BoundingBox, optional): Trim the cube to the common bounding box of valid pixels across `images`. Pass a pre-computed `BoundingBox` to reuse a box shared with another cube (e.g. weights). Defaults to False.
+        compress (bool, optional): Gzip-compress the cube once written. Defaults to False.
+        compress_method (Literal["gzip", "pgzip"], optional): Compression backend used when `compress` is set. Defaults to "pgzip".
 
     Returns:
         ImageSet: Updated iamgeset describing the new outputs
@@ -290,7 +301,10 @@ def combine_images_to_cube(
 
     logger.info(f"Combining {len(images)} images. {images=}")
     freqs = combine_fits(
-        file_list=images, out_cube=output_cube_name, invalidate_zeros=invalidate_zeros
+        file_list=images,
+        out_cube=output_cube_name,
+        invalidate_zeros=invalidate_zeros,
+        bounding_box=bounding_box,
     )
     rotate_cube(output_cube_name, inplace=inplace)
 
@@ -302,6 +316,9 @@ def combine_images_to_cube(
 
     if remove_original_images:
         remove_files_folders(*images)
+
+    if compress:
+        output_cube_name = compress_cube(output_cube_name, method=compress_method)
 
     return output_cube_name
 
@@ -1151,6 +1168,8 @@ def combine_image_set_to_cube(
     image_set: ImageSet,
     remove_original_images: bool = False,
     inplace: bool = True,
+    compress: bool = False,
+    compress_method: Literal["gzip", "pgzip"] = "pgzip",
 ) -> ImageSet:
     """Combine wsclean subband channel images into a cube. Each collection attribute
     of the input `image_set` will be inspected. The MFS images will be ignored.
@@ -1162,6 +1181,8 @@ def combine_image_set_to_cube(
         remove_original_images (bool, optional): If True, images that went into the cube are removed. Defaults to False.
         inplace (bool, optional): If True, modify the file in-place. If False, write to a temporary file and
         then replace the original. Default True
+        compress (bool, optional): Gzip-compress each cube once written. Defaults to False.
+        compress_method (Literal["gzip", "pgzip"], optional): Compression backend used when `compress` is set. Defaults to "pgzip".
 
     Returns:
         ImageSet: Updated iamgeset describing the new outputs
@@ -1205,6 +1226,11 @@ def combine_image_set_to_cube(
 
         output_freqs_name = Path(output_cube_name).with_suffix(".freqs_Hz.txt")
         np.savetxt(output_freqs_name, freqs.to("Hz").value)
+
+        if compress:
+            output_cube_name = compress_cube(
+                Path(output_cube_name), method=compress_method
+            )
 
         image_set_dict[mode] = [Path(output_cube_name)] + [
             image for image in image_set_dict[mode] if image not in subband_images
@@ -1385,6 +1411,8 @@ def run_wsclean_imager(
             image_set=image_set,
             remove_original_images=True,
             inplace=wsclean_result.options.flint_make_cube_inplace,
+            compress=wsclean_result.options.flint_make_cube_compress,
+            compress_method=wsclean_result.options.flint_make_cube_compress_method,
         )
 
     image_set = rename_wsclean_prefix_in_image_set(input_image_set=image_set)

--- a/flint/options.py
+++ b/flint/options.py
@@ -10,7 +10,7 @@ hold stateful properties throughout the flint codebase.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Protocol
+from typing import Literal, Protocol
 
 import numpy as np
 import yaml
@@ -230,7 +230,7 @@ class PolFieldOptions(BaseOptions):
     """Specify the final beamsize of linmos field images in (arcsec, arcsec, deg)"""
     pb_cutoff: float = 0.1
     """Primary beam attenuation cutoff to use during linmos"""
-    trim_linmos_fits: bool = False
+    trim_linmos_fits: bool = True
     """Trim the linmos fits files to remove the padding that is added. If True, the output fits files will be smaller but might be different shapes"""
     imaging_strategy: Path | None = None
     """Path to a FLINT imaging yaml file that contains settings to use throughout imaging"""
@@ -383,6 +383,10 @@ class FitsCubeOptions(BaseOptions):
     """The number of concurrent workers (readers/writers) that are permitted at a time"""
     invalidate_zeros: bool = True
     """Set pixels whose values are exactly 0.0 to not-a-number (nan)"""
+    compress: bool = False
+    """Gzip-compress the output cube once written"""
+    compress_method: Literal["gzip", "pgzip"] = "pgzip"
+    """The compression backend to use when ``compress`` is set"""
 
 
 class MSSummary(BaseOptions):

--- a/flint/prefect/common/imaging.py
+++ b/flint/prefect/common/imaging.py
@@ -8,10 +8,11 @@ from __future__ import annotations
 
 from collections.abc import Collection
 from pathlib import Path
-from typing import Any, ParamSpec, TypeVar
+from typing import Any, Literal, ParamSpec, TypeVar
 
 import numpy as np
 import pandas as pd
+from fitscube.bounding_box import BoundingBox, get_common_bounding_box
 from prefect import Task, unmapped
 from prefect.artifacts import create_table_artifact
 from prefect.futures import PrefectFuture
@@ -23,12 +24,9 @@ from flint.calibrate.aocalibrate import (
     select_aosolution_for_ms,
 )
 from flint.coadd.linmos import (
-    BoundingBox,
     LinmosOptions,
     LinmosResult,
-    common_bound_box,
     linmos_images,
-    trim_fits_image,
 )
 from flint.convol import (
     BeamShape,
@@ -109,7 +107,7 @@ task_merge_image_sets_from_results = task(merge_image_sets_from_results)
 task_transpose_and_sort_channel_images = task(transpose_and_sort_channel_images)
 task_create_name_from_common_fields = task(create_name_from_common_fields)
 task_remove_files_folders = task(remove_files_folders)
-task_common_bound_box = task(common_bound_box)
+task_get_common_bounding_box = task(get_common_bounding_box)
 
 # Tasks below are extracting componented from earlier stages, or are
 # otherwise doing something important
@@ -120,12 +118,6 @@ FlagMS = TypeVar("FlagMS", MS, ApplySolutions)
 @task
 def task_get_channel_images_from_paths(paths: list[Path]) -> list[Path]:
     return [path for path in paths if "MFS" not in path.name]
-
-
-@task
-def task_trim_to_bound_box(image: Path, bounding_box: BoundingBox) -> Path:
-    """Trim an image to a bounding box shared with other images"""
-    return trim_fits_image(image_path=image, bounding_box=bounding_box).path
 
 
 @task
@@ -991,13 +983,16 @@ def linmos_channel_groups_to_cubes(
     field_summary: FieldSummary | None = None,
     suffix_str: str | None = None,
     holofile: Path | None = None,
+    compress: bool = False,
+    compress_method: Literal["gzip", "pgzip"] = "pgzip",
 ) -> list[PrefectFuture[Path]]:
     """Co-add beam images one channel at a time, in parallel, then stack the
     resulting mosaics back into image and weight cubes.
 
-    Should ``linmos_options.trim_linmos_fits`` be set the trimming is deferred
-    until every channel has been co-added, so that a single bounding box may be
-    shared across the channels and the image and weight products.
+    Should ``linmos_options.trim_linmos_fits`` be set, the common bounding box
+    of valid pixels is computed once every channel has been co-added and is
+    passed into the cube assembly so fitscube trims both the image and weight
+    cubes to the same shared pixel grid while writing them.
 
     Args:
         channel_groups (Collection[Collection[Path]]): For each channel, the beam images to co-add
@@ -1007,6 +1002,8 @@ def linmos_channel_groups_to_cubes(
         field_summary (FieldSummary | None, optional): Description of the field, used to get the ``pol_axis``. Defaults to None.
         suffix_str (str | None, optional): Additional suffix added to the linmos and cube names. Defaults to None.
         holofile (Path | None, optional): Holography file overriding the one in ``linmos_options``. Defaults to None.
+        compress (bool, optional): Gzip-compress the image and weight cubes once written. Defaults to False.
+        compress_method (Literal["gzip", "pgzip"], optional): Compression backend used when `compress` is set. Defaults to "pgzip".
 
     Returns:
         list[PrefectFuture[Path]]: The image and weight cubes being created
@@ -1040,17 +1037,13 @@ def linmos_channel_groups_to_cubes(
         image_planes.append(task_getattr.submit(linmos_result, "image_fits"))
         weight_planes.append(task_getattr.submit(linmos_result, "weight_fits"))
 
+    bounding_box: bool | PrefectFuture[BoundingBox] = False
     if linmos_options.trim_linmos_fits:
         # Passing the futures in is what forms the barrier - every channel has to
-        # be co-added before the box that all of them share can be known
-        bounding_box = task_common_bound_box.submit(images=image_planes)
-        image_planes = task_trim_to_bound_box.map(
-            image=image_planes,  # type: ignore
-            bounding_box=unmapped(bounding_box),  # type: ignore
-        )
-        weight_planes = task_trim_to_bound_box.map(
-            image=weight_planes,  # type: ignore
-            bounding_box=unmapped(bounding_box),  # type: ignore
+        # be co-added before the box that all of them share can be known. The same
+        # box is then reused for both cubes so they stay on the same pixel grid.
+        bounding_box = task_get_common_bounding_box.submit(
+            file_list=image_planes, invalidate_zeros=True
         )
 
     # Stack the per-channel mosaics back into image and weight cubes,
@@ -1064,6 +1057,9 @@ def linmos_channel_groups_to_cubes(
             prefix=cube_prefix,
             mode=mode,
             remove_original_images=True,
+            bounding_box=bounding_box,
+            compress=compress,
+            compress_method=compress_method,
         )
         for planes, mode in ((image_planes, "image"), (weight_planes, "weight"))
     ]

--- a/flint/prefect/common/imaging.py
+++ b/flint/prefect/common/imaging.py
@@ -1058,6 +1058,7 @@ def linmos_channel_groups_to_cubes(
             mode=mode,
             remove_original_images=True,
             bounding_box=bounding_box,
+            invalidate_zeros=True,
             compress=compress,
             compress_method=compress_method,
         )

--- a/flint/prefect/common/imaging.py
+++ b/flint/prefect/common/imaging.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from collections.abc import Collection
 from pathlib import Path
-from typing import Any, Literal, ParamSpec, TypeVar
+from typing import Any, ParamSpec, TypeVar
 
 import numpy as np
 import pandas as pd
@@ -32,10 +32,8 @@ from flint.coadd.linmos import (
 )
 from flint.convol import (
     BeamShape,
-    convolve_cubes,
     convolve_images,
     get_common_beam,
-    get_cube_common_beam,
 )
 from flint.flagging import flag_ms_aoflagger
 from flint.imager.wsclean import (
@@ -554,92 +552,24 @@ task_get_common_beam_from_results: Task[P, R] = task(get_common_beam_from_result
 
 
 @task
-def task_get_cube_common_beam(
-    wsclean_results: Collection[WSCleanResult],
-    cutoff: float = 25,
-) -> list[BeamShape]:
-    """Compute a common beam size  for input cubes.
+def task_split_beam_cube_into_planes(wsclean_result: WSCleanResult) -> list[Path]:
+    """Split a per-beam wsclean image cube into its per-channel planes, ready
+    to be convolved individually rather than as a whole cube.
 
     Args:
-        wsclean_results (Collection[WSCleanResult]): Input images whose restoring beam properties will be considered
-        cutoff (float, optional): Major axis larger than this valur, in arcseconds, will be ignored. Defaults to 25.
+        wsclean_result (WSCleanResult): Output of wsclean whose image cube will be split
 
     Returns:
-        List[BeamShape]: The final convolving beam size to be used per channel in cubes
-    """
-
-    images_to_consider: list[Path] = []
-
-    # TODO: This should support other image types
-    for wsclean_result in wsclean_results:
-        if wsclean_result.image_set is None:
-            logger.warning(
-                f"No image_set for {wsclean_result.ms} found. Has imager finished?"
-            )
-            continue
-        images_to_consider.extend(wsclean_result.image_set.image)
-
-    images_to_consider = get_fits_cube_from_paths(paths=images_to_consider)
-
-    logger.info(
-        f"Considering {len(images_to_consider)} images across {len(wsclean_results)} outputs. "
-    )
-
-    beam_shapes = get_cube_common_beam(cube_paths=images_to_consider, cutoff=cutoff)
-
-    return beam_shapes
-
-
-@task
-def task_convolve_cube(
-    wsclean_result: WSCleanResult,
-    beam_shapes: list[BeamShape],
-    cutoff: float = 60,
-    mode: Literal["image"] = "image",
-    convol_suffix_str: str = "conv",
-) -> Collection[Path]:
-    """Convolve images to a specified resolution
-
-    Args:
-        wsclean_result (WSCleanResult): Collection of output images from wsclean that will be convolved
-        beam_shapes (BeamShape): The shape images will be convolved to
-        cutoff (float, optional): Maximum major beam axis an image is allowed to have before it will not be convolved. Defaults to 60.
-        convol_suffix_str (str, optional): The suffix added to the convolved images. Defaults to 'conv'.
-
-    Returns:
-        Collection[Path]: Path to the output images that have been convolved.
+        list[Path]: The per-channel planes extracted from the image cube
     """
     assert wsclean_result.image_set is not None, (
         f"{wsclean_result.ms} has no attached image_set."
     )
 
-    supported_modes = ("image",)
-    logger.info(f"Extracting {mode}")
-    if mode == "image":
-        image_paths = list(wsclean_result.image_set.image)
-    else:
-        raise ValueError(f"{mode=} is not supported. Known modes are {supported_modes}")
+    cube_paths = get_fits_cube_from_paths(paths=list(wsclean_result.image_set.image))
+    assert len(cube_paths) == 1, f"Expected a single image cube, got {cube_paths=}"
 
-    logger.info(f"Extracting cubes from image_set {mode=}")
-    image_paths = get_fits_cube_from_paths(paths=image_paths)
-
-    # It is possible depending on how aggressively cleaning image products are deleted that these
-    # some cleaning products (e.g. residuals) do not exist. There are a number of ways one could consider
-    # handling this. The pirate in me feels like less is more, so an error will be enough. Keeping
-    # things simple and avoiding the problem is probably the better way of dealing with this
-    # situation. In time this would mean that we inspect and handle conflicting pipeline options.
-    assert image_paths is not None, (
-        f"{image_paths=} for {mode=} and {wsclean_result.image_set=}"
-    )
-
-    logger.info(f"Will convolve {image_paths}")
-
-    return convolve_cubes(
-        cube_paths=image_paths,
-        beam_shapes=beam_shapes,
-        cutoff=cutoff,
-        convol_suffix=convol_suffix_str,
-    )
+    return split_cube_into_planes(cube=cube_paths[0])
 
 
 def convolve_image_set(
@@ -1151,28 +1081,33 @@ def create_convolve_linmos_cubes(
         suffixes.insert(0, additional_linmos_suffix_str)
     linmos_suffix_str = ".".join(suffixes)
 
-    beam_shapes = task_get_cube_common_beam.submit(
-        wsclean_results=wsclean_results, cutoff=field_options.beam_cutoff
-    )
-    convolved_cubes = task_convolve_cube.map(
-        wsclean_result=wsclean_results,  # type: ignore
-        cutoff=field_options.beam_cutoff,
-        mode=unmapped("image"),  # type: ignore
-        beam_shapes=unmapped(beam_shapes),  # type: ignore
-    )
     # linmos co-adds a cube channel-by-channel serially, so split the beam cubes
-    # into planes and co-add each channel in parallel instead. Resolving here
-    # blocks until the convolutions above have completed.
-    beam_planes = task_split_cube_into_planes.map(
-        cubes=convolved_cubes  # type: ignore
-    )
+    # into planes and co-add each channel in parallel instead. Splitting before
+    # convolving means each channel is convolved as a single 2D plane rather
+    # than pulling the whole per-beam cube into memory for a 3D convolution.
+    beam_planes = task_split_beam_cube_into_planes.map(wsclean_result=wsclean_results)  # type: ignore
     channel_groups: list[list[Path]] = task_transpose_and_sort_channel_images.submit(
         beam_channel_images=beam_planes  # type: ignore
     ).result()
 
+    beam_shapes = task_get_common_beam_from_images.map(
+        image_paths=channel_groups,  # type: ignore
+        cutoff=unmapped(field_options.beam_cutoff),  # type: ignore
+    )
+    convolved_channel_groups: list[list[Path]] = task_convolve_images.map(
+        image_paths=channel_groups,  # type: ignore
+        beam_shape=beam_shapes,  # type: ignore
+        cutoff=unmapped(field_options.beam_cutoff),  # type: ignore
+    ).result()
+
+    # The unconvolved planes have been superseded by convolved_channel_groups
+    task_remove_files_folders.submit(
+        *[plane for beam_images in channel_groups for plane in beam_images]
+    )
+
     assert field_options.yandasoft_container is not None
     cube_results = linmos_channel_groups_to_cubes(
-        channel_groups=channel_groups,
+        channel_groups=convolved_channel_groups,
         container=field_options.yandasoft_container,
         linmos_options=LinmosOptions(
             holofile=field_options.holofile,
@@ -1184,9 +1119,9 @@ def create_convolve_linmos_cubes(
         holofile=holofile,
     )
 
-    # Remove the extracted planes once every cube has been formed
+    # Remove the convolved planes once every cube has been formed
     task_remove_files_folders.submit(
-        *[plane for beam_images in channel_groups for plane in beam_images],
+        *[plane for beam_images in convolved_channel_groups for plane in beam_images],
         wait_for=cube_results,
     )
     return cube_results

--- a/flint/prefect/flows/racs_all_continuum_selfcal.py
+++ b/flint/prefect/flows/racs_all_continuum_selfcal.py
@@ -515,31 +515,6 @@ def process_racs_all_field(
                 terminal_futures.append(wsclean_result)
 
     if racs_all_options.yandasoft_container:
-        if racs_all_options.coadd_cubes:
-            with tags("cubes"):
-                cube_add_round = racs_all_options.rounds
-                cube_add_round = racs_all_options.rounds
-
-                assert cube_add_round is not None, (
-                    f"{racs_all_options.rounds=}, but needs to be positive"
-                )
-
-                cube_results = [
-                    beam_result.wsclean_result
-                    for beam_result in imaging_results[cube_add_round]
-                ]
-
-                linmos_cubes = create_convolve_linmos_cubes(
-                    wsclean_results=cube_results,  # type: ignore
-                    field_options=racs_all_options,
-                    current_round=(
-                        racs_all_options.rounds if racs_all_options.rounds else None
-                    ),
-                    additional_linmos_suffix_str="cube",
-                    holofile=holography_path,
-                )
-                terminal_futures.extend(linmos_cubes)
-
         for selfcal_round, final_beam_imaging_results in imaging_results.items():
             additional_linmos_suffix = (
                 "noselfcal" if selfcal_round == 0 else f"round{selfcal_round}"
@@ -579,6 +554,33 @@ def process_racs_all_field(
                     )
                     if val_results:
                         terminal_futures.extend(val_results)
+
+        # There are some blocking calls in the cube coadding, so do it
+        # as late as possible, ya sea rat
+        if racs_all_options.coadd_cubes:
+            with tags("cubes"):
+                cube_add_round = racs_all_options.rounds
+                cube_add_round = racs_all_options.rounds
+
+                assert cube_add_round is not None, (
+                    f"{racs_all_options.rounds=}, but needs to be positive"
+                )
+
+                cube_results = [
+                    beam_result.wsclean_result
+                    for beam_result in imaging_results[cube_add_round]
+                ]
+
+                linmos_cubes = create_convolve_linmos_cubes(
+                    wsclean_results=cube_results,  # type: ignore
+                    field_options=racs_all_options,
+                    current_round=(
+                        racs_all_options.rounds if racs_all_options.rounds else None
+                    ),
+                    additional_linmos_suffix_str="cube",
+                    holofile=holography_path,
+                )
+                terminal_futures.extend(linmos_cubes)
 
     terminal_futures.append(field_summary)
 

--- a/flint/prefect/flows/subtract_cube_pipeline.py
+++ b/flint/prefect/flows/subtract_cube_pipeline.py
@@ -17,7 +17,7 @@ import dask
 import numpy as np
 from capn_crunch import add_options_to_parser, create_options_from_parser
 from configargparse import ArgumentParser
-from fitscube.combine_fits import combine_fits
+from fitscube.combine_fits import combine_fits, compress_cube
 from prefect import flow, tags, unmapped
 from prefect.futures import PrefectFuture
 
@@ -264,6 +264,12 @@ def task_combine_all_linmos_images(
                 f"{image=} does not exist, but it should"
             )
             image.unlink()
+
+    if fits_cube_options.compress:
+        output_cube_path = compress_cube(
+            output_cube_path, method=fits_cube_options.compress_method
+        )
+
     return Path(output_cube_path)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "scikit-image",
     "pandas",
     "ConfigArgParse>=1.7",
-    "fitscube>=2.4.1",
+    "fitscube[pgzip]>=2.5.0",
     "astroquery>=0.4.8.dev0",
     "crystalball>=0.4.3",
     "jolly-roger>=0.10.1",

--- a/tests/test_linmos_coadd.py
+++ b/tests/test_linmos_coadd.py
@@ -20,12 +20,10 @@ from flint.coadd.linmos import (
     _get_holography_linmos_options,
     _get_image_weight_plane,
     _linmos_cleanup,
-    common_bound_box,
     create_bound_box,
     generate_weights_list_and_files,
     trim_fits_image,
 )
-from flint.exceptions import ShapeMismatchError
 from flint.naming import create_linmos_base_path
 
 
@@ -334,53 +332,6 @@ def test_trim_fits_image_matching(tmp_path):
 
     with pytest.raises(ValueError):
         trim_fits_image(image_path=out_fits2, bounding_box=og_trim.bounding_box)
-
-
-def test_common_bound_box(tmp_path):
-    """Planes destined for a cube have to be trimmed onto a single grid, so the
-    box has to be the union across them all"""
-    tmp_dir = tmp_path / "common_box"
-    tmp_dir.mkdir()
-
-    bounds = ((10, 600, 20, 500), (100, 200, 600, 800), (800, 888, 20, 500))
-    images = []
-    for index, (xmin, xmax, ymin, ymax) in enumerate(bounds):
-        data = np.zeros((1000, 1000))
-        data[xmin:xmax, ymin:ymax] = index + 1
-        images.append(tmp_dir / f"example{index}.fits")
-        # linmos blanks with 0.0, not NaN, which common_bound_box has to handle
-        fits.writeto(
-            images[-1],
-            data=data,
-            header=fits.header.Header({"CRPIX1": 10, "CRPIX2": 20}),
-        )
-
-    bb = common_bound_box(images=images)
-    assert bb == BoundingBox(
-        xmin=10, xmax=888, ymin=20, ymax=800, original_shape=(1000, 1000)
-    )
-
-    for image in images:
-        trim_fits_image(image_path=image, bounding_box=bb)
-
-    trimmed_shapes = {fits.getdata(image).shape for image in images}
-    assert trimmed_shapes == {(878, 780)}
-    assert {fits.getheader(image)["CRPIX1"] for image in images} == {-10}
-    assert {fits.getheader(image)["CRPIX2"] for image in images} == {10}
-
-
-def test_common_bound_box_shape_mismatch(tmp_path):
-    """Images on differing grids can not share a box"""
-    tmp_dir = tmp_path / "common_box_mismatch"
-    tmp_dir.mkdir()
-
-    images = []
-    for index, shape in enumerate(((100, 100), (100, 101))):
-        images.append(tmp_dir / f"example{index}.fits")
-        fits.writeto(images[-1], data=np.ones(shape))
-
-    with pytest.raises(ShapeMismatchError):
-        common_bound_box(images=images)
 
 
 def test_bounding_box():


### PR DESCRIPTION
Refactors how per-cube cubes are made during the self-cal flows. Currently we convolve the 3D cubes which can blow up memory (annoyingly).

This changes the ordering to `split into planes → group by channel across beams → convolve each plane (2D) → linmos`