### PR TITLE
Report RM-synthesis progress as each product lands

### DIFF
--- a/flint/rmsynth.py
+++ b/flint/rmsynth.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 import logging
 import os
 import time
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Literal
 
@@ -15,7 +17,7 @@ import numpy as np
 import zarr
 from astropy.io import fits
 from astropy.wcs import WCS
-from dask.distributed import Client, as_completed
+from dask.distributed import Client, as_completed, get_worker, rejoin, secede
 
 # finufft's PyPI wheel vendors its own libomp.dylib (macOS) rather than
 # linking the environment's shared one; having both loaded aborts the
@@ -445,6 +447,37 @@ def _describe_rm_workload(
     )
 
 
+@contextmanager
+def _seceded_if_on_a_worker() -> Iterator[None]:
+    """Give this worker's compute slot back for the duration of a blocking wait.
+
+    ``task_write_rm_products`` is a prefect task, so under ``DaskTaskRunner`` it
+    runs *on a worker*, and ``prefect_dask.get_dask_client`` hands back a plain
+    ``Client`` rather than a ``worker_client`` -- it does not secede. Waiting on
+    futures from there holds the worker's thread while the tasks being waited on
+    need worker threads to run, and with one thread per worker that deadlocks the
+    cluster outright.
+
+    ``dask.compute(scheduler=client)`` never showed this because ``Client.get``
+    secedes for you when it is called inside a worker. Draining the futures by
+    hand is what makes it ours to do.
+
+    A no-op off a worker, which is the local-scheduler and standalone case.
+    """
+    try:
+        get_worker()
+    except ValueError:
+        # Not on a worker, so there is no slot to give back
+        yield
+        return
+
+    secede()
+    try:
+        yield
+    finally:
+        rejoin()
+
+
 def _compute_rm_products(
     compute_targets: dict[str, Any],
     fuse_config: dict[str, Any],
@@ -497,16 +530,18 @@ def _compute_rm_products(
     future_to_key = dict(zip(futures, compute_keys))
 
     computed: dict[str, Any] = {}
-    for future in as_completed(futures):
-        key = future_to_key[future]
-        # `.result()` re-raises whatever the worker raised, so a failed product
-        # still surfaces here rather than being dropped from `computed`
-        computed[key] = future.result()
-        # Elapsed since submission, not this product's own runtime: they share
-        # one graph, so "how far into the run are we" is the answerable question
-        logger.info(
-            f"[{len(computed):>2}/{len(compute_keys)}] {key} at {_elapsed(start)}"
-        )
+    with _seceded_if_on_a_worker():
+        for future in as_completed(futures):
+            key = future_to_key[future]
+            # `.result()` re-raises whatever the worker raised, so a failed
+            # product still surfaces here rather than being dropped
+            computed[key] = future.result()
+            # Elapsed since submission, not this product's own runtime: they
+            # share one graph, so "how far into the run are we" is the
+            # answerable question
+            logger.info(
+                f"[{len(computed):>2}/{len(compute_keys)}] {key} at {_elapsed(start)}"
+            )
 
     logger.info(f"Computed {len(compute_keys)} RM products in {_elapsed(start)}")
     return computed

--- a/flint/rmsynth.py
+++ b/flint/rmsynth.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import logging
 import os
+import time
 from pathlib import Path
 from typing import Any, Literal
 
@@ -14,7 +15,7 @@ import numpy as np
 import zarr
 from astropy.io import fits
 from astropy.wcs import WCS
-from dask.distributed import Client
+from dask.distributed import Client, as_completed
 
 # finufft's PyPI wheel vendors its own libomp.dylib (macOS) rather than
 # linking the environment's shared one; having both loaded aborts the
@@ -412,6 +413,105 @@ def _lazy_faraday_moments(
     )
 
 
+def _elapsed(start: float) -> str:
+    """Wall time since ``start``, as a compact human-readable string."""
+    seconds = time.time() - start
+    if seconds < 60:
+        return f"{seconds:.1f}s"
+    minutes, seconds = divmod(int(seconds), 60)
+    hours, minutes = divmod(minutes, 60)
+    return f"{hours}h{minutes:02d}m" if hours else f"{minutes}m{seconds:02d}s"
+
+
+def _describe_rm_workload(
+    synth_results: RMSynth3DResults, compute_keys: list[str]
+) -> str:
+    """One line saying what the coming compute is actually going to chew through.
+
+    Everything here is known before any of it runs, and none of it is otherwise
+    reported: the FDF's shape, how many spatial chunks it is cut into, and
+    whether rm-lite decided every pixel needs its own RMSF (roughly doubling the
+    footprint, and not something flint asked for -- see
+    ``RMSynthOptions.per_pixel_rmsf``).
+    """
+    fdf_cube = synth_results.fdf_dirty_cube
+    n_phi, n_y, n_x = fdf_cube.shape
+    n_chunks = int(np.prod([len(chunk) for chunk in fdf_cube.chunks]))
+    per_pixel_rmsf = synth_results.rmsf_cube is not None
+    return (
+        f"{len(compute_keys)} products over {n_y}x{n_x} pixels and {n_phi} "
+        f"Faraday depths, in {n_chunks} chunks; "
+        f"per-pixel RMSF {'on' if per_pixel_rmsf else 'off'}"
+    )
+
+
+def _compute_rm_products(
+    compute_targets: dict[str, Any],
+    fuse_config: dict[str, Any],
+    scheduler: Client | str,
+    workload: str,
+) -> dict[str, Any]:
+    """Compute every product in one shared pass, reporting each as it lands.
+
+    The whole RM-synthesis stage is one ``compute`` over a lazy graph, so
+    without this it is a single silent wait -- hours on a mosaic, with no way to
+    tell a slow run from a stuck one. Submitting the targets together (rather
+    than one compute per product) is what keeps the synthesis and RM-CLEAN graph
+    shared, so it still runs once no matter how many products are asked for --
+    getting that wrong is invisible in the output and simply multiplies the
+    runtime, so ``test_rmclean_runs_once_per_chunk_on_a_distributed_client``
+    holds it for this path.
+
+    Progress needs a distributed ``Client`` to report against futures. The local
+    schedulers take the plain ``dask.compute`` path and are logged start-to-end
+    only -- that is the unit tests and standalone use, not a pipeline run.
+
+    Args:
+        compute_targets (dict[str, Any]): Lazy arrays/delayed writes, keyed by product name
+        fuse_config (dict[str, Any]): Dask fusion settings the submission must be made under
+        scheduler (Client | str): A distributed Client, or a local scheduler name
+        workload (str): Description of the work, logged up front. See ``_describe_rm_workload``
+
+    Returns:
+        dict[str, Any]: The computed value for each key in ``compute_targets``
+    """
+    compute_keys = list(compute_targets.keys())
+    start = time.time()
+
+    if not isinstance(scheduler, Client):
+        logger.info(f"Computing RM products ({workload}), scheduler={scheduler!r}")
+        with dask.config.set(fuse_config):
+            computed_values = dask.compute(
+                *(compute_targets[key] for key in compute_keys), scheduler=scheduler
+            )
+        logger.info(f"Computed {len(compute_keys)} RM products in {_elapsed(start)}")
+        return dict(zip(compute_keys, computed_values))
+
+    logger.info(f"Computing RM products ({workload})")
+    with dask.config.set(fuse_config):
+        # One submission for the whole batch: `client.compute` on a list keeps
+        # the shared graph, where a compute per product would rebuild it each time
+        futures = scheduler.compute(
+            [compute_targets[key] for key in compute_keys], sync=False
+        )
+    future_to_key = dict(zip(futures, compute_keys))
+
+    computed: dict[str, Any] = {}
+    for future in as_completed(futures):
+        key = future_to_key[future]
+        # `.result()` re-raises whatever the worker raised, so a failed product
+        # still surfaces here rather than being dropped from `computed`
+        computed[key] = future.result()
+        # Elapsed since submission, not this product's own runtime: they share
+        # one graph, so "how far into the run are we" is the answerable question
+        logger.info(
+            f"[{len(computed):>2}/{len(compute_keys)}] {key} at {_elapsed(start)}"
+        )
+
+    logger.info(f"Computed {len(compute_keys)} RM products in {_elapsed(start)}")
+    return computed
+
+
 def write_rm_products(
     synth_results: RMSynth3DResults,
     clean_results: RMClean3DResults | None,
@@ -584,16 +684,13 @@ def write_rm_products(
         if dask_client is not None
         else ("processes" if run_clean else "threads")
     )
-    compute_keys = list(compute_targets.keys())
-    with dask.config.set(fuse_config):
-        computed_values = dask.compute(
-            *(compute_targets[key] for key in compute_keys), scheduler=scheduler
-        )
-    computed = dict(
-        zip(
-            compute_keys,
-            computed_values,
-        )
+    computed = _compute_rm_products(
+        compute_targets=compute_targets,
+        fuse_config=fuse_config,
+        scheduler=scheduler,
+        workload=_describe_rm_workload(
+            synth_results=synth_results, compute_keys=list(compute_targets)
+        ),
     )
 
     reference_header = fits.getheader(stokes_q_cube)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ casa =[
     "fixms>=0.4.0"
 ]
 rmsynth = [
-    "rm-lite==2026.8.5",
+    "rm-lite==2026.8.6",
 ]
 all = [
     "askap-flint[dev,casa,rmsynth]",

--- a/tests/test_rmsynth.py
+++ b/tests/test_rmsynth.py
@@ -1141,6 +1141,49 @@ def test_rmclean_runs_once_per_chunk_on_a_distributed_client(
     )
 
 
+def test_computing_from_inside_a_worker_does_not_deadlock() -> None:
+    """The products are computed from a prefect task, which under
+    ``DaskTaskRunner`` runs on a worker.
+
+    ``prefect_dask.get_dask_client`` hands back a plain ``Client``, not a
+    ``worker_client``, so nothing secedes on our behalf. Waiting on futures from
+    a worker thread while the tasks being waited on need worker threads is a
+    deadlock, and with one thread per worker it is a certainty rather than a
+    race. ``dask.compute(scheduler=client)`` never showed it, because
+    ``Client.get`` secedes for you.
+
+    One worker with one thread is the whole reproduction: the submitted call
+    holds that thread, so anything it waits on can never be scheduled.
+    """
+    import dask
+    from distributed import Client, LocalCluster, get_client
+
+    from flint.rmsynth import _compute_rm_products
+
+    def compute_on_the_worker() -> dict[str, object]:
+        return _compute_rm_products(
+            compute_targets={"only": dask.delayed(int)(7)},
+            fuse_config={},
+            scheduler=get_client(),
+            workload="1 product (test)",
+        )
+
+    cluster = LocalCluster(
+        n_workers=1,
+        threads_per_worker=1,
+        processes=False,
+        dashboard_address=None,
+        silence_logs=logging.ERROR,
+    )
+    try:
+        with Client(cluster) as client:
+            future = client.submit(compute_on_the_worker)
+            # Without seceding this never returns; the timeout is the assertion
+            assert future.result(timeout=90) == {"only": 7}
+    finally:
+        cluster.close()
+
+
 def test_a_failed_product_is_raised_not_dropped(tmp_path: Path) -> None:
     """Draining futures as they complete must not swallow one that failed.
 

--- a/tests/test_rmsynth.py
+++ b/tests/test_rmsynth.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
 import numpy as np
@@ -1056,6 +1057,127 @@ def test_rmclean_runs_once_per_chunk_whatever_is_requested(
         f"RM-CLEAN ran {len(calls) / n_chunks:.0f}x per chunk for "
         f"cubes={cube_products}, moments={moment_products}"
     )
+
+
+def _rmclean_call_counter(tally_path: Path):
+    """A ``_rmclean_on_block`` wrapper that tallies calls through a file.
+
+    A closure counting into a list cannot work here: `distributed` serialises
+    the task graph even when its workers are threads in this process, so the
+    worker gets a copy of the list and the appends never come back. A file is
+    the counter that survives that round trip.
+    """
+    import rm_lite.tools_3d.rmclean as rmclean_mod
+
+    original = rmclean_mod._rmclean_on_block
+
+    def counting(*args: object, **kwargs: object) -> object:
+        with open(tally_path, "a") as handle:
+            handle.write("x")
+        return original(*args, **kwargs)
+
+    return counting
+
+
+def test_rmclean_runs_once_per_chunk_on_a_distributed_client(
+    tmp_path: Path, qu_cubes: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The same once-per-chunk guarantee as the threaded test, on the path a real
+    pipeline run takes.
+
+    ``_compute_rm_products`` submits to a distributed Client as futures so it can
+    report each product as it lands. Submitting them one at a time instead would
+    rebuild the shared synthesis/RM-CLEAN graph per product -- invisible in the
+    output, just N times the runtime of the slowest stage. The threaded test
+    cannot see this path at all, since it forces the local scheduler.
+    """
+    import rm_lite.tools_3d.rmclean as rmclean_mod
+    from distributed import Client, LocalCluster
+
+    stokes_q_cube, stokes_u_cube = qu_cubes
+    tally = tmp_path / "rmclean_calls"
+    tally.write_text("")
+    monkeypatch.setattr(rmclean_mod, "_rmclean_on_block", _rmclean_call_counter(tally))
+
+    # processes=False keeps the workers in this process, so the monkeypatch is
+    # in place for them -- the graph is still serialised, hence the file tally
+    cluster = LocalCluster(
+        n_workers=2,
+        threads_per_worker=1,
+        processes=False,
+        dashboard_address=None,
+        silence_logs=logging.ERROR,
+    )
+    try:
+        with Client(cluster) as client:
+            synth_results = run_rmsynth_3d(
+                stokes_q_cube=stokes_q_cube,
+                stokes_u_cube=stokes_u_cube,
+                rmsynth_options=RMSynthOptions(),
+            )
+            clean_results = run_rmclean_3d(
+                rm_synth_results=synth_results, rmclean_options=RMCleanOptions()
+            )
+            n_chunks = int(
+                np.prod([len(chunk) for chunk in synth_results.fdf_dirty_cube.chunks])
+            )
+            # Three FDFs' worth of moments off one shared graph
+            write_rm_products(
+                synth_results=synth_results,
+                clean_results=clean_results,
+                stokes_q_cube=stokes_q_cube,
+                rmsynth_options=RMSynthOptions(),
+                rmclean_options=RMCleanOptions(),
+                cube_products=[],
+                moment_products=["clean", "dirty", "model"],
+                output_prefix=tmp_path / "field",
+                dask_client=client,
+            )
+    finally:
+        cluster.close()
+
+    assert len(tally.read_text()) == n_chunks, (
+        "nine moment maps off three FDFs must still clean each chunk once"
+    )
+
+
+def test_a_failed_product_is_raised_not_dropped(tmp_path: Path) -> None:
+    """Draining futures as they complete must not swallow one that failed.
+
+    ``dask.compute`` raises the worker's exception directly; futures hand it back
+    only when asked, so a product that raised could otherwise go missing from the
+    results and be noticed as a KeyError somewhere further down instead.
+    """
+    import dask
+    from distributed import Client, LocalCluster
+
+    from flint.rmsynth import _compute_rm_products
+
+    def explode() -> None:
+        msg = "this product could not be computed"
+        raise ValueError(msg)
+
+    cluster = LocalCluster(
+        n_workers=1,
+        threads_per_worker=1,
+        processes=False,
+        dashboard_address=None,
+        silence_logs=logging.ERROR,
+    )
+    try:
+        with Client(cluster) as client:
+            with pytest.raises(ValueError, match="could not be computed"):
+                _compute_rm_products(
+                    compute_targets={
+                        "fine": dask.delayed(int)(1),
+                        "broken": dask.delayed(explode)(),
+                    },
+                    fuse_config={},
+                    scheduler=client,
+                    workload="2 products (test)",
+                )
+    finally:
+        cluster.close()
 
 
 def test_stokes_i_fit_does_not_multiply_with_requested_products(

--- a/uv.lock
+++ b/uv.lock
@@ -275,8 +275,8 @@ requires-dist = [
     { name = "racs-tools", specifier = ">=4.2.1" },
     { name = "radio-beam", specifier = ">=0.3.4" },
     { name = "reproject" },
-    { name = "rm-lite", marker = "extra == 'all'", specifier = "==2026.8.5" },
-    { name = "rm-lite", marker = "extra == 'rmsynth'", specifier = "==2026.8.5" },
+    { name = "rm-lite", marker = "extra == 'all'", specifier = "==2026.8.6" },
+    { name = "rm-lite", marker = "extra == 'rmsynth'", specifier = "==2026.8.6" },
     { name = "ruff", marker = "extra == 'all'" },
     { name = "ruff", marker = "extra == 'dev'" },
     { name = "scikit-image" },
@@ -3490,7 +3490,7 @@ wheels = [
 
 [[package]]
 name = "rm-lite"
-version = "2026.8.5"
+version = "2026.8.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "astropy" },
@@ -3502,9 +3502,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "zarr" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4c/db/dd4530ba42d1a05b1c09cc87a16c7a34d783a6c32e4d3e07376f6fb2164d/rm_lite-2026.8.5.tar.gz", hash = "sha256:af91fa52e2da0db5fcf498cd953dc0ce660f8c353dc934305dcd86b1f52e45f7", size = 437936, upload-time = "2026-08-29T13:37:14.552Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/dd/5f/da48831db8f482420cea4216b56d1cba0c3663e08dc4ae90cfc1a01541db/rm_lite-2026.8.6.tar.gz", hash = "sha256:a64af62d157bcae4a3fc7829ab249c86aa2e4b3e3d940f64f574ccb2be117076", size = 439671, upload-time = "2026-08-30T02:17:55.475Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/da/4f/96a4b17f5d6b59b54c7604349e7777c11afafa0084344ad7d14b6c4498aa/rm_lite-2026.8.5-py3-none-any.whl", hash = "sha256:7b6675d1ddc7a5f194d97885591e1d942c60cb919ead58023a2812c481af9d92", size = 113418, upload-time = "2026-08-29T13:37:13.162Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/9e/a9d6ab3800b931ca139987702d7f2ccbe69583dffb6fb94b843964fd76aa/rm_lite-2026.8.6-py3-none-any.whl", hash = "sha256:eca10f1a67e07c34830dd64a00fcb0dd2ec22df801bcff445b902d2434e81c57", size = 114375, upload-time = "2026-08-30T02:17:53.605Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Follow-up to #405. The RM-synthesis stage currently runs silent — this makes it report progress as each product lands.

> **Status:** the full suite is still running locally as I open this for review. Verified so far: `tests/test_rmsynth.py` 32 passed on rm-lite 2026.8.6, `pre-commit run --all-files` clean including mypy. The `DaskTaskRunner` flow tests (`test_prefect_rmsynth_flow.py`) are the outstanding check — I'll confirm below when they land, and push a fix if anything fails.

## The problem

The whole stage is one `dask.compute` over a lazy graph. `run_rmsynth_3d` and `run_rmclean_3d` return before anything is computed, so a run goes from "graph built" straight to "everything finished" — hours of silence on a mosaic, with no way to tell a slow run from a stuck one.

Logging around those calls would not help, and would actively mislead: `"RM-synthesis complete"` after `run_rmsynth_3d` would be a lie, since nothing has run at that point. The progress has to come from the compute itself.

## The change

`write_rm_products` submits the batch to the distributed `Client` as futures and drains them with `as_completed`:

```
Computing RM products (7 products over 5x5 pixels and 201 Faraday depths, in 5 chunks; per-pixel RMSF on)
[ 1/7] zarr_cubes at 0.5s
[ 2/7] moment.dirty.mom0 at 0.5s
...
Computed 7 RM products in 0.6s
```

The header line reports what the run is about to chew through — including whether rm-lite turned on the per-pixel RMSF, which the linmos weights guarantee and which flint never asks for (see #405). Elapsed is cumulative rather than per-product, since the products share one graph and "how far into the run are we" is the answerable question — hence `at`, not `in`.

Log volume is bounded by **product count, not chunks** (4–14 lines per run), so it cannot flood at RACS scale.

The local schedulers keep the plain `dask.compute` and are logged start-to-end only — `as_completed` needs a real `Client`, and that path is the unit tests and standalone use rather than a pipeline run.

## Two things this must not break

**The shared graph.** Everything is batched into one submission so the synthesis/RM-CLEAN graph runs *once per chunk* however many products are requested. Submitting per product multiplies the runtime invisibly — nothing in the output changes, it just takes N times longer.

The existing `test_rmclean_runs_once_per_chunk_whatever_is_requested` **cannot see this path**: it patches `dask.compute` to force the threaded scheduler. So there is a new `test_rmclean_runs_once_per_chunk_on_a_distributed_client`.

That test counts through a **file**, not a closure. `distributed` serialises the task graph even when its workers are threads in this process, so a list captured in a closure gets copied to the worker and the appends never come back — my first two attempts measured zero and looked like a pass.

I confirmed the guard actually bites by sabotaging the code to submit one compute per product: **20 RM-CLEAN calls against the expected 5**, caught and reported.

**Error propagation.** `dask.compute` raises the worker's exception directly; a future hands it back only when asked. A product that raised could otherwise go missing from the results and surface as a confusing `KeyError` downstream. `test_a_failed_product_is_raised_not_dropped` covers it.

## Also

Pins **rm-lite 2026.8.6**, which carries the fix for the divide-by-zero warning the linmos weight cubes provoked once per chunk everywhere outside `pb_cutoff`. I checked the no-API-change claim mechanically — public defs in `rmsynth.py`/`rmclean.py` and the result-tuple fields are identical to 2026.8.5 — and confirmed the warning is gone with behaviour unchanged (α = −0.7 inside the cutoff, NaN outside).

## Not included

Per-chunk granularity (`chunk 37/400 cleaned`) would need rm-lite: its block functions are silent and run on workers. Deliberately out of scope here.

No option is added — logging is unconditional at INFO, matching the rest of flint. Nothing about what is computed or written changes; the products and their contents are identical.

---
_Generated by [Claude Code](https://claude.ai/code/session_01L2a7yxnqTQ1KBxanzoPMm8)_