### PR TITLE
Spice the weight cubes alongside the image cubes

### DIFF
--- a/flint/options.py
+++ b/flint/options.py
@@ -376,7 +376,9 @@ class SpiceFieldOptions(BaseOptions):
     ``imaging_strategy`` rather than exposed here."""
 
     cubes: list[Path] = []
-    """Stokes cubes to trim and compress. Computed by the racs-all flow, so required only when running this pipeline standalone"""
+    """Stokes image cubes to trim and compress. Computed by the racs-all flow, so required only when running this pipeline standalone"""
+    weight_cubes: list[Path] = []
+    """LINMOS weight cubes to trim and compress alongside ``cubes``, spiced with the same boxes so they stay on a matching grid. Computed by the racs-all flow"""
     reference_image: Path | None = None
     """A 2D MFS image whose WCS/shape sources the source-finding boxes. Required only when catalogue is not set (built-in aegean source finding)"""
     catalogue: Path | None = None

--- a/flint/prefect/flows/racs_all_pipeline.py
+++ b/flint/prefect/flows/racs_all_pipeline.py
@@ -42,7 +42,7 @@ STAGE_CLUSTER_CONFIG_ATTRS = (
 
 # Fields on the rm-synth/spice options classes that process_racs_all always recomputes
 # from the polarisation stage's output. Excluded from the combined CLI.
-COMPUTED_FIELDS = {"stokes_q_cube", "stokes_u_cube", "cubes"}
+COMPUTED_FIELDS = {"stokes_q_cube", "stokes_u_cube", "cubes", "weight_cubes"}
 
 
 def _check_stage_prerequisites(
@@ -275,6 +275,7 @@ def process_racs_all(
         )
         resolved_spice_field_options = spice_field_options.with_options(
             cubes=list(pol_result.stokes_cubes.values()),
+            weight_cubes=list(pol_result.weight_cubes.values()),
             reference_image=resolved_reference_image,
             output_path=spice_field_options.output_path or output_root / "spice",
         )
@@ -290,11 +291,14 @@ def process_racs_all(
         )
         terminal_results.extend(
             compress_cube(
-                stokes_cube,
+                cube,
                 method=pol_fitscube_options.compress_method,
                 max_workers=pol_fitscube_options.max_workers,
             )
-            for stokes_cube in pol_result.stokes_cubes.values()
+            for cube in (
+                *pol_result.stokes_cubes.values(),
+                *pol_result.weight_cubes.values(),
+            )
         )
 
     return terminal_results
@@ -370,7 +374,7 @@ def cli() -> None:
     # Excluded from the parser (COMPUTED_FIELDS), but create_options_from_parser
     # reads every field off the namespace. process_racs_all sets the real values.
     for field in COMPUTED_FIELDS:
-        setattr(args, field, [] if field == "cubes" else None)
+        setattr(args, field, [] if field in ("cubes", "weight_cubes") else None)
 
     pipeline_options = create_options_from_parser(
         parser_namespace=args, options_class=RACSAllPipelineOptions

--- a/flint/prefect/flows/spice_compression_pipeline.py
+++ b/flint/prefect/flows/spice_compression_pipeline.py
@@ -1,6 +1,7 @@
 """Standalone SPICE-style cube compression pipeline: trim already-imaged
-Stokes cubes down to small boxes around catalogued sources, crop to their
-union, and compress. See ``flint.spice``.
+Stokes image and weight cubes down to small boxes around catalogued sources,
+crop to their union, and compress. Every cube is trimmed with the same boxes,
+so they all land on a common grid. See ``flint.spice``.
 """
 
 from __future__ import annotations
@@ -27,7 +28,7 @@ from flint.prefect.common.spice import (
 )
 from flint.prefect.common.utils import task_archive_sbid, task_getattr
 from flint.source_finding.aegean import run_bane_and_aegean
-from flint.spice import any_box_overlaps
+from flint.spice import check_cubes_share_shape, shared_pixel_boxes
 
 task_run_bane_and_aegean = task(run_bane_and_aegean)
 
@@ -38,6 +39,8 @@ def process_spice_compression(spice_field_options: SpiceFieldOptions) -> list[Pa
         raise ValueError(
             "``cubes`` is required. The racs-all flow sets it from the polarisation stage."
         )
+
+    cubes = [*spice_field_options.cubes, *spice_field_options.weight_cubes]
 
     strategy = load_and_copy_strategy(
         output_split_science_path=spice_field_options.cubes[0].parent,
@@ -89,37 +92,29 @@ def process_spice_compression(spice_field_options: SpiceFieldOptions) -> list[Pa
         is_user_catalogue=is_user_catalogue,
     )
 
-    resolved_sky_boxes = island_sky_boxes.result()
-    overlapping = [
-        cube
-        for cube in spice_field_options.cubes
-        if any_box_overlaps(fits_path=cube, sky_boxes=resolved_sky_boxes)
-    ]
-    if not overlapping:
-        raise ValueError(
-            f"No island overlaps any of the {len(spice_field_options.cubes)} supplied "
-            "cubes. Check the catalogue and reference image match the field."
-        )
-    if len(overlapping) != len(spice_field_options.cubes):
-        logger.warning(
-            f"{len(spice_field_options.cubes) - len(overlapping)} cube(s) have no "
-            "islands and will be compressed without spicing"
-        )
-
-    spiced_cubes = task_spice_fits.map(
-        fits_path=spice_field_options.cubes,
-        sky_boxes=unmapped(resolved_sky_boxes),
-        output_path=unmapped(spice_field_options.output_path),
+    # One set of boxes for every image and weight cube, so they all come out of
+    # the spicing on the same pixel grid.
+    pixel_boxes = shared_pixel_boxes(
+        fits_paths=cubes, sky_boxes=island_sky_boxes.result()
     )
 
+    spiced_cubes = task_spice_fits.map(
+        fits_path=cubes,
+        pixel_boxes=unmapped(pixel_boxes),
+        output_path=unmapped(spice_field_options.output_path),
+    )
+    spiced_paths = spiced_cubes.result()
+    spiced_shape = check_cubes_share_shape(fits_paths=spiced_paths)
+    logger.info(f"Spiced {len(spiced_paths)} cubes, all of shape {spiced_shape}")
+
     compressed_cubes = task_compress_cube.map(
-        out_cube=spiced_cubes,
+        out_cube=spiced_paths,
         method=unmapped(spice_options.compress_method),
         max_workers=unmapped(spice_options.compress_max_workers),
     )
 
-    logger.info(f"Compressed {len(compressed_cubes)} cubes")
     written_paths = compressed_cubes.result()
+    logger.info(f"Compressed {len(written_paths)} cubes")
 
     if spice_field_options.sbid_copy_path:
         task_archive_sbid.submit(

--- a/flint/spice.py
+++ b/flint/spice.py
@@ -1,5 +1,7 @@
 """SPICE-style cube trimming: mask everything outside small boxes around
-catalogued sources, crop to their union. See ``flint.options.SpiceOptions``.
+catalogued sources, crop to their union. A set of cubes (image and weight,
+across all Stokes) is trimmed with one shared set of boxes, so they all come
+out on the same grid. See ``flint.options.SpiceOptions``.
 """
 
 from __future__ import annotations
@@ -323,44 +325,108 @@ def keep_mask_from_boxes(
     return mask
 
 
-def any_box_overlaps(fits_path: Path, sky_boxes: list[SkyBoundingBox]) -> bool:
-    """Whether any sky box projects onto ``fits_path``. Reads only the header
+def cube_shape(fits_path: Path) -> tuple[int, ...]:
+    """Shape of a FITS file's primary HDU in numpy order, read from its header"""
+    header = fits.getheader(fits_path)
+
+    return tuple(header[f"NAXIS{axis}"] for axis in range(header["NAXIS"], 0, -1))
+
+
+def check_cubes_share_shape(fits_paths: list[Path]) -> tuple[int, ...]:
+    """The shape shared by every cube. Image and weight cubes across all Stokes
+    come off the same linmos grid, so a disagreement means something upstream
+    has gone wrong. Reads headers only.
 
     Args:
-        fits_path (Path): The image or cube to test
+        fits_paths (list[Path]): The cubes to compare
+
+    Returns:
+        tuple[int, ...]: The shape they share
+
+    Raises:
+        ValueError: The cubes do not all share a shape
+    """
+    shapes = {fits_path: cube_shape(fits_path=fits_path) for fits_path in fits_paths}
+    unique_shapes = set(shapes.values())
+    if len(unique_shapes) != 1:
+        raise ValueError(f"Cubes do not share a shape: {shapes}")
+
+    return unique_shapes.pop()
+
+
+def shared_pixel_boxes(
+    fits_paths: list[Path], sky_boxes: list[SkyBoundingBox]
+) -> list[BoundingBox]:
+    """Project sky boxes onto the pixel grid shared by every cube.
+
+    Spicing all cubes with this one set of boxes is what leaves them on an
+    identical grid afterwards, so the cubes must start on one. Reads headers only.
+
+    Args:
+        fits_paths (list[Path]): The cubes about to be spiced together
         sky_boxes (list[SkyBoundingBox]): Sky boxes to project
 
     Returns:
-        bool: True if at least one box overlaps
-    """
-    header = fits.getheader(fits_path)
-    wcs = WCS(header)
-    image_shape = (header["NAXIS2"], header["NAXIS1"])
+        list[BoundingBox]: Those boxes that land on the shared grid
 
-    return any(
-        sky_box.to_bounding_box(wcs=wcs, image_shape=image_shape) is not None
-        for sky_box in sky_boxes
+    Raises:
+        ValueError: The cubes do not share a grid, or no box overlaps it
+    """
+    if not fits_paths:
+        raise ValueError("No cubes supplied")
+    if not sky_boxes:
+        raise ValueError("No sky boxes supplied")
+
+    shape = check_cubes_share_shape(fits_paths=fits_paths)
+    image_shape = (shape[-2], shape[-1])
+
+    reference_wcs = WCS(fits.getheader(fits_paths[0])).celestial
+    for fits_path in fits_paths[1:]:
+        wcs = WCS(fits.getheader(fits_path)).celestial
+        if not wcs.wcs.compare(reference_wcs.wcs, tolerance=1e-9):
+            raise ValueError(
+                f"{fits_path} is not on the same celestial grid as {fits_paths[0]}"
+            )
+
+    pixel_boxes = [
+        pixel_box
+        for pixel_box in (
+            sky_box.to_bounding_box(wcs=reference_wcs, image_shape=image_shape)
+            for sky_box in sky_boxes
+        )
+        if pixel_box is not None
+    ]
+    if not pixel_boxes:
+        raise ValueError(
+            f"None of the {len(sky_boxes)} island boxes overlap the shared "
+            f"{image_shape} grid of the {len(fits_paths)} supplied cubes. Check the "
+            "catalogue and reference image match the field."
+        )
+
+    logger.info(
+        f"{len(pixel_boxes)} of {len(sky_boxes)} island boxes land on the cubes"
     )
+    return pixel_boxes
 
 
 def spice_fits(
-    fits_path: Path, sky_boxes: list[SkyBoundingBox], output_path: Path | None = None
+    fits_path: Path, pixel_boxes: list[BoundingBox], output_path: Path | None = None
 ) -> Path:
-    """Mask every pixel outside ``boxes`` to NaN and crop to their union.
+    """Mask every pixel outside ``pixel_boxes`` to NaN and crop to their union.
 
-    Boxes are projected through this file's own WCS, so it need not share a pixel
-    grid with the image they were built from. Works on a single plane or a
-    multi-channel cube. A file that no box overlaps is left untouched.
+    Works on a single plane or a multi-channel cube. Extensions such as the beam
+    table are carried through untouched. Every cube spiced with the one set of
+    boxes from ``shared_pixel_boxes`` comes out on the same grid.
 
     Args:
         fits_path (Path): The image or cube to spice
-        sky_boxes (list[SkyBoundingBox]): Sky boxes to keep
+        pixel_boxes (list[BoundingBox]): Pixel boxes to keep, on this file's grid
         output_path (Path | None, optional): Directory to write the spiced cube into, deleting ``fits_path`` once written. Defaults to replacing ``fits_path`` in place.
 
     Returns:
-        Path: The spiced cube, or ``fits_path`` unchanged if no box overlapped it
+        Path: The spiced cube
     """
-    if not sky_boxes:
+    if not pixel_boxes:
         raise ValueError(f"No bounding boxes supplied for {fits_path}")
 
     # A dask worker death after the unlink below leaves the output written and the
@@ -371,34 +437,24 @@ def spice_fits(
             logger.info(f"{spiced_path} already written, nothing to redo")
             return spiced_path
 
+    overall = _merge_bound_boxes(bounding_boxes=pixel_boxes)
+
     with fits.open(fits_path) as hdul:
         header = hdul[0].header.copy()
         image_shape = tuple(hdul[0].data.shape[-2:])
-        wcs = WCS(header)
-
-        pixel_boxes = [
-            pixel_box
-            for pixel_box in (
-                sky_box.to_bounding_box(wcs=wcs, image_shape=image_shape)
-                for sky_box in sky_boxes
-            )
-            if pixel_box is not None
-        ]
-        if not pixel_boxes:
-            logger.warning(
-                f"No island overlaps {fits_path}, leaving it unspiced. "
-                f"Checked {len(sky_boxes)} sky boxes against shape {image_shape}"
-            )
-            return fits_path
-
-        overall = _merge_bound_boxes(bounding_boxes=pixel_boxes)
-        mask = keep_mask_from_boxes(bounding_boxes=pixel_boxes, image_shape=image_shape)
-        mask_cropped = mask[overall.xmin : overall.xmax, overall.ymin : overall.ymax]
         data = np.array(
             hdul[0].data[..., overall.xmin : overall.xmax, overall.ymin : overall.ymax]
         )
         extra_hdus = [hdu.copy() for hdu in hdul[1:]]
 
+    if image_shape != overall.original_shape:
+        raise ValueError(
+            f"{fits_path} has plane shape {image_shape}, but the boxes were built "
+            f"against {overall.original_shape}"
+        )
+
+    mask = keep_mask_from_boxes(bounding_boxes=pixel_boxes, image_shape=image_shape)
+    mask_cropped = mask[overall.xmin : overall.xmax, overall.ymin : overall.ymax]
     data[..., ~mask_cropped] = np.nan
 
     header["CRPIX1"] -= overall.ymin

--- a/tests/test_racs_all_pipeline.py
+++ b/tests/test_racs_all_pipeline.py
@@ -36,8 +36,8 @@ def test_get_parser() -> None:
 
 
 def test_get_parser_excludes_computed_stage_outputs() -> None:
-    """stokes_q_cube/stokes_u_cube (rm-synth) and cubes (spice) are computed
-    from the polarisation stage's output inside process_racs_all, so the
+    """stokes_q_cube/stokes_u_cube (rm-synth) and cubes/weight_cubes (spice) are
+    computed from the polarisation stage's output inside process_racs_all, so the
     combined CLI must not force the user to supply dummy positional values
     for them -- only low_data/mid_data/high_data should be positional."""
     args = get_parser().parse_args(["/low", "/mid", "/high"])
@@ -45,12 +45,14 @@ def test_get_parser_excludes_computed_stage_outputs() -> None:
     assert not hasattr(args, "stokes_q_cube")
     assert not hasattr(args, "stokes_u_cube")
     assert not hasattr(args, "cubes")
+    assert not hasattr(args, "weight_cubes")
 
     # create_options_from_parser reads every field off the namespace, so cli()
     # sets the computed ones to their empty defaults first, as done here.
     args.stokes_q_cube = None
     args.stokes_u_cube = None
     args.cubes = []
+    args.weight_cubes = []
 
     rmsynth_field_options = create_options_from_parser(
         parser_namespace=args, options_class=RMSynthFieldOptions
@@ -60,6 +62,7 @@ def test_get_parser_excludes_computed_stage_outputs() -> None:
     )
     assert rmsynth_field_options.stokes_q_cube is None
     assert spice_field_options.cubes == []
+    assert spice_field_options.weight_cubes == []
 
 
 @pytest.fixture

--- a/tests/test_spice.py
+++ b/tests/test_spice.py
@@ -19,9 +19,11 @@ from flint.coadd.linmos import BoundingBox
 from flint.convol import BeamShape
 from flint.options import SpiceOptions
 from flint.spice import (
-    any_box_overlaps,
+    SkyBoundingBox,
+    check_cubes_share_shape,
     island_sky_boxes,
     keep_mask_from_boxes,
+    shared_pixel_boxes,
     spice_fits,
 )
 
@@ -369,7 +371,10 @@ def test_spice_fits_masks_crops_and_replaces(tmp_path: Path, shape):
         is_user_catalogue=False,
     )
 
-    out_path = spice_fits(fits_path=fits_path, sky_boxes=sky_boxes)
+    out_path = spice_fits(
+        fits_path=fits_path,
+        pixel_boxes=shared_pixel_boxes(fits_paths=[fits_path], sky_boxes=sky_boxes),
+    )
     assert out_path == fits_path
 
     with fits.open(out_path) as hdul:
@@ -415,7 +420,10 @@ def test_spice_fits_preserves_extra_hdus(tmp_path: Path):
         spice_options=SpiceOptions(n_beamwidths=1.0),
         is_user_catalogue=False,
     )
-    spice_fits(fits_path=fits_path, sky_boxes=sky_boxes)
+    spice_fits(
+        fits_path=fits_path,
+        pixel_boxes=shared_pixel_boxes(fits_paths=[fits_path], sky_boxes=sky_boxes),
+    )
 
     with fits.open(fits_path) as hdul:
         assert len(hdul) == 2
@@ -427,7 +435,7 @@ def test_spice_fits_no_boxes_raises(tmp_path: Path):
     fits_path = tmp_path / "test.fits"
     _write_test_fits(fits_path, wcs, (NY, NX))
     with pytest.raises(ValueError):
-        spice_fits(fits_path=fits_path, sky_boxes=[])
+        spice_fits(fits_path=fits_path, pixel_boxes=[])
 
 
 def _shifted_wcs(crpix_shift: tuple[float, float]) -> WCS:
@@ -460,7 +468,10 @@ def test_boxes_survive_a_trimmed_reference_grid(tmp_path: Path):
     fits_path = tmp_path / "cube.fits"
     _write_test_fits(fits_path, cube_wcs, (NY, NX))
 
-    spice_fits(fits_path=fits_path, sky_boxes=sky_boxes)
+    spice_fits(
+        fits_path=fits_path,
+        pixel_boxes=shared_pixel_boxes(fits_paths=[fits_path], sky_boxes=sky_boxes),
+    )
 
     with fits.open(fits_path) as hdul:
         data, header = hdul[0].data, hdul[0].header
@@ -471,43 +482,6 @@ def test_boxes_survive_a_trimmed_reference_grid(tmp_path: Path):
     )
     assert np.isfinite(data[int(np.round(y_pix)), int(np.round(x_pix))])
     assert data.shape[-2:] != (NY, NX), "The cube should have been cropped"
-
-
-def test_spice_fits_leaves_a_cube_with_no_islands_untouched(tmp_path: Path):
-    reference_wcs = _make_wcs()
-    sky_boxes = island_sky_boxes(
-        table=_aegean_table([_default_row(0, RA0, DEC0)]),
-        wcs=reference_wcs,
-        beam_shape=BEAM,
-        spice_options=SpiceOptions(n_beamwidths=1.0),
-        is_user_catalogue=False,
-    )
-
-    # A cube pointed far away from the catalogued source
-    elsewhere = _make_wcs()
-    elsewhere.wcs.crval = [RA0 + 20.0, DEC0]
-    fits_path = tmp_path / "elsewhere.fits"
-    _write_test_fits(fits_path, elsewhere, (NY, NX))
-    before = fits_path.read_bytes()
-
-    assert not any_box_overlaps(fits_path=fits_path, sky_boxes=sky_boxes)
-    assert spice_fits(fits_path=fits_path, sky_boxes=sky_boxes) == fits_path
-    assert fits_path.read_bytes() == before, "An unspiced cube must not be rewritten"
-
-
-def test_any_box_overlaps_true_for_the_reference_grid(tmp_path: Path):
-    wcs = _make_wcs()
-    sky_boxes = island_sky_boxes(
-        table=_aegean_table([_default_row(0, RA0, DEC0)]),
-        wcs=wcs,
-        beam_shape=BEAM,
-        spice_options=SpiceOptions(n_beamwidths=1.0),
-        is_user_catalogue=False,
-    )
-    fits_path = tmp_path / "on_grid.fits"
-    _write_test_fits(fits_path, wcs, (NY, NX))
-
-    assert any_box_overlaps(fits_path=fits_path, sky_boxes=sky_boxes)
 
 
 def test_spice_fits_writes_to_output_path_and_removes_the_original(tmp_path: Path):
@@ -524,7 +498,9 @@ def test_spice_fits_writes_to_output_path_and_removes_the_original(tmp_path: Pat
 
     output_path = tmp_path / "spice"
     spiced = spice_fits(
-        fits_path=fits_path, sky_boxes=sky_boxes, output_path=output_path
+        fits_path=fits_path,
+        pixel_boxes=shared_pixel_boxes(fits_paths=[fits_path], sky_boxes=sky_boxes),
+        output_path=output_path,
     )
 
     assert spiced == output_path / "cube.fits"
@@ -534,30 +510,6 @@ def test_spice_fits_writes_to_output_path_and_removes_the_original(tmp_path: Pat
     with fits.open(spiced) as hdul:
         assert hdul[0].data.shape[-2:] != (NY, NX)
         assert any("flint.spice" in str(card) for card in hdul[0].header["HISTORY"])
-
-
-def test_spice_fits_unoverlapped_cube_is_not_moved(tmp_path: Path):
-    wcs = _make_wcs()
-    sky_boxes = island_sky_boxes(
-        table=_aegean_table([_default_row(0, RA0, DEC0)]),
-        wcs=wcs,
-        beam_shape=BEAM,
-        spice_options=SpiceOptions(n_beamwidths=1.0),
-        is_user_catalogue=False,
-    )
-
-    elsewhere = _make_wcs()
-    elsewhere.wcs.crval = [RA0 + 20.0, DEC0]
-    fits_path = tmp_path / "elsewhere.fits"
-    _write_test_fits(fits_path, elsewhere, (NY, NX))
-
-    output_path = tmp_path / "spice"
-    result = spice_fits(
-        fits_path=fits_path, sky_boxes=sky_boxes, output_path=output_path
-    )
-
-    assert result == fits_path
-    assert fits_path.exists(), "An unspiced cube must not be deleted"
 
 
 def test_spice_fits_is_idempotent_after_a_worker_death(tmp_path: Path):
@@ -575,14 +527,97 @@ def test_spice_fits_is_idempotent_after_a_worker_death(tmp_path: Path):
     )
     output_path = tmp_path / "spice"
 
+    pixel_boxes = shared_pixel_boxes(fits_paths=[fits_path], sky_boxes=sky_boxes)
     first = spice_fits(
-        fits_path=fits_path, sky_boxes=sky_boxes, output_path=output_path
+        fits_path=fits_path, pixel_boxes=pixel_boxes, output_path=output_path
     )
     first_bytes = first.read_bytes()
 
     second = spice_fits(
-        fits_path=fits_path, sky_boxes=sky_boxes, output_path=output_path
+        fits_path=fits_path, pixel_boxes=pixel_boxes, output_path=output_path
     )
 
     assert second == first
     assert second.read_bytes() == first_bytes, "The rerun must not re-crop the output"
+
+
+def _sky_boxes(wcs: WCS) -> list[SkyBoundingBox]:
+    return island_sky_boxes(
+        table=_aegean_table([_default_row(0, RA0, DEC0)]),
+        wcs=wcs,
+        beam_shape=BEAM,
+        spice_options=SpiceOptions(n_beamwidths=1.0),
+        is_user_catalogue=False,
+    )
+
+
+def test_image_and_weight_cubes_spice_to_the_same_shape(tmp_path: Path):
+    """The point of the shared boxes: every Stokes image and weight cube comes
+    out on one grid, extensions intact."""
+    wcs = _make_wcs()
+    cubes = []
+    for stokes in ("i", "q"):
+        for mode in ("image", "weight"):
+            fits_path = tmp_path / f"{stokes}.{mode}.fits"
+            _write_test_fits(fits_path, wcs, (3, NY, NX), extra_hdu=True)
+            cubes.append(fits_path)
+
+    pixel_boxes = shared_pixel_boxes(fits_paths=cubes, sky_boxes=_sky_boxes(wcs))
+    output_path = tmp_path / "spice"
+    spiced = [
+        spice_fits(fits_path=cube, pixel_boxes=pixel_boxes, output_path=output_path)
+        for cube in cubes
+    ]
+
+    shape = check_cubes_share_shape(fits_paths=spiced)
+    assert shape[-2:] != (NY, NX), "The cubes should have been cropped"
+    for spiced_path in spiced:
+        with fits.open(spiced_path) as hdul:
+            assert hdul[1].name == "BEAMS"
+
+
+def test_check_cubes_share_shape_rejects_a_mismatch(tmp_path: Path):
+    wcs = _make_wcs()
+    matching = tmp_path / "match.fits"
+    odd = tmp_path / "odd.fits"
+    _write_test_fits(matching, wcs, (3, NY, NX))
+    _write_test_fits(odd, wcs, (2, NY, NX))
+
+    assert check_cubes_share_shape(fits_paths=[matching, matching]) == (3, NY, NX)
+    with pytest.raises(ValueError, match="do not share a shape"):
+        check_cubes_share_shape(fits_paths=[matching, odd])
+
+
+def test_shared_pixel_boxes_rejects_a_differing_grid(tmp_path: Path):
+    """Same shape, shifted WCS -- the same boxes would crop them differently"""
+    wcs = _make_wcs()
+    on_grid = tmp_path / "on_grid.fits"
+    shifted = tmp_path / "shifted.fits"
+    _write_test_fits(on_grid, wcs, (NY, NX))
+    _write_test_fits(shifted, _shifted_wcs((30.0, 20.0)), (NY, NX))
+
+    with pytest.raises(ValueError, match="same celestial grid"):
+        shared_pixel_boxes(fits_paths=[on_grid, shifted], sky_boxes=_sky_boxes(wcs))
+
+
+def test_shared_pixel_boxes_raises_when_no_island_overlaps(tmp_path: Path):
+    wcs = _make_wcs()
+    elsewhere = _make_wcs()
+    elsewhere.wcs.crval = [RA0 + 20.0, DEC0]
+    fits_path = tmp_path / "elsewhere.fits"
+    _write_test_fits(fits_path, elsewhere, (NY, NX))
+
+    with pytest.raises(ValueError, match="island boxes overlap"):
+        shared_pixel_boxes(fits_paths=[fits_path], sky_boxes=_sky_boxes(wcs))
+
+
+def test_spice_fits_rejects_boxes_built_against_another_shape(tmp_path: Path):
+    wcs = _make_wcs()
+    reference = tmp_path / "reference.fits"
+    smaller = tmp_path / "smaller.fits"
+    _write_test_fits(reference, wcs, (NY, NX))
+    _write_test_fits(smaller, wcs, (NY // 2, NX // 2))
+
+    pixel_boxes = shared_pixel_boxes(fits_paths=[reference], sky_boxes=_sky_boxes(wcs))
+    with pytest.raises(ValueError, match="boxes were built against"):
+        spice_fits(fits_path=smaller, pixel_boxes=pixel_boxes)


### PR DESCRIPTION
SPICE compression only took the Stokes image cubes. It now takes the LINMOS weight cubes too, and every cube it touches is guaranteed to come out on the same grid.

## Weight cubes

- `SpiceFieldOptions.weight_cubes` — the weight cubes to trim and compress alongside `cubes`. Empty by default, so the standalone pipeline behaves as before when it isn't set.
- The racs-all flow fills it from `PolPipelineResult.weight_cubes`, matching how it already fills `cubes` from `stokes_cubes`.
- The spice pipeline concatenates the two lists and treats them identically from there on.

## One shared grid

Previously each file projected the island sky boxes through its own WCS and merged whatever landed on it, so two cubes could legitimately end up different sizes — and a cube no island landed on was left unspiced at full size altogether.

- `shared_pixel_boxes` checks the cubes share a data shape and celestial WCS, then projects the sky boxes once against that grid.
- `spice_fits` now takes those pixel boxes instead of sky boxes, and raises if handed boxes built against a different plane shape.
- `check_cubes_share_shape` re-reads the written cubes' headers and confirms they agree.

A grid that no island overlaps is now a hard error naming the catalogue/reference-image mismatch, replacing `any_box_overlaps` and the per-file skip that let the shapes diverge. The reference image may still sit on its own grid — only the cubes spiced together have to match.

## Extensions

Extensions (the fitscube `BEAMS` table in particular) were already copied through `spice_fits` and still are; the channel axis is untouched, so a beam table stays valid. `compress_cube` gzips the byte stream, so extensions survive compression as well. Now covered by a test that spices a four-cube image/weight set and asserts both the shared shape and the surviving `BEAMS` extension on each output.

## Also

The skip-spice path in the racs-all flow compressed only the image cubes, even though the polarisation stage had deferred compression for both. It now compresses the weight cubes too.

## Testing

`tests/test_spice.py` updated for the new signature, plus new cases for the shared image/weight shape, a shape mismatch, a differing celestial grid, a grid with no islands, and boxes from another shape. Full suite: 474 passed, 3 pre-existing failures unrelated to this change (two network-blocked Vizier downloads, one `rsync` test).


---
_Generated by [Claude Code](https://claude.ai/code/session_01MzDY78jjEiVKdumjYTEjms)_