### PR TITLE
FDF peak statistics, RM-CLEAN niter map, and rm-lite 2026.8.7

### DIFF
--- a/flint/data/tests/test_config_pol.yaml
+++ b/flint/data/tests/test_config_pol.yaml
@@ -118,6 +118,14 @@ polarisation:
 rmsynth:
   rmsynth:
     phi_max_radm2: 1000.0
+    # 'auto' derotates the whole cube to one reference lambda^2; 'per_pixel'
+    # gives each pixel its own, which also forces the per-pixel RMSF
+    lam_sq_0_m2: auto
   rmclean:
     auto_mask: 7
     auto_threshold: 1
+    # Peak statistics per FDF, like cube_products/moment_products: peak
+    # polarised intensity (raw and debiased), Faraday depth, polarisation angle
+    # and intrinsic angle, each with its error. Nine (ny, nx) maps per entry --
+    # ~9 GB apiece at 16032^2 -- so empty by default. 'dirty' needs no RM-CLEAN.
+    peak_products: []

--- a/flint/data/tests/test_config_pol.yaml
+++ b/flint/data/tests/test_config_pol.yaml
@@ -118,14 +118,10 @@ polarisation:
 rmsynth:
   rmsynth:
     phi_max_radm2: 1000.0
-    # 'auto' derotates the whole cube to one reference lambda^2; 'per_pixel'
-    # gives each pixel its own, which also forces the per-pixel RMSF
+    # 'auto', 'per_pixel', or a lambda^2 in m^2
     lam_sq_0_m2: auto
   rmclean:
     auto_mask: 7
     auto_threshold: 1
-    # Peak statistics per FDF, like cube_products/moment_products: peak
-    # polarised intensity (raw and debiased), Faraday depth, polarisation angle
-    # and intrinsic angle, each with its error. Nine (ny, nx) maps per entry --
-    # ~9 GB apiece at 16032^2 -- so empty by default. 'dirty' needs no RM-CLEAN.
+    # Any of: dirty, clean, model
     peak_products: []

--- a/flint/options.py
+++ b/flint/options.py
@@ -275,6 +275,8 @@ class RMSynthOptions(BaseOptions):
     """Also compute a debiased (via rm_lite's debias_fdf) mom0/mom1/mom2 set per requested FDF"""
     debias_filter_size: int = 5
     """Median filter size (pixels) used by mom0 debiasing"""
+    lam_sq_0_m2: float | Literal["auto", "per_pixel"] = "auto"
+    """Reference lambda^2 the FDF is derotated to. 'auto' picks one value for the whole cube; 'per_pixel' gives each pixel its own, which also forces per_pixel_rmsf since the RMSF then differs pixel to pixel. A float pins it explicitly"""
     per_pixel_rmsf: bool = False
     """Compute the RMSF for each pixel rather than one shared by the cube. Roughly doubles the FDF's size. rm-lite turns this on itself when the weights make pixels disagree, as the linmos weight cubes do"""
     estimate_stokes_i_noise: bool = True
@@ -296,6 +298,8 @@ class RMCleanOptions(BaseOptions):
     """CLEAN loop gain"""
     moment_threshold_snr: float = 5.0
     """SNR cut (times the theoretical FDF noise) applied before computing Faraday moment maps, the dirty ones included"""
+    peak_products: list[Literal["dirty", "clean", "model"]] = []
+    """Which FDF(s) to measure peak statistics from: peak polarised intensity (raw and debiased), Faraday depth, polarisation angle and intrinsic angle, each with its error. Nine (ny, nx) maps per FDF, so empty by default -- at 16032^2 that is ~9 GB per entry"""
 
 
 class SpiceOptions(BaseOptions):

--- a/flint/prefect/common/rmsynth.py
+++ b/flint/prefect/common/rmsynth.py
@@ -72,6 +72,7 @@ def task_write_rm_products(
     cube_products: list[FDFLabel],
     moment_products: list[FDFLabel],
     output_prefix: Path,
+    peak_products: list[FDFLabel] | None = None,
 ) -> list[Path]:
     """Batch-compute and write the requested RM-synthesis/RM-CLEAN products"""
     from prefect_dask import get_dask_client
@@ -88,4 +89,5 @@ def task_write_rm_products(
             moment_products=moment_products,
             output_prefix=output_prefix,
             dask_client=client,
+            peak_products=peak_products,
         )

--- a/flint/prefect/flows/rmsynth_pipeline.py
+++ b/flint/prefect/flows/rmsynth_pipeline.py
@@ -42,13 +42,6 @@ def process_rmsynth(rmsynth_field_options: RMSynthFieldOptions) -> list[Path]:
         imaging_strategy=rmsynth_field_options.imaging_strategy,
     )
 
-    if (
-        not rmsynth_field_options.cube_products
-        and not rmsynth_field_options.moment_products
-    ):
-        logger.info("No RM-synthesis products requested, skipping.")
-        return []
-
     rmsynth_options = RMSynthOptions(
         **get_options_from_strategy(
             strategy=strategy, operation="rmsynth", mode="rmsynth"
@@ -59,6 +52,16 @@ def process_rmsynth(rmsynth_field_options: RMSynthFieldOptions) -> list[Path]:
             strategy=strategy, operation="rmsynth", mode="rmclean"
         )
     )
+
+    # After the options are built, not before: peak_products is a product
+    # request like the other two, but it comes from the strategy, not the CLI
+    if (
+        not rmsynth_field_options.cube_products
+        and not rmsynth_field_options.moment_products
+        and not rmclean_options.peak_products
+    ):
+        logger.info("No RM-synthesis products requested, skipping.")
+        return []
 
     synth_result = task_rmsynth.submit(
         stokes_q_cube=rmsynth_field_options.stokes_q_cube,
@@ -73,6 +76,7 @@ def process_rmsynth(rmsynth_field_options: RMSynthFieldOptions) -> list[Path]:
     run_clean = needs_rmclean(
         cube_products=rmsynth_field_options.cube_products,
         moment_products=rmsynth_field_options.moment_products,
+        peak_products=rmclean_options.peak_products,
     )
     clean_result = (
         task_rmclean.submit(
@@ -101,6 +105,7 @@ def process_rmsynth(rmsynth_field_options: RMSynthFieldOptions) -> list[Path]:
         cube_products=rmsynth_field_options.cube_products,
         moment_products=rmsynth_field_options.moment_products,
         output_prefix=output_prefix,
+        peak_products=rmclean_options.peak_products,
     )
 
     written_paths = output_paths.result()

--- a/flint/rmsynth.py
+++ b/flint/rmsynth.py
@@ -437,34 +437,6 @@ def _lazy_faraday_moments(
     )
 
 
-def _lazy_faraday_peaks(
-    fdf_cube: dask.array.Array,
-    synth_results: RMSynth3DResults,
-    threshold: float | np.ndarray | None,
-) -> FaradayPeaks:
-    """Build the lazy peak-statistic maps of an FDF cube.
-
-    The same shape of work as ``_lazy_faraday_moments``: ``calc_faraday_peaks``
-    reduces along the (never-chunked) Faraday-depth axis, so the result is nine
-    lazy (ny, nx) maps each spatial chunk contributes to independently, and the
-    cube itself never has to reach the calling worker.
-
-    rm-lite also returns peaks of its own on ``RMClean3DResults``, but only for
-    the clean FDF and only under its own threshold. Deriving them here instead
-    is what lets any requested FDF have them -- the dirty one included, which
-    needs no RM-CLEAN at all -- under the same cut flint gives its moments.
-    """
-    return calc_faraday_peaks(
-        fdf_cube,
-        phi_arr_radm2=synth_results.phi_arr_radm2,
-        fwhm_rmsf_radm2=synth_results.fwhm_rmsf_radm2,
-        fdf_error=synth_results.theoretical_noise.fdf_error_noise,
-        lam_sq_0_m2=synth_results.lam_sq_0_m2,
-        lambda_sq_arr_m2=synth_results.lambda_sq_arr_m2,
-        threshold=threshold,
-    )
-
-
 def _elapsed(start: float) -> str:
     """Wall time since ``start``, as a compact human-readable string."""
     seconds = time.time() - start
@@ -791,10 +763,18 @@ def write_rm_products(
         assert clean_results is not None  # run_clean is `clean_results is not None`
         compute_targets["rmclean_niter"] = clean_results.iter_count_map
 
+    # rm-lite returns peaks of its own on RMClean3DResults, but only for the
+    # clean FDF and only under its own threshold. Deriving them here is what
+    # lets any requested FDF have them -- the dirty one included, which needs no
+    # RM-CLEAN at all -- under the same cut flint gives its moments.
     for label in peak_products or ():
-        peaks = _lazy_faraday_peaks(
-            fdf_cube=fdf_sources[label],
-            synth_results=synth_results,
+        peaks = calc_faraday_peaks(
+            fdf_sources[label],
+            phi_arr_radm2=synth_results.phi_arr_radm2,
+            fwhm_rmsf_radm2=synth_results.fwhm_rmsf_radm2,
+            fdf_error=synth_results.theoretical_noise.fdf_error_noise,
+            lam_sq_0_m2=synth_results.lam_sq_0_m2,
+            lambda_sq_arr_m2=synth_results.lambda_sq_arr_m2,
             threshold=moment_threshold,
         )
         for field in _PEAK_MAPS:
@@ -895,7 +875,7 @@ def write_rm_products(
         output_paths.extend(
             write_peak_maps_to_fits(
                 peaks=FaradayPeaks(
-                    *(computed[f"peak.{label}.{field}"] for field in _PEAK_MAPS)
+                    **{field: computed[f"peak.{label}.{field}"] for field in _PEAK_MAPS}
                 ),
                 reference_header=reference_header,
                 output_prefix=output_prefix,

--- a/flint/rmsynth.py
+++ b/flint/rmsynth.py
@@ -37,7 +37,9 @@ from rm_lite.tools_3d.rmsynth import (  # noqa: E402
 )
 from rm_lite.utils.synthesis import (  # noqa: E402
     FaradayMoments,
+    FaradayPeaks,
     calc_faraday_moments,
+    calc_faraday_peaks,
 )
 
 from flint.exceptions import NotSupportedError
@@ -47,21 +49,40 @@ from flint.options import RMCleanOptions, RMSynthOptions
 FDFLabel = Literal["dirty", "clean", "model"]
 _MOMENT_NAMES = ("mom0", "mom1", "mom2")
 
+# The FDF peak statistics, as {FaradayPeaks field: (file suffix, BUNIT, comment)}.
+# Units matter more here than for the moments: three of these are angles in
+# degrees and two are Faraday depths, so a map with no BUNIT is easy to misread.
+_PEAK_MAPS = {
+    "peak_pi": ("peak_pi", "Jy/beam", "peak polarised intensity"),
+    "peak_pi_debias": ("peak_pi_debias", "Jy/beam", "debiased peak"),
+    "peak_pi_error": ("peak_pi_error", "Jy/beam", "1-sigma on the peak"),
+    "peak_rm_radm2": ("peak_rm", "rad/m2", "Faraday depth of the peak"),
+    "peak_rm_error_radm2": ("peak_rm_error", "rad/m2", "1-sigma on the depth"),
+    "peak_pa_deg": ("peak_pa", "deg", "polarisation angle at the peak"),
+    "peak_pa_error_deg": ("peak_pa_error", "deg", "1-sigma on the angle"),
+    "peak_pa0_deg": ("peak_pa0", "deg", "intrinsic polarisation angle"),
+    "peak_pa0_error_deg": ("peak_pa0_error", "deg", "1-sigma on the intrinsic angle"),
+}
+
 
 def needs_rmclean(
-    cube_products: list[FDFLabel], moment_products: list[FDFLabel]
+    cube_products: list[FDFLabel],
+    moment_products: list[FDFLabel],
+    peak_products: list[FDFLabel] | None = None,
 ) -> bool:
     """Whether any requested product requires RM-CLEAN to be run.
 
     Args:
         cube_products (list[FDFLabel]): Requested FDF cubes
         moment_products (list[FDFLabel]): Requested Faraday moment maps
+        peak_products (list[FDFLabel] | None, optional): Requested FDF peak-statistic maps. Defaults to None.
 
     Returns:
         bool: True if RM-CLEAN is needed
     """
     return any(
-        label in ("clean", "model") for label in (*cube_products, *moment_products)
+        label in ("clean", "model")
+        for label in (*cube_products, *moment_products, *(peak_products or ()))
     )
 
 
@@ -141,6 +162,7 @@ def run_rmsynth_3d(
         phi_max_radm2=rmsynth_options.phi_max_radm2,
         d_phi_radm2=rmsynth_options.d_phi_radm2,
         n_samples=rmsynth_options.n_samples,
+        lam_sq_0_m2=rmsynth_options.lam_sq_0_m2,
         weight_type=rmsynth_options.weight_type,
         robust=rmsynth_options.robust,
         per_pixel_rmsf=rmsynth_options.per_pixel_rmsf,
@@ -415,6 +437,34 @@ def _lazy_faraday_moments(
     )
 
 
+def _lazy_faraday_peaks(
+    fdf_cube: dask.array.Array,
+    synth_results: RMSynth3DResults,
+    threshold: float | np.ndarray | None,
+) -> FaradayPeaks:
+    """Build the lazy peak-statistic maps of an FDF cube.
+
+    The same shape of work as ``_lazy_faraday_moments``: ``calc_faraday_peaks``
+    reduces along the (never-chunked) Faraday-depth axis, so the result is nine
+    lazy (ny, nx) maps each spatial chunk contributes to independently, and the
+    cube itself never has to reach the calling worker.
+
+    rm-lite also returns peaks of its own on ``RMClean3DResults``, but only for
+    the clean FDF and only under its own threshold. Deriving them here instead
+    is what lets any requested FDF have them -- the dirty one included, which
+    needs no RM-CLEAN at all -- under the same cut flint gives its moments.
+    """
+    return calc_faraday_peaks(
+        fdf_cube,
+        phi_arr_radm2=synth_results.phi_arr_radm2,
+        fwhm_rmsf_radm2=synth_results.fwhm_rmsf_radm2,
+        fdf_error=synth_results.theoretical_noise.fdf_error_noise,
+        lam_sq_0_m2=synth_results.lam_sq_0_m2,
+        lambda_sq_arr_m2=synth_results.lambda_sq_arr_m2,
+        threshold=threshold,
+    )
+
+
 def _elapsed(start: float) -> str:
     """Wall time since ``start``, as a compact human-readable string."""
     seconds = time.time() - start
@@ -547,6 +597,69 @@ def _compute_rm_products(
     return computed
 
 
+def write_rmclean_niter_map_to_fits(
+    niter_map: np.ndarray, reference_header: fits.Header, output_prefix: Path
+) -> Path:
+    """Write the per-pixel RM-CLEAN iteration count.
+
+    One small integer map, written whenever RM-CLEAN runs rather than on
+    request: it is the map that answers "why does this field look wrong" --
+    where CLEAN hit ``max_iter`` instead of converging on the threshold -- and
+    that question gets asked after the run, when producing it on demand would
+    mean repeating the whole stage.
+
+    Args:
+        niter_map (np.ndarray): Computed (ny, nx) iteration count
+        reference_header (fits.Header): Header to derive the spatial WCS from
+        output_prefix (Path): Common prefix for the output file
+
+    Returns:
+        Path: The written map path
+    """
+    header = WCS(reference_header).celestial.to_header()
+    header["BUNIT"] = ("", "CLEAN iterations")
+    output_path = Path(f"{output_prefix}.fdf.clean.niter.fits")
+    # int32 rather than rm-lite's int64: max_iter is 1e5 by default, so half the
+    # bytes carry every value this can hold
+    fits.writeto(
+        output_path, np.asarray(niter_map, dtype=np.int32), header, overwrite=True
+    )
+    return output_path
+
+
+def write_peak_maps_to_fits(
+    peaks: FaradayPeaks,
+    reference_header: fits.Header,
+    output_prefix: Path,
+    label: FDFLabel,
+) -> list[Path]:
+    """Write the already-computed FDF peak-statistic maps to FITS.
+
+    Args:
+        peaks (FaradayPeaks): Computed peak maps, each (ny, nx)
+        reference_header (fits.Header): Header to derive the spatial WCS from
+        output_prefix (Path): Common prefix for the output files
+        label (FDFLabel): Which FDF the peaks came from, used to name the outputs
+
+    Returns:
+        list[Path]: The written map paths, nine per FDF
+    """
+    celestial = WCS(reference_header).celestial.to_header()
+    output_paths = []
+    for field, (suffix, unit, comment) in _PEAK_MAPS.items():
+        header = celestial.copy()
+        header["BUNIT"] = (unit, comment)
+        output_path = Path(f"{output_prefix}.fdf.{label}.{suffix}.fits")
+        fits.writeto(
+            output_path,
+            np.asarray(getattr(peaks, field), dtype=np.float32),
+            header,
+            overwrite=True,
+        )
+        output_paths.append(output_path)
+    return output_paths
+
+
 def write_rm_products(
     synth_results: RMSynth3DResults,
     clean_results: RMClean3DResults | None,
@@ -557,6 +670,7 @@ def write_rm_products(
     moment_products: list[FDFLabel],
     output_prefix: Path,
     dask_client: Client | None = None,
+    peak_products: list[FDFLabel] | None = None,
 ) -> list[Path]:
     """Batch-compute and write the requested RM-synthesis/RM-CLEAN output products.
 
@@ -568,6 +682,7 @@ def write_rm_products(
         rmclean_options (RMCleanOptions): Options controlling RM-CLEAN
         cube_products (list[FDFLabel]): Which FDF cube(s) to write ('dirty', 'clean', 'model')
         moment_products (list[FDFLabel]): Which FDF(s) to compute Faraday moment maps from
+        peak_products (list[FDFLabel] | None, optional): Which FDF(s) to write peak-statistic maps from, nine per entry. Defaults to None.
         output_prefix (Path): Common prefix for the output files
         dask_client (Client | None, optional): A distributed Client (e.g. the one backing a Prefect ``DaskTaskRunner``) to compute across, rather than just the local worker. Defaults to None.
 
@@ -670,6 +785,23 @@ def write_rm_products(
             )
             for name, moment_map in zip(_MOMENT_NAMES, debiased):
                 compute_targets[f"debiased.{label}.{name}"] = moment_map
+    # Unconditional whenever RM-CLEAN ran: one small integer map, and the
+    # diagnostic you want already written rather than a stage to repeat.
+    if run_clean:
+        assert clean_results is not None  # run_clean is `clean_results is not None`
+        compute_targets["rmclean_niter"] = clean_results.iter_count_map
+
+    for label in peak_products or ():
+        peaks = _lazy_faraday_peaks(
+            fdf_cube=fdf_sources[label],
+            synth_results=synth_results,
+            threshold=moment_threshold,
+        )
+        for field in _PEAK_MAPS:
+            compute_targets[f"peak.{label}.{field}"] = getattr(peaks, field).astype(
+                np.float32
+            )
+
     # stokes_i_alpha_error_map is None unless compute_model_error gives the fit
     # something to propagate; the other maps are None only if the Stokes I fit
     # didn't run at all. Skip whichever are None rather than feeding them to
@@ -747,6 +879,27 @@ def write_rm_products(
                 )
                 if rmsynth_options.debias_moments
                 else None,
+            )
+        )
+
+    if "rmclean_niter" in computed:
+        output_paths.append(
+            write_rmclean_niter_map_to_fits(
+                niter_map=computed["rmclean_niter"],
+                reference_header=reference_header,
+                output_prefix=output_prefix,
+            )
+        )
+
+    for label in peak_products or ():
+        output_paths.extend(
+            write_peak_maps_to_fits(
+                peaks=FaradayPeaks(
+                    *(computed[f"peak.{label}.{field}"] for field in _PEAK_MAPS)
+                ),
+                reference_header=reference_header,
+                output_prefix=output_prefix,
+                label=label,
             )
         )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ casa =[
     "fixms>=0.4.0"
 ]
 rmsynth = [
-    "rm-lite==2026.8.6",
+    "rm-lite==2026.8.7",
 ]
 all = [
     "askap-flint[dev,casa,rmsynth]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
     "scikit-image",
     "pandas",
     "ConfigArgParse>=1.7",
-    "fitscube[pgzip]>=2.5.1",
+    "fitscube[pgzip]>=2.6",
     "astroquery>=0.4.8.dev0",
     "crystalball>=0.4.3",
     "jolly-roger>=0.10.1",

--- a/tests/test_prefect_rmsynth_flow.py
+++ b/tests/test_prefect_rmsynth_flow.py
@@ -95,7 +95,12 @@ def test_process_rmsynth_on_dask_cluster(
             cluster.close()
 
     zarr_store = tmp_path / f"{STEM}.fdf.zarr"
-    assert set(output_paths) == {zarr_store} | {
+    # The CLEAN iteration count comes out of every RM-CLEAN run, alongside the
+    # zarr store and the requested moments
+    assert set(output_paths) == {
+        zarr_store,
+        tmp_path / f"{STEM}.fdf.clean.niter.fits",
+    } | {
         tmp_path / f"{STEM}.fdf.clean.{moment}.fits"
         for moment in ("mom0", "mom1", "mom2")
     }

--- a/tests/test_rmsynth.py
+++ b/tests/test_rmsynth.py
@@ -129,8 +129,9 @@ def _synth_and_write(
     stokes_i_weight_cube: Path | None = None,
     stokes_q_weight_cube: Path | None = None,
     stokes_u_weight_cube: Path | None = None,
+    peak_products: list[FDFLabel] | None = None,
 ) -> list[Path]:
-    if not cube_products and not moment_products:
+    if not cube_products and not moment_products and not peak_products:
         return []
 
     synth_results = run_rmsynth_3d(
@@ -144,7 +145,11 @@ def _synth_and_write(
     )
     clean_results = (
         run_rmclean_3d(rm_synth_results=synth_results, rmclean_options=rmclean_options)
-        if needs_rmclean(cube_products=cube_products, moment_products=moment_products)
+        if needs_rmclean(
+            cube_products=cube_products,
+            moment_products=moment_products,
+            peak_products=peak_products,
+        )
         else None
     )
     return write_rm_products(
@@ -155,6 +160,7 @@ def _synth_and_write(
         rmclean_options=rmclean_options,
         cube_products=cube_products,
         moment_products=moment_products,
+        peak_products=peak_products,
         output_prefix=output_prefix,
     )
 
@@ -173,8 +179,9 @@ def test_rmsynth_all_products(tmp_path: Path, qu_cubes: tuple[Path, Path]) -> No
         output_prefix=output_prefix,
     )
 
-    # One zarr store holding all three cubes, plus three moments per label
-    assert len(output_paths) == 1 + 3 * 3
+    # One zarr store holding all three cubes, three moments per label, and the
+    # CLEAN iteration count that every RM-CLEAN run writes
+    assert len(output_paths) == 1 + 3 * 3 + 1
     for path in output_paths:
         assert path.exists()
 
@@ -470,7 +477,8 @@ def test_rmsynth_debias_moments_runs(
     assert mom0_path.exists()
     assert debiased_mom0_path in output_paths
     assert debiased_mom0_path.exists()
-    assert len(output_paths) == 6
+    # Three moments, three debiased, plus the CLEAN iteration count
+    assert len(output_paths) == 6 + 1
 
 
 def test_rmsynth_writes_fdf_cubes_to_zarr(
@@ -537,7 +545,8 @@ def test_moment_only_never_computes_a_full_cube(
     # Every gathered array is a 2D map; a 3D shape means an FDF cube came back.
     assert all(len(shape) == 2 for shape in computed_shapes), computed_shapes
     # 3 labels x mom0/mom1/mom2, and nothing else.
-    assert len(computed_shapes) == 9
+    # Nine moment maps plus the CLEAN iteration count, all still (ny, nx)
+    assert len(computed_shapes) == 9 + 1
 
 
 def test_rmsynth_no_products_is_noop(
@@ -876,7 +885,7 @@ def test_linmos_weights_through_to_the_moment_maps(
     assert {path.name for path in output_paths} == {
         f"{output_prefix.name}.fdf.clean.{moment}.fits"
         for moment in ("mom0", "mom1", "mom2")
-    }
+    } | {f"{output_prefix.name}.fdf.clean.niter.fits"}
 
     mom1 = fits.getdata(Path(f"{output_prefix}.fdf.clean.mom1.fits"))
     inside_cutoff = _within_cutoff(1.5)
@@ -921,6 +930,107 @@ def _make_noise_only_cubes(
         paths[2],
         _make_weight_cube(tmp_path, shape, freq_hz, sigma=1e-3, name=f"{prefix}.i"),
     )
+
+
+def test_every_fdf_can_have_cubes_moments_and_peaks(
+    tmp_path: Path, qu_cubes: tuple[Path, Path]
+) -> None:
+    """The three product kinds are independent of the three FDFs, so all nine
+    combinations have to be reachable -- a peak map off the dirty FDF included,
+    which is the one that needs no RM-CLEAN at all."""
+    stokes_q_cube, stokes_u_cube = qu_cubes
+    labels: list[FDFLabel] = ["dirty", "clean", "model"]
+    output_prefix = tmp_path / "field"
+
+    output_paths = _synth_and_write(
+        stokes_q_cube=stokes_q_cube,
+        stokes_u_cube=stokes_u_cube,
+        rmsynth_options=RMSynthOptions(),
+        rmclean_options=RMCleanOptions(),
+        cube_products=labels,
+        moment_products=labels,
+        peak_products=labels,
+        output_prefix=output_prefix,
+    )
+    names = {path.name for path in output_paths}
+
+    # One zarr store holds every cube; moments and peaks are a file each
+    assert f"{output_prefix.name}.fdf.zarr" in names
+    for label in labels:
+        assert sum(f".{label}.mom" in name for name in names) == 3, label
+        assert sum(f".{label}.peak_" in name for name in names) == 9, label
+
+    # The peak Faraday depth is the recoverable truth in all three
+    for label in labels:
+        peak_rm = fits.getdata(Path(f"{output_prefix}.fdf.{label}.peak_rm.fits"))
+        assert np.nanmedian(peak_rm) == pytest.approx(PHI_TRUE_RADM2, abs=5.0), label
+
+
+def test_dirty_peaks_alone_do_not_run_rmclean(
+    tmp_path: Path, qu_cubes: tuple[Path, Path]
+) -> None:
+    """Peaks off the dirty FDF are measured from the synthesis output, so asking
+    for only those must not drag RM-CLEAN in -- it is the expensive half of the
+    stage. The iteration-count map is the tell: it only exists if CLEAN ran."""
+    assert (
+        needs_rmclean(cube_products=[], moment_products=[], peak_products=["dirty"])
+        is False
+    )
+    assert (
+        needs_rmclean(cube_products=[], moment_products=[], peak_products=["clean"])
+        is True
+    )
+    assert (
+        needs_rmclean(cube_products=[], moment_products=[], peak_products=["model"])
+        is True
+    )
+
+    stokes_q_cube, stokes_u_cube = qu_cubes
+    output_prefix = tmp_path / "field"
+    output_paths = _synth_and_write(
+        stokes_q_cube=stokes_q_cube,
+        stokes_u_cube=stokes_u_cube,
+        rmsynth_options=RMSynthOptions(),
+        rmclean_options=RMCleanOptions(),
+        cube_products=[],
+        moment_products=[],
+        peak_products=["dirty"],
+        output_prefix=output_prefix,
+    )
+
+    names = {path.name for path in output_paths}
+    assert len(names) == 9, names
+    assert not any("niter" in name for name in names), (
+        "the CLEAN iteration map means RM-CLEAN ran for dirty-only peaks"
+    )
+
+
+def test_rmclean_niter_map_is_always_written(
+    tmp_path: Path, qu_cubes: tuple[Path, Path]
+) -> None:
+    """Unconditional whenever RM-CLEAN runs, and not an option: it is the map
+    that says where CLEAN hit max_iter instead of converging, and that gets
+    asked after the run, when producing it on demand means repeating the stage."""
+    stokes_q_cube, stokes_u_cube = qu_cubes
+    output_prefix = tmp_path / "field"
+
+    output_paths = _synth_and_write(
+        stokes_q_cube=stokes_q_cube,
+        stokes_u_cube=stokes_u_cube,
+        rmsynth_options=RMSynthOptions(),
+        rmclean_options=RMCleanOptions(max_iter=20),
+        cube_products=[],
+        moment_products=["clean"],
+        output_prefix=output_prefix,
+    )
+
+    niter_path = Path(f"{output_prefix}.fdf.clean.niter.fits")
+    assert niter_path in output_paths
+    niter = fits.getdata(niter_path)
+    assert niter.shape == (NY, NX)
+    # Integer, and capped by max_iter rather than running away
+    assert np.issubdtype(niter.dtype, np.integer)
+    assert niter.max() <= 20
 
 
 def test_multiscale_rmclean_is_refused_rather_than_ignored(tmp_path: Path) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -275,8 +275,8 @@ requires-dist = [
     { name = "racs-tools", specifier = ">=4.2.1" },
     { name = "radio-beam", specifier = ">=0.3.4" },
     { name = "reproject" },
-    { name = "rm-lite", marker = "extra == 'all'", specifier = "==2026.8.6" },
-    { name = "rm-lite", marker = "extra == 'rmsynth'", specifier = "==2026.8.6" },
+    { name = "rm-lite", marker = "extra == 'all'", specifier = "==2026.8.7" },
+    { name = "rm-lite", marker = "extra == 'rmsynth'", specifier = "==2026.8.7" },
     { name = "ruff", marker = "extra == 'all'" },
     { name = "ruff", marker = "extra == 'dev'" },
     { name = "scikit-image" },
@@ -3490,7 +3490,7 @@ wheels = [
 
 [[package]]
 name = "rm-lite"
-version = "2026.8.6"
+version = "2026.8.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "astropy" },
@@ -3502,9 +3502,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "zarr" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/dd/5f/da48831db8f482420cea4216b56d1cba0c3663e08dc4ae90cfc1a01541db/rm_lite-2026.8.6.tar.gz", hash = "sha256:a64af62d157bcae4a3fc7829ab249c86aa2e4b3e3d940f64f574ccb2be117076", size = 439671, upload-time = "2026-08-30T02:17:55.475Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/9f/c3d7d0260ae064d4e810b476aa4b7ce56298d0457617dc3b544a2a9611ab/rm_lite-2026.8.7.tar.gz", hash = "sha256:155519c3e4063bfa733c7da7f383001c9e47f6cdc5a51d9f33a6b8a06e60f68f", size = 447821, upload-time = "2026-08-31T02:52:55.402Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a4/9e/a9d6ab3800b931ca139987702d7f2ccbe69583dffb6fb94b843964fd76aa/rm_lite-2026.8.6-py3-none-any.whl", hash = "sha256:eca10f1a67e07c34830dd64a00fcb0dd2ec22df801bcff445b902d2434e81c57", size = 114375, upload-time = "2026-08-30T02:17:53.605Z" },
+    { url = "https://files.pythonhosted.org/packages/44/1d/92c36880b4b3deb64710951fd2232a586010f872c9b80363e4d994fe88fe/rm_lite-2026.8.7-py3-none-any.whl", hash = "sha256:bf1760d5ebaeead154fb5b24cd600e18fe5c742a7044411469b15d8316002e75", size = 117925, upload-time = "2026-08-31T02:52:54.139Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -242,7 +242,7 @@ requires-dist = [
     { name = "configargparse", specifier = ">=1.7" },
     { name = "crystalball", specifier = ">=0.4.3" },
     { name = "dask-jobqueue" },
-    { name = "fitscube", extras = ["pgzip"], specifier = ">=2.5.1" },
+    { name = "fitscube", extras = ["pgzip"], specifier = ">=2.6" },
     { name = "fixms", marker = "extra == 'all'", specifier = ">=0.4.0" },
     { name = "fixms", marker = "extra == 'casa'", specifier = ">=0.4.0" },
     { name = "furo", marker = "extra == 'all'" },
@@ -1253,7 +1253,7 @@ wheels = [
 
 [[package]]
 name = "fitscube"
-version = "2.5.1"
+version = "2.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "astropy" },
@@ -1261,9 +1261,9 @@ dependencies = [
     { name = "radio-beam" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8c/62/872a1ed7f41d46e3a27c7b0a5b290e3c18b7a98f32cffecd541aca590ba1/fitscube-2.5.1.tar.gz", hash = "sha256:8ad83bd5a02f9dda108785fcb00a5066ea582cfe81937067d47f52be673c56d0", size = 791105, upload-time = "2026-08-15T07:52:57.53Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e6/82/097d1f2c9441b07f91a75d57ddbe62a32dde8dba11f93968395c349523af/fitscube-2.6.0.tar.gz", hash = "sha256:d073194681e93a0b3069d7e430cf75f0c21882fefc5d54ef631c7c4654109c77", size = 794576, upload-time = "2026-08-31T08:06:08.977Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/35/5d/ec7c95e81adacce2575c3374caa019bbf4e7cda26445345825b2f16f6f30/fitscube-2.5.1-py3-none-any.whl", hash = "sha256:b70992229de4faaf221f7c76713b1fa6a6bdda432bd3d69d5951acdedd93d02d", size = 29316, upload-time = "2026-08-15T07:52:55.917Z" },
+    { url = "https://files.pythonhosted.org/packages/50/a3/010b81e2cca21ea4f362903eb181082aca6cb788597ef0441eea1f9cea5a/fitscube-2.6.0-py3-none-any.whl", hash = "sha256:6094a8af7dc52a0250549e67030398d5ce52e8d38a2a0cc0db0306b05fc33aac", size = 31194, upload-time = "2026-08-31T08:06:07.446Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
Builds against [rm-lite v2026.8.7](https://github.com/AlecThomson/rm-lite/releases/tag/v2026.8.7) and wires up its new outputs.

## Peak statistics, per FDF

rm-lite 2026.8.7 returns FDF peak statistics on `RMClean3DResults` — but only for the clean FDF, and under its own threshold. The underlying `calc_faraday_peaks` is public and takes any complex FDF, exactly like `calc_faraday_moments`, which flint already uses to rederive its own moments.

So this adds `peak_products` as a third product list beside `cube_products` and `moment_products`, and every FDF can have all three kinds:

```
{prefix}.fdf.{dirty,clean,model}.peak_{pi,pi_debias,pi_error,rm,rm_error,pa,pa_error,pa0,pa0_error}.fits
```

Nine `(ny, nx)` maps per entry, so the list is **empty by default** — ~9 GB apiece at 16032².

Because dirty peaks come off the synthesis output, `needs_rmclean` takes `peak_products` the same way it takes the other two lists, and a dirty-only request correctly leaves RM-CLEAN out. That falls out of the list shape; it would have needed a special case as a boolean.

Each map carries a `BUNIT`: three of these are angles in degrees and two are Faraday depths, so a bare map is easy to misread.

## RM-CLEAN iteration count, unconditional

`{prefix}.fdf.clean.niter.fits`, written whenever RM-CLEAN runs rather than on request. It is one small integer map, and it is the one that says where CLEAN hit `max_iter` instead of converging on the threshold — a question asked *after* a run, when producing it on demand would mean repeating the stage. `int32` rather than rm-lite's `int64`, which still holds every value `max_iter` allows.

Both join the existing batched compute, so neither costs an extra pass over the graph — they show up as extra lines in the progress log from #406.

## `lam_sq_0_m2` in the strategy

Exposed on `RMSynthOptions` and passed through: `auto` derotates the cube to one reference λ², `per_pixel` gives each pixel its own (which also forces the per-pixel RMSF), or a float pins it.

## Where the options live

`peak_products` is on `RMCleanOptions`, not `RMSynthFieldOptions` — `RMSynthFieldOptions` is not in `MODE_OPTIONS_MAPPING`, so nothing on it is strategy-reachable, including the existing `cube_products`/`moment_products`. Putting it there is what makes it settable from a strategy file. The consequence is that the "no products requested" skip check has to run *after* the options are built rather than before.

Both new keys are in the example strategy with comments.

## Also

Pins `fitscube>=2.6` (2.5.1 → 2.6.0 in the lock).

## Verified, not just typechecked

- **Full 3×3 matrix** → 38 products (one zarr store + 9 moments + 27 peaks + the iteration map), and `peak_rm` recovers 50 rad/m² from all three FDFs: dirty 50.00, clean 49.99, model 49.73.
- **All nine peak maps come back finite**, including the five rm-lite documents as NaN without an `fdf_noise`. That was the open risk: since #405 flint's theoretical noise is an `(ny, nx)` map rather than a scalar, and it feeds them correctly.
- Iteration map is integer, capped by `max_iter`, and absent when RM-CLEAN did not run.
- `pytest -ra -n 4 --skip-slow` → **473 passed**. The only failures are the three environmental to the sandbox: two Vizier tests (proxy blocks `vizier.cds.unistra.fr`) and `test_copy_directory` (no `rsync` in the container).
- `pre-commit run --hook-stage manual --all-files` → clean, mypy included.

**Five pre-existing exact-count assertions changed** (four in `test_rmsynth.py`, one in `test_prefect_rmsynth_flow.py`). That is the intended behaviour of an unconditional iteration map — one more file per RM-CLEAN run — so the expectations moved, with comments saying why, rather than the code.