### PR TITLE
Fix RM-synthesis on the linmos weight cubes

### DIFF
--- a/flint/options.py
+++ b/flint/options.py
@@ -276,7 +276,7 @@ class RMSynthOptions(BaseOptions):
     debias_filter_size: int = 5
     """Median filter size (pixels) used by mom0 debiasing"""
     per_pixel_rmsf: bool = False
-    """Compute the RMSF for each pixel rather than one shared by the cube. Roughly doubles the FDF's size"""
+    """Compute the RMSF for each pixel rather than one shared by the cube. Roughly doubles the FDF's size. rm-lite turns this on itself when the weights make pixels disagree, as the linmos weight cubes do"""
     estimate_stokes_i_noise: bool = True
     """Derive the per-channel Stokes I error from the Stokes I cube when no Stokes I weight cube is given. A weight cube takes precedence"""
 

--- a/flint/options.py
+++ b/flint/options.py
@@ -276,14 +276,9 @@ class RMSynthOptions(BaseOptions):
     debias_filter_size: int = 5
     """Median filter size (pixels) used by mom0 debiasing"""
     per_pixel_rmsf: bool = False
-    """Compute the RMSF for each pixel in the cube. ~2x the FDF's size, and only
-    worth turning on for per-pixel blanking that the channel weights do not carry"""
+    """Compute the RMSF for each pixel rather than one shared by the cube. Roughly doubles the FDF's size"""
     estimate_stokes_i_noise: bool = True
-    """Derive a per-channel Stokes I error from the Stokes I cube itself when no
-    Stokes I weight cube is given. rm-lite refuses a ``stokes_i_snr_cut`` with
-    nothing to measure SNR against, and scoring every pixel as infinite SNR would
-    fit noise as if it were signal, so the estimate is the fallback that keeps the
-    cut meaningful. A supplied weight cube takes precedence over it"""
+    """Derive the per-channel Stokes I error from the Stokes I cube when no Stokes I weight cube is given. A weight cube takes precedence"""
 
 
 class RMCleanOptions(BaseOptions):

--- a/flint/options.py
+++ b/flint/options.py
@@ -276,7 +276,14 @@ class RMSynthOptions(BaseOptions):
     debias_filter_size: int = 5
     """Median filter size (pixels) used by mom0 debiasing"""
     per_pixel_rmsf: bool = False
-    """ Compute the RMSF for each pixel in the cube """
+    """Compute the RMSF for each pixel in the cube. ~2x the FDF's size, and only
+    worth turning on for per-pixel blanking that the channel weights do not carry"""
+    estimate_stokes_i_noise: bool = True
+    """Derive a per-channel Stokes I error from the Stokes I cube itself when no
+    Stokes I weight cube is given. rm-lite refuses a ``stokes_i_snr_cut`` with
+    nothing to measure SNR against, and scoring every pixel as infinite SNR would
+    fit noise as if it were signal, so the estimate is the fallback that keeps the
+    cut meaningful. A supplied weight cube takes precedence over it"""
 
 
 class RMCleanOptions(BaseOptions):

--- a/flint/prefect/flows/polarisation_pipeline.py
+++ b/flint/prefect/flows/polarisation_pipeline.py
@@ -78,6 +78,30 @@ class PolPipelineResult(BaseOptions):
     """Every future the polarisation stage produced, propagated so Prefect still detects any of their failures"""
 
 
+def _no_products(
+    terminal_futures: list[PrefectFuture[Any]] | None = None,
+) -> PolPipelineResult:
+    """The result of a polarisation stage that imaged nothing.
+
+    Built here rather than at each early return so that a field added to
+    ``PolPipelineResult`` cannot turn one of them into a ValidationError: the
+    downstream rm-synth stage reads ``weight_cubes`` off this, and an early
+    return that forgot it failed only once the flow was already running.
+
+    Args:
+        terminal_futures (list[PrefectFuture[Any]] | None, optional): Futures produced before the stage gave up, propagated so Prefect still detects their failures. Defaults to None.
+
+    Returns:
+        PolPipelineResult: An empty result carrying only ``terminal_futures``
+    """
+    return PolPipelineResult(
+        stokes_cubes={},
+        weight_cubes={},
+        mfs_products={},
+        terminal_futures=terminal_futures or [],
+    )
+
+
 @flow(name="Flint Polarisation Pipeline")
 def process_science_fields_pol(
     flint_ms_directory: Path,
@@ -105,9 +129,7 @@ def process_science_fields_pol(
 
     if strategy is None:
         logger.info("No strategy provided. Returning.")
-        return PolPipelineResult(
-            stokes_cubes={}, weight_cubes={}, mfs_products={}, terminal_futures=[]
-        )
+        return _no_products()
 
     if mss_by_beam is not None:
         # Already Flint-processed, self-calibrated MSs handed down by the calling
@@ -190,9 +212,7 @@ def process_science_fields_pol(
 
     if pol_field_options.wsclean_container is None:
         logger.info("No wsclean container provided. Returning. ")
-        return PolPipelineResult(
-            stokes_cubes={}, mfs_products={}, terminal_futures=[field_summary]
-        )
+        return _no_products(terminal_futures=[field_summary])
 
     polarisations: dict[str, str] = strategy.get("polarisation", {"total": {}})
 

--- a/flint/rmsynth.py
+++ b/flint/rmsynth.py
@@ -6,10 +6,12 @@ from __future__ import annotations
 
 import logging
 import os
+import warnings
 from pathlib import Path
 from typing import Any, Literal
 
 import dask
+import dask.array as da
 import numpy as np
 import zarr
 from astropy.io import fits
@@ -32,6 +34,7 @@ from rm_lite.tools_3d.rmsynth import (  # noqa: E402
     RMSynth3DResults,
     rmsynth_3d_from_fits,
 )
+from rm_lite.utils.dask_io import read_fits_cube_channel_chunks  # noqa: E402
 from rm_lite.utils.synthesis import (  # noqa: E402
     FaradayMoments,
     calc_faraday_moments,
@@ -77,6 +80,88 @@ def _check_cubes_memmappable(*cubes: Path | None) -> None:
         raise NotSupportedError(msg)
 
 
+def per_channel_weights_from_linmos(
+    stokes_q_weight_cube: Path,
+    stokes_u_weight_cube: Path,
+    target_chunk_mb: float = 256,
+) -> np.ndarray:
+    """Collapse the linmos Q/U weight cubes to the per-channel weight spectrum.
+
+    RM-synthesis weights channels, not pixels: rm-lite derives one RMSF and one
+    theoretical FDF noise for the whole cube from a single ``(n_freq,)`` weight
+    vector, and its ``_shared_rmsf`` is only valid if every pixel shares that
+    vector. A linmos weight cube is the opposite -- it is dominated by the
+    primary-beam taper, and is zero outside ``LinmosOptions.cutoff`` -- so
+    handing the cube straight to rm-lite as an error file would let one pixel's
+    beam response stand in for the whole field's channel weighting, and would
+    fold the blanked-out edge into the whole-cube noise.
+
+    So the spatial axes are reduced here instead, to the median over the pixels
+    linmos actually filled. The median (rather than the mean) keeps the taper
+    and the blanked edge from dragging a channel's weight around, leaving the
+    channel-to-channel ratio -- all RM-synthesis uses -- set by sensitivity
+    rather than by how much of the field happened to be covered. A channel
+    linmos blanked entirely keeps a zero weight, which drops it from the
+    synthesis as intended.
+
+    Computed eagerly, not left lazy: rm-lite's theoretical noise is a scalar
+    reduction over this array, and a lazy one propagates a dask scalar into
+    ``run_rmclean_from_synth``, which formats it into a log line.
+
+    Args:
+        stokes_q_weight_cube (Path): Path to the linmos Stokes Q weight cube
+        stokes_u_weight_cube (Path): Path to the linmos Stokes U weight cube
+        target_chunk_mb (float, optional): Target per-chunk memory footprint, in MB, for the frequency-chunked reads. Defaults to 256.
+
+    Returns:
+        np.ndarray: Per-channel weights, shape (n_freq,), zero where a channel
+        carries no valid weight
+    """
+    q_planes, _ = read_fits_cube_channel_chunks(
+        stokes_q_weight_cube, target_chunk_mb=target_chunk_mb
+    )
+    u_planes, _ = read_fits_cube_channel_chunks(
+        stokes_u_weight_cube, target_chunk_mb=target_chunk_mb
+    )
+    if q_planes.shape != u_planes.shape:
+        msg = (
+            f"The Stokes Q and U weight cubes disagree on shape: "
+            f"{q_planes.shape} against {u_planes.shape}. They come from the same "
+            "linmos run over the same channels, so a mismatch means the wrong "
+            "pair was paired up."
+        )
+        raise NotSupportedError(msg)
+
+    # Frequency-chunked, so each block holds whole channel planes and the
+    # per-channel median never needs pixels from another block.
+    mean_weights = (q_planes + u_planes) / 2.0
+    valid = da.isfinite(mean_weights) & (mean_weights > 0)
+    with warnings.catch_warnings():
+        # A channel linmos blanked everywhere is all-NaN by construction here,
+        # and is meant to median to nan and then to a zero weight below
+        warnings.filterwarnings("ignore", "All-NaN slice encountered", RuntimeWarning)
+        per_channel = da.nanmedian(
+            da.where(valid, mean_weights, np.nan), axis=(1, 2)
+        ).compute()
+
+    # An all-blank channel medians to nan; it has no sensitivity, so weight zero
+    weight_arr = np.nan_to_num(np.asarray(per_channel, dtype=np.float64), nan=0.0)
+    n_blank = int((weight_arr <= 0).sum())
+    if n_blank:
+        logger.info(
+            f"{n_blank} of {weight_arr.size} channels carry no linmos weight and "
+            "will be dropped from the RM-synthesis"
+        )
+    if not weight_arr.any():
+        msg = (
+            f"{stokes_q_weight_cube} and {stokes_u_weight_cube} are zero or blank "
+            "in every channel, so every channel would be dropped from the "
+            "RM-synthesis. Check that linmos produced usable weights."
+        )
+        raise NotSupportedError(msg)
+    return weight_arr
+
+
 def run_rmsynth_3d(
     stokes_q_cube: Path,
     stokes_u_cube: Path,
@@ -93,6 +178,9 @@ def run_rmsynth_3d(
         stokes_u_cube (Path): Path to the Stokes U FITS cube
         rmsynth_options (RMSynthOptions): Options controlling the synthesis
         stokes_i_cube (Path | None, optional): Path to a Stokes I FITS cube, used to fit a per-pixel fractional-polarisation correction. FDF stays in Q/U flux if not given. Defaults to None.
+        stokes_q_weight_cube (Path | None, optional): Path to the linmos Stokes Q weight cube, used as the per-channel weights instead of a noise estimate from the Q/U cubes. Both Q and U must be given for either to be used. Defaults to None.
+        stokes_u_weight_cube (Path | None, optional): Path to the linmos Stokes U weight cube. See ``stokes_q_weight_cube``. Defaults to None.
+        stokes_i_weight_cube (Path | None, optional): Path to the linmos Stokes I weight cube, used to weight the per-pixel Stokes I fit and to score it against ``stokes_i_snr_cut``. Falls back to ``RMSynthOptions.estimate_stokes_i_noise`` if not given. Defaults to None.
 
     Returns:
         RMSynth3DResults: Lazy dirty FDF cube, the RMSF spectrum every pixel
@@ -104,7 +192,26 @@ def run_rmsynth_3d(
         stokes_i_cube,
         stokes_q_weight_cube,
         stokes_u_weight_cube,
+        stokes_i_weight_cube,
     )
+    if (stokes_q_weight_cube is None) != (stokes_u_weight_cube is None):
+        logger.warning(
+            "Only one of the Stokes Q/U linmos weight cubes was given "
+            f"({stokes_q_weight_cube=}, {stokes_u_weight_cube=}); the channel "
+            "weights need both, so they will be estimated from the Q/U cubes instead"
+        )
+    # rm-lite would otherwise read these as error cubes and reduce them over the
+    # whole cube; collapse them to the per-channel spectrum it weights with
+    weight_arr = (
+        per_channel_weights_from_linmos(
+            stokes_q_weight_cube=stokes_q_weight_cube,
+            stokes_u_weight_cube=stokes_u_weight_cube,
+            target_chunk_mb=rmsynth_options.target_chunk_mb,
+        )
+        if stokes_q_weight_cube is not None and stokes_u_weight_cube is not None
+        else None
+    )
+
     stokes_i_kwargs = (
         {
             "stokes_i_file": stokes_i_cube,
@@ -112,6 +219,9 @@ def run_rmsynth_3d(
             "fit_order": rmsynth_options.fit_order,
             "fit_function": rmsynth_options.fit_function,
             "stokes_i_snr_cut": rmsynth_options.stokes_i_snr_cut,
+            # Only consulted when no Stokes I weight cube is given: rm-lite
+            # refuses a stokes_i_snr_cut it has no error to measure against.
+            "estimate_stokes_i_noise": rmsynth_options.estimate_stokes_i_noise,
             "compute_model_error": rmsynth_options.compute_model_error,
             "n_error_samples": rmsynth_options.n_error_samples,
         }
@@ -121,14 +231,16 @@ def run_rmsynth_3d(
     return rmsynth_3d_from_fits(
         stokes_q_file=stokes_q_cube,
         stokes_u_file=stokes_u_cube,
-        stokes_q_error_file=stokes_q_weight_cube,
-        stokes_u_error_file=stokes_u_weight_cube,
+        weight_arr=weight_arr,
+        # Only reaches the Stokes I error cube now that the Q/U weights are
+        # collapsed here: a per-pixel error is what the Stokes I fit wants
         noise_files_are_weight=True,
         phi_max_radm2=rmsynth_options.phi_max_radm2,
         d_phi_radm2=rmsynth_options.d_phi_radm2,
         n_samples=rmsynth_options.n_samples,
         weight_type=rmsynth_options.weight_type,
         robust=rmsynth_options.robust,
+        per_pixel_rmsf=rmsynth_options.per_pixel_rmsf,
         nufft_nthreads=rmsynth_options.nufft_nthreads,
         target_chunk_mb=rmsynth_options.target_chunk_mb,
         log_level=logging.INFO,

--- a/flint/rmsynth.py
+++ b/flint/rmsynth.py
@@ -6,12 +6,10 @@ from __future__ import annotations
 
 import logging
 import os
-import warnings
 from pathlib import Path
 from typing import Any, Literal
 
 import dask
-import dask.array as da
 import numpy as np
 import zarr
 from astropy.io import fits
@@ -34,7 +32,6 @@ from rm_lite.tools_3d.rmsynth import (  # noqa: E402
     RMSynth3DResults,
     rmsynth_3d_from_fits,
 )
-from rm_lite.utils.dask_io import read_fits_cube_channel_chunks  # noqa: E402
 from rm_lite.utils.synthesis import (  # noqa: E402
     FaradayMoments,
     calc_faraday_moments,
@@ -80,88 +77,6 @@ def _check_cubes_memmappable(*cubes: Path | None) -> None:
         raise NotSupportedError(msg)
 
 
-def per_channel_weights_from_linmos(
-    stokes_q_weight_cube: Path,
-    stokes_u_weight_cube: Path,
-    target_chunk_mb: float = 256,
-) -> np.ndarray:
-    """Collapse the linmos Q/U weight cubes to the per-channel weight spectrum.
-
-    RM-synthesis weights channels, not pixels: rm-lite derives one RMSF and one
-    theoretical FDF noise for the whole cube from a single ``(n_freq,)`` weight
-    vector, and its ``_shared_rmsf`` is only valid if every pixel shares that
-    vector. A linmos weight cube is the opposite -- it is dominated by the
-    primary-beam taper, and is zero outside ``LinmosOptions.cutoff`` -- so
-    handing the cube straight to rm-lite as an error file would let one pixel's
-    beam response stand in for the whole field's channel weighting, and would
-    fold the blanked-out edge into the whole-cube noise.
-
-    So the spatial axes are reduced here instead, to the median over the pixels
-    linmos actually filled. The median (rather than the mean) keeps the taper
-    and the blanked edge from dragging a channel's weight around, leaving the
-    channel-to-channel ratio -- all RM-synthesis uses -- set by sensitivity
-    rather than by how much of the field happened to be covered. A channel
-    linmos blanked entirely keeps a zero weight, which drops it from the
-    synthesis as intended.
-
-    Computed eagerly, not left lazy: rm-lite's theoretical noise is a scalar
-    reduction over this array, and a lazy one propagates a dask scalar into
-    ``run_rmclean_from_synth``, which formats it into a log line.
-
-    Args:
-        stokes_q_weight_cube (Path): Path to the linmos Stokes Q weight cube
-        stokes_u_weight_cube (Path): Path to the linmos Stokes U weight cube
-        target_chunk_mb (float, optional): Target per-chunk memory footprint, in MB, for the frequency-chunked reads. Defaults to 256.
-
-    Returns:
-        np.ndarray: Per-channel weights, shape (n_freq,), zero where a channel
-        carries no valid weight
-    """
-    q_planes, _ = read_fits_cube_channel_chunks(
-        stokes_q_weight_cube, target_chunk_mb=target_chunk_mb
-    )
-    u_planes, _ = read_fits_cube_channel_chunks(
-        stokes_u_weight_cube, target_chunk_mb=target_chunk_mb
-    )
-    if q_planes.shape != u_planes.shape:
-        msg = (
-            f"The Stokes Q and U weight cubes disagree on shape: "
-            f"{q_planes.shape} against {u_planes.shape}. They come from the same "
-            "linmos run over the same channels, so a mismatch means the wrong "
-            "pair was paired up."
-        )
-        raise NotSupportedError(msg)
-
-    # Frequency-chunked, so each block holds whole channel planes and the
-    # per-channel median never needs pixels from another block.
-    mean_weights = (q_planes + u_planes) / 2.0
-    valid = da.isfinite(mean_weights) & (mean_weights > 0)
-    with warnings.catch_warnings():
-        # A channel linmos blanked everywhere is all-NaN by construction here,
-        # and is meant to median to nan and then to a zero weight below
-        warnings.filterwarnings("ignore", "All-NaN slice encountered", RuntimeWarning)
-        per_channel = da.nanmedian(
-            da.where(valid, mean_weights, np.nan), axis=(1, 2)
-        ).compute()
-
-    # An all-blank channel medians to nan; it has no sensitivity, so weight zero
-    weight_arr = np.nan_to_num(np.asarray(per_channel, dtype=np.float64), nan=0.0)
-    n_blank = int((weight_arr <= 0).sum())
-    if n_blank:
-        logger.info(
-            f"{n_blank} of {weight_arr.size} channels carry no linmos weight and "
-            "will be dropped from the RM-synthesis"
-        )
-    if not weight_arr.any():
-        msg = (
-            f"{stokes_q_weight_cube} and {stokes_u_weight_cube} are zero or blank "
-            "in every channel, so every channel would be dropped from the "
-            "RM-synthesis. Check that linmos produced usable weights."
-        )
-        raise NotSupportedError(msg)
-    return weight_arr
-
-
 def run_rmsynth_3d(
     stokes_q_cube: Path,
     stokes_u_cube: Path,
@@ -178,13 +93,15 @@ def run_rmsynth_3d(
         stokes_u_cube (Path): Path to the Stokes U FITS cube
         rmsynth_options (RMSynthOptions): Options controlling the synthesis
         stokes_i_cube (Path | None, optional): Path to a Stokes I FITS cube, used to fit a per-pixel fractional-polarisation correction. FDF stays in Q/U flux if not given. Defaults to None.
-        stokes_q_weight_cube (Path | None, optional): Path to the linmos Stokes Q weight cube, used as the per-channel weights instead of a noise estimate from the Q/U cubes. Both Q and U must be given for either to be used. Defaults to None.
+        stokes_q_weight_cube (Path | None, optional): Path to the linmos Stokes Q weight cube, giving each pixel its own channel weights rather than one spectrum estimated from the Q/U cubes. rm-lite requires both Q and U, or neither. Defaults to None.
         stokes_u_weight_cube (Path | None, optional): Path to the linmos Stokes U weight cube. See ``stokes_q_weight_cube``. Defaults to None.
         stokes_i_weight_cube (Path | None, optional): Path to the linmos Stokes I weight cube, used to weight the per-pixel Stokes I fit and to score it against ``stokes_i_snr_cut``. Falls back to ``RMSynthOptions.estimate_stokes_i_noise`` if not given. Defaults to None.
 
     Returns:
-        RMSynth3DResults: Lazy dirty FDF cube, the RMSF spectrum every pixel
-        shares, and associated parameters
+        RMSynth3DResults: Lazy dirty FDF cube, the RMSF, and associated
+        parameters. The linmos weights vary with the primary beam, so pixels
+        rarely share one RMSF and rm-lite turns on the per-pixel RMSF cube
+        itself; see ``RMSynthOptions.per_pixel_rmsf`` for what that costs
     """
     _check_cubes_memmappable(
         stokes_q_cube,
@@ -194,24 +111,6 @@ def run_rmsynth_3d(
         stokes_u_weight_cube,
         stokes_i_weight_cube,
     )
-    if (stokes_q_weight_cube is None) != (stokes_u_weight_cube is None):
-        logger.warning(
-            "Only one of the Stokes Q/U linmos weight cubes was given "
-            f"({stokes_q_weight_cube=}, {stokes_u_weight_cube=}); the channel "
-            "weights need both, so they will be estimated from the Q/U cubes instead"
-        )
-    # rm-lite would otherwise read these as error cubes and reduce them over the
-    # whole cube; collapse them to the per-channel spectrum it weights with
-    weight_arr = (
-        per_channel_weights_from_linmos(
-            stokes_q_weight_cube=stokes_q_weight_cube,
-            stokes_u_weight_cube=stokes_u_weight_cube,
-            target_chunk_mb=rmsynth_options.target_chunk_mb,
-        )
-        if stokes_q_weight_cube is not None and stokes_u_weight_cube is not None
-        else None
-    )
-
     stokes_i_kwargs = (
         {
             "stokes_i_file": stokes_i_cube,
@@ -231,9 +130,10 @@ def run_rmsynth_3d(
     return rmsynth_3d_from_fits(
         stokes_q_file=stokes_q_cube,
         stokes_u_file=stokes_u_cube,
-        weight_arr=weight_arr,
-        # Only reaches the Stokes I error cube now that the Q/U weights are
-        # collapsed here: a per-pixel error is what the Stokes I fit wants
+        stokes_q_error_file=stokes_q_weight_cube,
+        stokes_u_error_file=stokes_u_weight_cube,
+        # linmos writes 1/sigma**2 directly, so rm-lite must not invert and
+        # square these again. Applies to the Stokes I error cube as well
         noise_files_are_weight=True,
         phi_max_radm2=rmsynth_options.phi_max_radm2,
         d_phi_radm2=rmsynth_options.d_phi_radm2,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ casa =[
     "fixms>=0.4.0"
 ]
 rmsynth = [
-    "rm-lite==2026.8.4",
+    "rm-lite==2026.8.5",
 ]
 all = [
     "askap-flint[dev,casa,rmsynth]",

--- a/tests/test_racs_all_pipeline.py
+++ b/tests/test_racs_all_pipeline.py
@@ -173,6 +173,28 @@ def test_process_racs_all_everything_disabled_returns_immediately(
     assert result == []
 
 
+def test_pol_stage_with_nothing_to_do_still_feeds_rm_synth() -> None:
+    """``process_racs_all`` reads ``weight_cubes`` off the polarisation result,
+    so a polarisation stage that imaged nothing has to return an empty one
+    rather than fail to construct. Both of its give-up paths go through
+    ``_no_products``, which is what this pins."""
+    from unittest.mock import MagicMock
+
+    from prefect.futures import PrefectFuture
+
+    from flint.prefect.flows.polarisation_pipeline import _no_products
+
+    future = MagicMock(spec=PrefectFuture)
+    for result in (_no_products(), _no_products(terminal_futures=[future])):
+        assert result.stokes_cubes == {}
+        assert result.weight_cubes == {}
+        assert result.mfs_products == {}
+
+    # The give-up path that has already built a field summary still propagates it
+    assert _no_products().terminal_futures == []
+    assert _no_products(terminal_futures=[future]).terminal_futures == [future]
+
+
 def test_get_parser_pol_cube_channel_width_is_independent() -> None:
     """The polarisation cube channelisation is deliberately its own option: a
     field name shared with RACSAllOptions is deduplicated in this combined CLI,

--- a/tests/test_racs_all_pipeline.py
+++ b/tests/test_racs_all_pipeline.py
@@ -195,6 +195,28 @@ def test_pol_stage_with_nothing_to_do_still_feeds_rm_synth() -> None:
     assert _no_products(terminal_futures=[future]).terminal_futures == [future]
 
 
+def test_pol_stage_without_a_strategy_returns_an_empty_result(tmp_path: Path) -> None:
+    """The give-up path that is reachable without any imaging setup, run through
+    the real flow rather than through ``_no_products`` directly: returning an
+    empty result is only useful if the flow actually gets there instead of
+    raising on the way, which is how the missing ``weight_cubes`` surfaced."""
+    from prefect.logging import disable_run_logger
+
+    from flint.options import PolFieldOptions
+    from flint.prefect.flows.polarisation_pipeline import process_science_fields_pol
+
+    with prefect_test_harness(), disable_run_logger():
+        result = process_science_fields_pol(
+            flint_ms_directory=tmp_path,
+            pol_field_options=PolFieldOptions(),
+        )
+
+    assert result.stokes_cubes == {}
+    assert result.weight_cubes == {}
+    assert result.mfs_products == {}
+    assert result.terminal_futures == []
+
+
 def test_get_parser_pol_cube_channel_width_is_independent() -> None:
     """The polarisation cube channelisation is deliberately its own option: a
     field name shared with RACSAllOptions is deduplicated in this combined CLI,

--- a/tests/test_rmsynth.py
+++ b/tests/test_rmsynth.py
@@ -15,6 +15,7 @@ from flint.options import RMCleanOptions, RMSynthOptions
 from flint.rmsynth import (
     FDFLabel,
     needs_rmclean,
+    per_channel_weights_from_linmos,
     run_rmclean_3d,
     run_rmsynth_3d,
     write_rm_products,
@@ -565,6 +566,222 @@ def test_rmsynth_rejects_compressed_cubes(tmp_path: Path) -> None:
             stokes_u_cube=tmp_path / "u.fits.gz",
             rmsynth_options=RMSynthOptions(),
         )
+
+
+def test_rmsynth_rejects_a_compressed_weight_cube(tmp_path: Path) -> None:
+    """The weight cubes are read block-by-block just like the Stokes cubes, so a
+    gzipped one inflates the whole cube per read in exactly the same way."""
+    stokes_q_cube, stokes_u_cube = _make_qu_cubes(tmp_path)
+    for weights in (
+        {"stokes_q_weight_cube": tmp_path / "q.weight.fits.gz"},
+        {"stokes_u_weight_cube": tmp_path / "u.weight.fits.gz"},
+        {"stokes_i_weight_cube": tmp_path / "i.weight.fits.gz"},
+    ):
+        with pytest.raises(NotSupportedError):
+            run_rmsynth_3d(
+                stokes_q_cube=stokes_q_cube,
+                stokes_u_cube=stokes_u_cube,
+                stokes_i_cube=_make_i_cube(tmp_path),
+                rmsynth_options=RMSynthOptions(),
+                **weights,
+            )
+
+
+def test_stokes_i_noise_is_estimated_when_no_weight_cube_is_given(
+    tmp_path: Path, qu_cubes: tuple[Path, Path]
+) -> None:
+    """The linmos weight cubes are the preferred Stokes I error, but they only
+    exist when the cubes came from the polarisation pipeline. rm-lite refuses a
+    ``stokes_i_snr_cut`` with no error to score against, so a Stokes I cube on its
+    own has to fall back to the per-channel estimate rather than raise."""
+    assert RMSynthOptions().estimate_stokes_i_noise is True
+    assert RMSynthOptions().stokes_i_snr_cut is not None
+
+    stokes_q_cube, stokes_u_cube = qu_cubes
+    output_prefix = tmp_path / "no_i_weights"
+
+    output_paths = _synth_and_write(
+        stokes_q_cube=stokes_q_cube,
+        stokes_u_cube=stokes_u_cube,
+        stokes_i_cube=_make_i_cube(tmp_path),
+        rmsynth_options=RMSynthOptions(),
+        rmclean_options=RMCleanOptions(),
+        cube_products=[],
+        moment_products=["dirty"],
+        output_prefix=output_prefix,
+        stokes_i_weight_cube=None,
+    )
+
+    alpha_path = Path(f"{output_prefix}.stokesi.alpha.fits")
+    assert alpha_path in output_paths
+    assert np.all(np.isfinite(fits.getdata(alpha_path)))
+
+
+def test_rmsynth_options_reach_rm_lite(
+    tmp_path: Path, qu_cubes: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Every RMSynthOptions field is there to change what rm-lite does, so one
+    that is never passed on is a silently ignored setting rather than a default."""
+    import flint.rmsynth as rmsynth_mod
+
+    captured: dict[str, object] = {}
+
+    def _capture(**kwargs: object) -> None:
+        captured.update(kwargs)
+        msg = "stop before synthesising"
+        raise NotSupportedError(msg)
+
+    monkeypatch.setattr(rmsynth_mod, "rmsynth_3d_from_fits", _capture)
+
+    stokes_q_cube, stokes_u_cube = qu_cubes
+    rmsynth_options = RMSynthOptions(per_pixel_rmsf=True, estimate_stokes_i_noise=False)
+    with pytest.raises(NotSupportedError, match="stop before synthesising"):
+        run_rmsynth_3d(
+            stokes_q_cube=stokes_q_cube,
+            stokes_u_cube=stokes_u_cube,
+            stokes_i_cube=_make_i_cube(tmp_path),
+            rmsynth_options=rmsynth_options,
+        )
+
+    assert captured["per_pixel_rmsf"] is True
+    assert captured["estimate_stokes_i_noise"] is False
+
+
+def _make_linmos_weight_cube(
+    tmp_path: Path,
+    name: str,
+    taper: bool = True,
+    blank_outside: float | None = None,
+    blank_channels: tuple[int, ...] = (),
+) -> Path:
+    """A weight cube shaped like the one linmos writes: a primary-beam taper,
+    zero outside the ``LinmosOptions.cutoff``, and an all-zero plane for any
+    channel that was flagged everywhere."""
+    freq_hz = np.linspace(700e6, 1300e6, N_CHAN)
+    yy, xx = np.mgrid[0:NY, 0:NX]
+    radius = np.hypot(yy - (NY - 1) / 2, xx - (NX - 1) / 2)
+
+    plane = np.exp(-(radius**2) / 2.0) if taper else np.ones((NY, NX))
+    if blank_outside is not None:
+        plane = np.where(radius > blank_outside, 0.0, plane)
+
+    cube = (plane[None] / 1e-3**2).repeat(N_CHAN, axis=0).astype(np.float32)
+    for channel in blank_channels:
+        cube[channel] = 0.0
+
+    wcs = WCS(naxis=3)
+    wcs.wcs.ctype = ["RA---SIN", "DEC--SIN", "FREQ"]
+    wcs.wcs.crval = [180.0, -30.0, freq_hz[0]]
+    wcs.wcs.crpix = [NX / 2, NY / 2, 1]
+    wcs.wcs.cdelt = [-1e-3, 1e-3, freq_hz[1] - freq_hz[0]]
+    wcs.wcs.cunit = ["deg", "deg", "Hz"]
+
+    path = tmp_path / f"{name}.weight.fits"
+    fits.writeto(path, cube, wcs.to_header(), overwrite=True)
+    return path
+
+
+def test_linmos_weights_collapse_to_one_weight_per_channel(tmp_path: Path) -> None:
+    """rm-lite weights channels, not pixels, and derives the cube's single RMSF
+    from a ``(n_freq,)`` vector. The linmos cubes are dominated by the
+    primary-beam taper and are zero outside the cutoff, so the spatial axes have
+    to come off before rm-lite sees them."""
+    weights = per_channel_weights_from_linmos(
+        stokes_q_weight_cube=_make_linmos_weight_cube(tmp_path, "q", blank_outside=1.5),
+        stokes_u_weight_cube=_make_linmos_weight_cube(tmp_path, "u", blank_outside=1.5),
+    )
+
+    assert weights.shape == (N_CHAN,)
+    assert weights.dtype == np.float64
+    # Computed, not lazy: rm-lite's theoretical noise reduces over this, and a
+    # lazy one reaches run_rmclean_from_synth as a dask scalar it cannot format
+    assert isinstance(weights, np.ndarray)
+    assert np.all(np.isfinite(weights))
+    # The taper is constant in frequency here, so every channel weighs the same
+    assert np.all(weights > 0)
+    assert np.allclose(weights, weights[0])
+
+
+def test_channels_linmos_blanked_get_no_weight(tmp_path: Path) -> None:
+    """An all-zero plane is linmos saying the channel was flagged everywhere, so
+    it has to reach RM-synthesis with zero weight rather than as a live channel."""
+    blanked = (0, 5, N_CHAN - 1)
+    weights = per_channel_weights_from_linmos(
+        stokes_q_weight_cube=_make_linmos_weight_cube(
+            tmp_path, "q", blank_outside=1.5, blank_channels=blanked
+        ),
+        stokes_u_weight_cube=_make_linmos_weight_cube(
+            tmp_path, "u", blank_outside=1.5, blank_channels=blanked
+        ),
+    )
+
+    assert np.all(weights[list(blanked)] == 0.0)
+    live = np.setdiff1d(np.arange(N_CHAN), blanked)
+    assert np.all(weights[live] > 0)
+
+
+def test_unusable_linmos_weights_are_refused(tmp_path: Path) -> None:
+    """Both failures leave nothing to weight with, and both are cheap to spot
+    here rather than as an empty FDF after the synthesis has run."""
+    q_weight = _make_linmos_weight_cube(tmp_path, "q", blank_outside=1.5)
+
+    with pytest.raises(NotSupportedError, match="zero or blank in every channel"):
+        per_channel_weights_from_linmos(
+            stokes_q_weight_cube=_make_linmos_weight_cube(
+                tmp_path, "allzero_q", blank_channels=tuple(range(N_CHAN))
+            ),
+            stokes_u_weight_cube=_make_linmos_weight_cube(
+                tmp_path, "allzero_u", blank_channels=tuple(range(N_CHAN))
+            ),
+        )
+
+    mismatched = tmp_path / "short.weight.fits"
+    fits.writeto(
+        mismatched,
+        np.ones((N_CHAN - 1, NY, NX), dtype=np.float32),
+        fits.getheader(q_weight),
+        overwrite=True,
+    )
+    with pytest.raises(NotSupportedError, match="disagree on shape"):
+        per_channel_weights_from_linmos(
+            stokes_q_weight_cube=q_weight, stokes_u_weight_cube=mismatched
+        )
+
+
+def test_rmsynth_with_linmos_weights_stays_cleanable(
+    tmp_path: Path, qu_cubes: tuple[Path, Path]
+) -> None:
+    """The whole point of the weight cubes is the run that follows them, and
+    RM-CLEAN is where a lazy theoretical noise surfaced: it scales its mask and
+    threshold by that scalar and logs it, so a dask one is a TypeError rather
+    than a wrong number. The blanked edge is what makes the noise lazy, since it
+    is what a real linmos cutoff leaves behind."""
+    stokes_q_cube, stokes_u_cube = qu_cubes
+
+    synth_results = run_rmsynth_3d(
+        stokes_q_cube=stokes_q_cube,
+        stokes_u_cube=stokes_u_cube,
+        rmsynth_options=RMSynthOptions(),
+        stokes_q_weight_cube=_make_linmos_weight_cube(tmp_path, "q", blank_outside=1.5),
+        stokes_u_weight_cube=_make_linmos_weight_cube(tmp_path, "u", blank_outside=1.5),
+    )
+
+    fdf_error_noise = synth_results.theoretical_noise.fdf_error_noise
+    assert np.isscalar(fdf_error_noise) or np.ndim(fdf_error_noise) == 0
+    assert float(fdf_error_noise) > 0
+    assert f"{fdf_error_noise:0.3g}"  # what run_rmclean_from_synth does with it
+
+    clean_results = run_rmclean_3d(
+        rm_synth_results=synth_results, rmclean_options=RMCleanOptions()
+    )
+    clean_cube = np.asarray(clean_results.clean_fdf_cube)
+    assert np.all(np.isfinite(clean_cube)), (
+        "a blanked linmos edge must not put NaNs into pixels that have data"
+    )
+
+    phi_arr_radm2 = np.asarray(synth_results.phi_arr_radm2)
+    peak_phi = phi_arr_radm2[np.abs(clean_cube).mean(axis=(1, 2)).argmax()]
+    assert peak_phi == pytest.approx(PHI_TRUE_RADM2, abs=5.0)
 
 
 def _make_noise_only_cubes(

--- a/tests/test_rmsynth.py
+++ b/tests/test_rmsynth.py
@@ -126,6 +126,8 @@ def _synth_and_write(
     output_prefix: Path,
     stokes_i_cube: Path | None = None,
     stokes_i_weight_cube: Path | None = None,
+    stokes_q_weight_cube: Path | None = None,
+    stokes_u_weight_cube: Path | None = None,
 ) -> list[Path]:
     if not cube_products and not moment_products:
         return []
@@ -136,6 +138,8 @@ def _synth_and_write(
         rmsynth_options=rmsynth_options,
         stokes_i_cube=stokes_i_cube,
         stokes_i_weight_cube=stokes_i_weight_cube,
+        stokes_q_weight_cube=stokes_q_weight_cube,
+        stokes_u_weight_cube=stokes_u_weight_cube,
     )
     clean_results = (
         run_rmclean_3d(rm_synth_results=synth_results, rmclean_options=rmclean_options)
@@ -800,6 +804,49 @@ def test_linmos_weights_give_each_pixel_its_own_rmsf(
         rm_synth_results=synth_results, rmclean_options=RMCleanOptions()
     )
     assert np.asarray(clean_results.clean_fdf_cube).shape[-2:] == (NY, NX)
+
+
+def test_linmos_weights_through_to_the_moment_maps(
+    tmp_path: Path, qu_cubes: tuple[Path, Path]
+) -> None:
+    """Weights plus moment maps is what the racs-all flow actually runs, and it
+    is where the per-pixel shapes have to agree: the moment threshold is
+    ``moment_threshold_snr * theoretical_noise``, now an (ny, nx) map, while the
+    RMSF FWHM it is applied alongside stays a scalar. A mismatch between those
+    two would not raise -- it would broadcast into the wrong threshold per pixel
+    and quietly reshape every moment map."""
+    stokes_q_cube, stokes_u_cube = qu_cubes
+    output_prefix = tmp_path / "field"
+
+    output_paths = _synth_and_write(
+        stokes_q_cube=stokes_q_cube,
+        stokes_u_cube=stokes_u_cube,
+        rmsynth_options=RMSynthOptions(),
+        rmclean_options=RMCleanOptions(),
+        cube_products=[],
+        moment_products=["clean"],
+        output_prefix=output_prefix,
+        stokes_q_weight_cube=_make_linmos_weight_cube(
+            tmp_path, "q", blank_outside=1.5, taper_per_channel=True
+        ),
+        stokes_u_weight_cube=_make_linmos_weight_cube(
+            tmp_path, "u", blank_outside=1.5, taper_per_channel=True
+        ),
+    )
+
+    assert {path.name for path in output_paths} == {
+        f"{output_prefix.name}.fdf.clean.{moment}.fits"
+        for moment in ("mom0", "mom1", "mom2")
+    }
+
+    mom1 = fits.getdata(Path(f"{output_prefix}.fdf.clean.mom1.fits"))
+    inside_cutoff = _within_cutoff(1.5)
+    assert np.allclose(mom1[inside_cutoff], PHI_TRUE_RADM2, atol=5.0), (
+        "the per-pixel noise map must threshold each pixel, not reshape the field"
+    )
+    assert np.all(np.isnan(mom1[~inside_cutoff])), (
+        "pixels linmos blanked have no weight, so they get no moment"
+    )
 
 
 def _make_noise_only_cubes(

--- a/tests/test_rmsynth.py
+++ b/tests/test_rmsynth.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
 import numpy as np
@@ -746,6 +747,30 @@ def test_unusable_linmos_weights_are_refused(tmp_path: Path) -> None:
         per_channel_weights_from_linmos(
             stokes_q_weight_cube=q_weight, stokes_u_weight_cube=mismatched
         )
+
+
+def test_one_linmos_weight_cube_falls_back_to_the_qu_noise_estimate(
+    tmp_path: Path, qu_cubes: tuple[Path, Path], caplog: pytest.LogCaptureFixture
+) -> None:
+    """rm-lite needs both Q and U to build the channel weights, so one on its own
+    is a wiring mistake. Estimating from the Q/U cubes is the right fallback --
+    the run is still correct, just not linmos-weighted -- but it is silent
+    otherwise, and a half-wired pipeline would look like a working one."""
+    stokes_q_cube, stokes_u_cube = qu_cubes
+
+    with caplog.at_level(logging.WARNING, logger="flint"):
+        synth_results = run_rmsynth_3d(
+            stokes_q_cube=stokes_q_cube,
+            stokes_u_cube=stokes_u_cube,
+            rmsynth_options=RMSynthOptions(),
+            stokes_q_weight_cube=_make_linmos_weight_cube(
+                tmp_path, "q", blank_outside=1.5
+            ),
+        )
+
+    assert "Only one of the Stokes Q/U linmos weight cubes" in caplog.text
+    # Fell back rather than failed, and the fallback is the eager MAD estimate
+    assert float(synth_results.theoretical_noise.fdf_error_noise) > 0
 
 
 def test_rmsynth_with_linmos_weights_stays_cleanable(

--- a/tests/test_rmsynth.py
+++ b/tests/test_rmsynth.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import logging
 from pathlib import Path
 
 import numpy as np
@@ -16,7 +15,6 @@ from flint.options import RMCleanOptions, RMSynthOptions
 from flint.rmsynth import (
     FDFLabel,
     needs_rmclean,
-    per_channel_weights_from_linmos,
     run_rmclean_3d,
     run_rmsynth_3d,
     write_rm_products,
@@ -648,16 +646,29 @@ def test_rmsynth_options_reach_rm_lite(
     assert captured["estimate_stokes_i_noise"] is False
 
 
+def _within_cutoff(blank_outside: float) -> np.ndarray:
+    """The (ny, nx) mask ``_make_linmos_weight_cube`` leaves non-zero."""
+    yy, xx = np.mgrid[0:NY, 0:NX]
+    return np.hypot(yy - (NY - 1) / 2, xx - (NX - 1) / 2) <= blank_outside
+
+
 def _make_linmos_weight_cube(
     tmp_path: Path,
     name: str,
     taper: bool = True,
     blank_outside: float | None = None,
     blank_channels: tuple[int, ...] = (),
+    taper_per_channel: bool = False,
 ) -> Path:
     """A weight cube shaped like the one linmos writes: a primary-beam taper,
     zero outside the ``LinmosOptions.cutoff``, and an all-zero plane for any
-    channel that was flagged everywhere."""
+    channel that was flagged everywhere.
+
+    ``taper_per_channel`` narrows the taper with frequency, as a real primary
+    beam does. That is what stops pixels sharing one channel weighting, so it is
+    the case that earns the per-pixel RMSF; the default keeps the taper flat in
+    frequency so the shared spectrum still describes every pixel.
+    """
     freq_hz = np.linspace(700e6, 1300e6, N_CHAN)
     yy, xx = np.mgrid[0:NY, 0:NX]
     radius = np.hypot(yy - (NY - 1) / 2, xx - (NX - 1) / 2)
@@ -666,7 +677,15 @@ def _make_linmos_weight_cube(
     if blank_outside is not None:
         plane = np.where(radius > blank_outside, 0.0, plane)
 
-    cube = (plane[None] / 1e-3**2).repeat(N_CHAN, axis=0).astype(np.float32)
+    if taper_per_channel:
+        # Beam width goes as 1/frequency, so each channel tapers differently
+        scale = (freq_hz / freq_hz[0]) ** 2
+        cube = np.exp(-(radius[None] ** 2) * scale[:, None, None] / 2.0)
+        if blank_outside is not None:
+            cube = np.where(radius[None] > blank_outside, 0.0, cube)
+        cube = (cube / 1e-3**2).astype(np.float32)
+    else:
+        cube = (plane[None] / 1e-3**2).repeat(N_CHAN, axis=0).astype(np.float32)
     for channel in blank_channels:
         cube[channel] = 0.0
 
@@ -682,84 +701,17 @@ def _make_linmos_weight_cube(
     return path
 
 
-def test_linmos_weights_collapse_to_one_weight_per_channel(tmp_path: Path) -> None:
-    """rm-lite weights channels, not pixels, and derives the cube's single RMSF
-    from a ``(n_freq,)`` vector. The linmos cubes are dominated by the
-    primary-beam taper and are zero outside the cutoff, so the spatial axes have
-    to come off before rm-lite sees them."""
-    weights = per_channel_weights_from_linmos(
-        stokes_q_weight_cube=_make_linmos_weight_cube(tmp_path, "q", blank_outside=1.5),
-        stokes_u_weight_cube=_make_linmos_weight_cube(tmp_path, "u", blank_outside=1.5),
-    )
-
-    assert weights.shape == (N_CHAN,)
-    assert weights.dtype == np.float64
-    # Computed, not lazy: rm-lite's theoretical noise reduces over this, and a
-    # lazy one reaches run_rmclean_from_synth as a dask scalar it cannot format
-    assert isinstance(weights, np.ndarray)
-    assert np.all(np.isfinite(weights))
-    # The taper is constant in frequency here, so every channel weighs the same
-    assert np.all(weights > 0)
-    assert np.allclose(weights, weights[0])
-
-
-def test_channels_linmos_blanked_get_no_weight(tmp_path: Path) -> None:
-    """An all-zero plane is linmos saying the channel was flagged everywhere, so
-    it has to reach RM-synthesis with zero weight rather than as a live channel."""
-    blanked = (0, 5, N_CHAN - 1)
-    weights = per_channel_weights_from_linmos(
-        stokes_q_weight_cube=_make_linmos_weight_cube(
-            tmp_path, "q", blank_outside=1.5, blank_channels=blanked
-        ),
-        stokes_u_weight_cube=_make_linmos_weight_cube(
-            tmp_path, "u", blank_outside=1.5, blank_channels=blanked
-        ),
-    )
-
-    assert np.all(weights[list(blanked)] == 0.0)
-    live = np.setdiff1d(np.arange(N_CHAN), blanked)
-    assert np.all(weights[live] > 0)
-
-
-def test_unusable_linmos_weights_are_refused(tmp_path: Path) -> None:
-    """Both failures leave nothing to weight with, and both are cheap to spot
-    here rather than as an empty FDF after the synthesis has run."""
-    q_weight = _make_linmos_weight_cube(tmp_path, "q", blank_outside=1.5)
-
-    with pytest.raises(NotSupportedError, match="zero or blank in every channel"):
-        per_channel_weights_from_linmos(
-            stokes_q_weight_cube=_make_linmos_weight_cube(
-                tmp_path, "allzero_q", blank_channels=tuple(range(N_CHAN))
-            ),
-            stokes_u_weight_cube=_make_linmos_weight_cube(
-                tmp_path, "allzero_u", blank_channels=tuple(range(N_CHAN))
-            ),
-        )
-
-    mismatched = tmp_path / "short.weight.fits"
-    fits.writeto(
-        mismatched,
-        np.ones((N_CHAN - 1, NY, NX), dtype=np.float32),
-        fits.getheader(q_weight),
-        overwrite=True,
-    )
-    with pytest.raises(NotSupportedError, match="disagree on shape"):
-        per_channel_weights_from_linmos(
-            stokes_q_weight_cube=q_weight, stokes_u_weight_cube=mismatched
-        )
-
-
-def test_one_linmos_weight_cube_falls_back_to_the_qu_noise_estimate(
-    tmp_path: Path, qu_cubes: tuple[Path, Path], caplog: pytest.LogCaptureFixture
+def test_one_linmos_weight_cube_is_refused(
+    tmp_path: Path, qu_cubes: tuple[Path, Path]
 ) -> None:
-    """rm-lite needs both Q and U to build the channel weights, so one on its own
-    is a wiring mistake. Estimating from the Q/U cubes is the right fallback --
-    the run is still correct, just not linmos-weighted -- but it is silent
-    otherwise, and a half-wired pipeline would look like a working one."""
+    """rm-lite builds the weights from Q and U together, so a lone cube is a
+    wiring mistake it refuses rather than half-applies. Pinned here because the
+    racs-all flow passes the pair positionally and a silent drop would look like
+    a linmos-weighted run that never was."""
     stokes_q_cube, stokes_u_cube = qu_cubes
 
-    with caplog.at_level(logging.WARNING, logger="flint"):
-        synth_results = run_rmsynth_3d(
+    with pytest.raises(ValueError, match="[Mm]ust pass both"):
+        run_rmsynth_3d(
             stokes_q_cube=stokes_q_cube,
             stokes_u_cube=stokes_u_cube,
             rmsynth_options=RMSynthOptions(),
@@ -768,19 +720,18 @@ def test_one_linmos_weight_cube_falls_back_to_the_qu_noise_estimate(
             ),
         )
 
-    assert "Only one of the Stokes Q/U linmos weight cubes" in caplog.text
-    # Fell back rather than failed, and the fallback is the eager MAD estimate
-    assert float(synth_results.theoretical_noise.fdf_error_noise) > 0
-
 
 def test_rmsynth_with_linmos_weights_stays_cleanable(
     tmp_path: Path, qu_cubes: tuple[Path, Path]
 ) -> None:
-    """The whole point of the weight cubes is the run that follows them, and
-    RM-CLEAN is where a lazy theoretical noise surfaced: it scales its mask and
-    threshold by that scalar and logs it, so a dask one is a TypeError rather
-    than a wrong number. The blanked edge is what makes the noise lazy, since it
-    is what a real linmos cutoff leaves behind."""
+    """The whole point of the weight cubes is the run that follows them.
+
+    A linmos weight cube is dominated by the primary-beam taper, so pixels do
+    not share one channel weighting and rm-lite gives each its own noise and
+    RMSF. That makes the theoretical noise an (ny, nx) map rather than a scalar,
+    and RM-CLEAN scales its mask and threshold by it -- so this is the run that
+    catches a shape or laziness mismatch between the two.
+    """
     stokes_q_cube, stokes_u_cube = qu_cubes
 
     synth_results = run_rmsynth_3d(
@@ -791,22 +742,64 @@ def test_rmsynth_with_linmos_weights_stays_cleanable(
         stokes_u_weight_cube=_make_linmos_weight_cube(tmp_path, "u", blank_outside=1.5),
     )
 
-    fdf_error_noise = synth_results.theoretical_noise.fdf_error_noise
-    assert np.isscalar(fdf_error_noise) or np.ndim(fdf_error_noise) == 0
-    assert float(fdf_error_noise) > 0
-    assert f"{fdf_error_noise:0.3g}"  # what run_rmclean_from_synth does with it
+    # Per-pixel weights, so a map over the sky rather than one number for it
+    fdf_error_noise = np.asarray(synth_results.theoretical_noise.fdf_error_noise)
+    assert fdf_error_noise.shape == (NY, NX)
+    assert np.all(fdf_error_noise[np.isfinite(fdf_error_noise)] > 0)
 
     clean_results = run_rmclean_3d(
         rm_synth_results=synth_results, rmclean_options=RMCleanOptions()
     )
     clean_cube = np.asarray(clean_results.clean_fdf_cube)
-    assert np.all(np.isfinite(clean_cube)), (
-        "a blanked linmos edge must not put NaNs into pixels that have data"
+
+    # Per-pixel weights mean a pixel linmos blanked has no weight of its own and
+    # so no FDF, rather than borrowing the rest of the field's. Blank there,
+    # finite everywhere the cutoff kept.
+    inside_cutoff = _within_cutoff(1.5)
+    assert np.all(np.isfinite(clean_cube[:, inside_cutoff])), (
+        "pixels inside the linmos cutoff have data and must not come back blank"
+    )
+    assert np.all(np.isnan(clean_cube[:, ~inside_cutoff])), (
+        "pixels linmos blanked carry no weight, so they must stay blank"
     )
 
     phi_arr_radm2 = np.asarray(synth_results.phi_arr_radm2)
-    peak_phi = phi_arr_radm2[np.abs(clean_cube).mean(axis=(1, 2)).argmax()]
+    peak_phi = phi_arr_radm2[np.abs(clean_cube[:, inside_cutoff]).mean(axis=1).argmax()]
     assert peak_phi == pytest.approx(PHI_TRUE_RADM2, abs=5.0)
+
+
+def test_linmos_weights_give_each_pixel_its_own_rmsf(
+    tmp_path: Path, qu_cubes: tuple[Path, Path]
+) -> None:
+    """A per-pixel RMSF is the costly half of per-pixel weights, so flint should
+    not be surprised into it. rm-lite turns it on by itself whenever pixels
+    weight the channels differently -- which is what a frequency-dependent
+    primary beam does -- and the linmos cubes are exactly that case."""
+    stokes_q_cube, stokes_u_cube = qu_cubes
+
+    synth_results = run_rmsynth_3d(
+        stokes_q_cube=stokes_q_cube,
+        stokes_u_cube=stokes_u_cube,
+        rmsynth_options=RMSynthOptions(),
+        stokes_q_weight_cube=_make_linmos_weight_cube(
+            tmp_path, "q", blank_outside=1.5, taper_per_channel=True
+        ),
+        stokes_u_weight_cube=_make_linmos_weight_cube(
+            tmp_path, "u", blank_outside=1.5, taper_per_channel=True
+        ),
+    )
+
+    assert synth_results.rmsf_cube is not None, (
+        "pixels weighting channels differently must get the per-pixel RMSF cube"
+    )
+    rmsf_cube = np.asarray(synth_results.rmsf_cube)
+    assert rmsf_cube.shape[-2:] == (NY, NX)
+
+    # RM-CLEAN has to consume that cube rather than the shared spectrum
+    clean_results = run_rmclean_3d(
+        rm_synth_results=synth_results, rmclean_options=RMCleanOptions()
+    )
+    assert np.asarray(clean_results.clean_fdf_cube).shape[-2:] == (NY, NX)
 
 
 def _make_noise_only_cubes(
@@ -934,13 +927,13 @@ def test_rmclean_runs_once_per_chunk_whatever_is_requested(
     stokes_q_cube, stokes_u_cube = qu_cubes
 
     calls: list[int] = []
-    original = rmclean_mod._clean_block
+    original = rmclean_mod._rmclean_on_block
 
     def counting_clean_block(*args: object, **kwargs: object) -> object:
         calls.append(1)
         return original(*args, **kwargs)
 
-    monkeypatch.setattr(rmclean_mod, "_clean_block", counting_clean_block)
+    monkeypatch.setattr(rmclean_mod, "_rmclean_on_block", counting_clean_block)
     # write_rm_products picks the process scheduler when cleaning, which would
     # put the counter in a subprocess. Fusion, not the scheduler, is what
     # duplicates the task, so counting under threads measures the same thing.

--- a/tests/test_rmsynth.py
+++ b/tests/test_rmsynth.py
@@ -659,7 +659,6 @@ def _within_cutoff(blank_outside: float) -> np.ndarray:
 def _make_linmos_weight_cube(
     tmp_path: Path,
     name: str,
-    taper: bool = True,
     blank_outside: float | None = None,
     blank_channels: tuple[int, ...] = (),
     taper_per_channel: bool = False,
@@ -677,7 +676,7 @@ def _make_linmos_weight_cube(
     yy, xx = np.mgrid[0:NY, 0:NX]
     radius = np.hypot(yy - (NY - 1) / 2, xx - (NX - 1) / 2)
 
-    plane = np.exp(-(radius**2) / 2.0) if taper else np.ones((NY, NX))
+    plane = np.exp(-(radius**2) / 2.0)
     if blank_outside is not None:
         plane = np.where(radius > blank_outside, 0.0, plane)
 
@@ -804,6 +803,45 @@ def test_linmos_weights_give_each_pixel_its_own_rmsf(
         rm_synth_results=synth_results, rmclean_options=RMCleanOptions()
     )
     assert np.asarray(clean_results.clean_fdf_cube).shape[-2:] == (NY, NX)
+
+
+def test_channels_linmos_blanked_everywhere_drop_out(
+    tmp_path: Path, qu_cubes: tuple[Path, Path]
+) -> None:
+    """An all-zero weight plane is linmos saying that channel was flagged across
+    the whole field. It has to leave the synthesis rather than divide into it:
+    zero weight is a channel that contributes nothing, not one whose 1/0 poisons
+    every pixel that would have used it."""
+    stokes_q_cube, stokes_u_cube = qu_cubes
+    blanked_channels = (0, 5, N_CHAN - 1)
+
+    synth_results = run_rmsynth_3d(
+        stokes_q_cube=stokes_q_cube,
+        stokes_u_cube=stokes_u_cube,
+        rmsynth_options=RMSynthOptions(),
+        stokes_q_weight_cube=_make_linmos_weight_cube(
+            tmp_path, "q", blank_outside=1.5, blank_channels=blanked_channels
+        ),
+        stokes_u_weight_cube=_make_linmos_weight_cube(
+            tmp_path, "u", blank_outside=1.5, blank_channels=blanked_channels
+        ),
+    )
+    clean_results = run_rmclean_3d(
+        rm_synth_results=synth_results, rmclean_options=RMCleanOptions()
+    )
+
+    inside_cutoff = _within_cutoff(1.5)
+    clean_cube = np.asarray(clean_results.clean_fdf_cube)
+    noise = np.asarray(synth_results.theoretical_noise.fdf_error_noise)
+
+    assert np.all(np.isfinite(clean_cube[:, inside_cutoff]))
+    assert np.all(np.isfinite(noise[inside_cutoff]))
+
+    phi_arr_radm2 = np.asarray(synth_results.phi_arr_radm2)
+    peak_phi = phi_arr_radm2[np.abs(clean_cube[:, inside_cutoff]).mean(axis=1).argmax()]
+    assert peak_phi == pytest.approx(PHI_TRUE_RADM2, abs=5.0), (
+        "losing three channels must not move the recovered Faraday depth"
+    )
 
 
 def test_linmos_weights_through_to_the_moment_maps(

--- a/uv.lock
+++ b/uv.lock
@@ -275,8 +275,8 @@ requires-dist = [
     { name = "racs-tools", specifier = ">=4.2.1" },
     { name = "radio-beam", specifier = ">=0.3.4" },
     { name = "reproject" },
-    { name = "rm-lite", marker = "extra == 'all'", specifier = "==2026.8.4" },
-    { name = "rm-lite", marker = "extra == 'rmsynth'", specifier = "==2026.8.4" },
+    { name = "rm-lite", marker = "extra == 'all'", specifier = "==2026.8.5" },
+    { name = "rm-lite", marker = "extra == 'rmsynth'", specifier = "==2026.8.5" },
     { name = "ruff", marker = "extra == 'all'" },
     { name = "ruff", marker = "extra == 'dev'" },
     { name = "scikit-image" },
@@ -3490,7 +3490,7 @@ wheels = [
 
 [[package]]
 name = "rm-lite"
-version = "2026.8.4"
+version = "2026.8.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "astropy" },
@@ -3502,9 +3502,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "zarr" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/71/4c/f8058080a16cf08e50b5d53d7bd209a458e436278e2854860b913c035b5a/rm_lite-2026.8.4.tar.gz", hash = "sha256:05b9b3a2e40e25eed5392861e2866e4b9946807ee0cab906faccacbfb7d92b49", size = 421985, upload-time = "2026-08-28T07:27:12.107Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4c/db/dd4530ba42d1a05b1c09cc87a16c7a34d783a6c32e4d3e07376f6fb2164d/rm_lite-2026.8.5.tar.gz", hash = "sha256:af91fa52e2da0db5fcf498cd953dc0ce660f8c353dc934305dcd86b1f52e45f7", size = 437936, upload-time = "2026-08-29T13:37:14.552Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d8/4d/2f79c7721eccf41b1ff2694d362c9097f375c1db731c78cbda9de0630fd8/rm_lite-2026.8.4-py3-none-any.whl", hash = "sha256:02a12f1c406af244574d96008348ec80b2c46b796a10510b9ab594b624ae0dae", size = 105928, upload-time = "2026-08-28T07:27:10.656Z" },
+    { url = "https://files.pythonhosted.org/packages/da/4f/96a4b17f5d6b59b54c7604349e7777c11afafa0084344ad7d14b6c4498aa/rm_lite-2026.8.5-py3-none-any.whl", hash = "sha256:7b6675d1ddc7a5f194d97885591e1d942c60cb919ead58023a2812c481af9d92", size = 113418, upload-time = "2026-08-29T13:37:13.162Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Fixes the CI failure on `racs-all-pol`, plus two more breakages on the weight-cube path that only surface in a real run.

Pinned to **rm-lite 2026.8.5**, which carries the per-pixel weights refactor ([#70](https://github.com/AlecThomson/rm-lite/pull/70), [#71](https://github.com/AlecThomson/rm-lite/pull/71)) this branch is written against.

## 1. CI: `test_process_rmsynth_with_stokes_i_on_dask_cluster`

```
ValueError: snr_cut=5.0 needs a Stokes I error to measure SNR against,
and none was given (or it is all zero).
```

rm-lite 2026.8.4 added `check_snr_cut_has_error`. `8911540` dropped `RMSynthOptions.estimate_stokes_i_noise` on the assumption that the linmos Stokes I weight cube would always supply the error — but that test, and any standalone `process_rmsynth`, has a Stokes I cube and no weights.

Restored the option (default `True`). rm-lite's own precedence (`if stokes_i_error_file is not None … elif estimate_stokes_i_noise`) means a supplied weight cube still wins; the estimate only fills the gap. The validator that used to pair the option with the cut stays removed — rm-lite enforces that itself now.

## 2. The Q/U weight cubes

Wiring the linmos weights in broke RM-CLEAN on 2026.8.4: the theoretical FDF noise came back a lazy dask scalar, and `rmclean.py` formatted it with `:0.3g` → `TypeError: unsupported format string passed to Array.__format__`. A hard crash on any run with weight cubes.

2026.8.5 fixes that and goes further: **per-pixel weights are now the intended path**. Error cubes yield a lazy `(n_freq, ny, nx)` weight array, each pixel gets its own theoretical noise map, and the noise is formatted through `format_scalar_or_map`. So flint passes the cubes as `stokes_q_error_file`/`stokes_u_error_file` with `noise_files_are_weight=True` — linmos writes `1/sigma**2` directly, so rm-lite must not invert and square them again.

An earlier revision of this PR collapsed the cubes to a per-channel spectrum in flint. That is removed: it worked around the two bugs above, and after the refactor it would discard exactly the spatial information rm-lite is built to use.

**Two behaviour notes:**

- A pixel linmos blanked has no weight of its own and now comes back **blank**, rather than borrowing the rest of the field's channel weighting. An improvement — those pixels carry no data — but the FDF is NaN outside `pb_cutoff` where it previously wasn't.
- rm-lite **auto-enables the per-pixel RMSF** once pixels weight the channels differently, which a frequency-dependent primary beam guarantees. That roughly doubles the FDF's footprint, so it's documented on `RMSynthOptions.per_pixel_rmsf` and pinned by a test rather than left to surprise someone at scale. There is no way to decline it while using the weight cubes.

## 3. `PolPipelineResult` early return

The `wsclean_container is None` path never got `weight_cubes={}`, which is required, so it raised a `ValidationError` instead of returning empty. Both early returns now go through one `_no_products()` helper so a new field can't break them again.

## Also

- `per_pixel_rmsf` was added to `RMSynthOptions` in `8911540` but never passed to rm-lite — a silently ignored setting. Wired up.
- `stokes_i_weight_cube` was missing from the gzip-memmap check.

## Testing

- `pytest -ra -n 4 --skip-slow` → **469 passed** against the published 2026.8.5 wheel. Three failures are environmental to the sandbox, not this change: two Vizier tests (proxy blocks `vizier.cds.unistra.fr`) and `test_copy_directory` (no `rsync` in the container).
- `pre-commit run --hook-stage manual --all-files` → all hooks pass, mypy included.
- `flint/rmsynth.py` is at 100% patch coverage.

The Q/U weight path had **no** test coverage before this PR — the existing tests only ever passed `stokes_i_weight_cube`, which is exactly why the RM-CLEAN crash got past CI. It now covers:

| | |
|---|---|
| per-pixel theoretical noise map | shape and positivity |
| auto per-pixel RMSF | `rmsf_cube` present, RM-CLEAN consumes it |
| blanked primary-beam edge | blank outside the cutoff, finite inside |
| channels linmos flagged everywhere | drop out without moving the recovered φ |
| weights → moment maps | the path racs-all actually runs |
| a lone weight cube | rm-lite refuses it |