### PR TITLE
Make peak products a flow option like the moment products

### DIFF
--- a/flint/data/tests/test_config_pol.yaml
+++ b/flint/data/tests/test_config_pol.yaml
@@ -123,5 +123,3 @@ rmsynth:
   rmclean:
     auto_mask: 7
     auto_threshold: 1
-    # Any of: dirty, clean, model
-    peak_products: []

--- a/flint/options.py
+++ b/flint/options.py
@@ -298,8 +298,6 @@ class RMCleanOptions(BaseOptions):
     """CLEAN loop gain"""
     moment_threshold_snr: float = 5.0
     """SNR cut (times the theoretical FDF noise) applied before computing Faraday moment maps, the dirty ones included"""
-    peak_products: list[Literal["dirty", "clean", "model"]] = []
-    """Which FDF(s) to measure peak statistics from: peak polarised intensity (raw and debiased), Faraday depth, polarisation angle and intrinsic angle, each with its error. Nine (ny, nx) maps per FDF, so empty by default -- at 16032^2 that is ~9 GB per entry"""
 
 
 class SpiceOptions(BaseOptions):
@@ -369,6 +367,8 @@ class RMSynthFieldOptions(BaseOptions):
     """Which Faraday dispersion function (FDF) cubes to write as FITS. Nothing by default, as these cubes can be large."""
     moment_products: list[Literal["dirty", "clean", "model"]] = ["clean"]
     """Which FDF(s) to compute Faraday moment maps from."""
+    peak_products: list[Literal["dirty", "clean", "model"]] = []
+    """Which FDF(s) to measure peak statistics from: peak polarised intensity (raw and debiased), Faraday depth, polarisation angle and intrinsic angle, each with its error. Nine (ny, nx) maps per FDF, so empty by default -- at 16032^2 that is ~9 GB per entry"""
     output_path: Path | None = None
     """Directory the FDF cube and moment products are written into. Defaults to alongside the input Stokes cubes"""
     sbid_copy_path: Path | None = None

--- a/flint/prefect/common/rmsynth.py
+++ b/flint/prefect/common/rmsynth.py
@@ -74,8 +74,8 @@ def task_write_rm_products(
     rmclean_options: RMCleanOptions,
     cube_products: list[FDFLabel],
     moment_products: list[FDFLabel],
+    peak_products: list[FDFLabel],
     output_prefix: Path,
-    peak_products: list[FDFLabel] | None = None,
 ) -> list[Path]:
     """Batch-compute and write the requested RM-synthesis/RM-CLEAN products"""
     from prefect_dask import get_dask_client
@@ -90,7 +90,7 @@ def task_write_rm_products(
             rmclean_options=rmclean_options,
             cube_products=cube_products,
             moment_products=moment_products,
+            peak_products=peak_products,
             output_prefix=output_prefix,
             dask_client=client,
-            peak_products=peak_products,
         )

--- a/flint/prefect/flows/rmsynth_pipeline.py
+++ b/flint/prefect/flows/rmsynth_pipeline.py
@@ -85,6 +85,14 @@ def process_rmsynth(
             "stokes_q_cube and stokes_u_cube are required. The racs-all flow sets "
             "them from the polarisation stage."
         )
+    if (
+        not rmsynth_field_options.cube_products
+        and not rmsynth_field_options.moment_products
+        and not rmsynth_field_options.peak_products
+    ):
+        logger.info("No RM-synthesis products requested, skipping.")
+        return RMSynthPipelineResult(written_paths=[], convolved_cubes=[])
+
     stokes_cubes = {
         "q": rmsynth_field_options.stokes_q_cube,
         "u": rmsynth_field_options.stokes_u_cube,
@@ -108,16 +116,6 @@ def process_rmsynth(
         )
     )
 
-    # After the options are built, not before: peak_products is a product
-    # request like the other two, but it comes from the strategy, not the CLI
-    if (
-        not rmsynth_field_options.cube_products
-        and not rmsynth_field_options.moment_products
-        and not rmclean_options.peak_products
-    ):
-        logger.info("No RM-synthesis products requested, skipping.")
-        return RMSynthPipelineResult(written_paths=[], convolved_cubes=[])
-
     stokes_cubes, convolved_cubes = _resolve_common_resolution_cubes(
         stokes_cubes=stokes_cubes,
         output_path=rmsynth_field_options.output_path,
@@ -137,7 +135,7 @@ def process_rmsynth(
     run_clean = needs_rmclean(
         cube_products=rmsynth_field_options.cube_products,
         moment_products=rmsynth_field_options.moment_products,
-        peak_products=rmclean_options.peak_products,
+        peak_products=rmsynth_field_options.peak_products,
     )
     clean_result = (
         task_rmclean.submit(
@@ -162,8 +160,8 @@ def process_rmsynth(
         rmclean_options=rmclean_options,
         cube_products=rmsynth_field_options.cube_products,
         moment_products=rmsynth_field_options.moment_products,
+        peak_products=rmsynth_field_options.peak_products,
         output_prefix=output_prefix,
-        peak_products=rmclean_options.peak_products,
     )
 
     written_paths = output_paths.result()

--- a/flint/rmsynth.py
+++ b/flint/rmsynth.py
@@ -68,21 +68,21 @@ _PEAK_MAPS = {
 def needs_rmclean(
     cube_products: list[FDFLabel],
     moment_products: list[FDFLabel],
-    peak_products: list[FDFLabel] | None = None,
+    peak_products: list[FDFLabel],
 ) -> bool:
     """Whether any requested product requires RM-CLEAN to be run.
 
     Args:
         cube_products (list[FDFLabel]): Requested FDF cubes
         moment_products (list[FDFLabel]): Requested Faraday moment maps
-        peak_products (list[FDFLabel] | None, optional): Requested FDF peak-statistic maps. Defaults to None.
+        peak_products (list[FDFLabel]): Requested FDF peak-statistic maps
 
     Returns:
         bool: True if RM-CLEAN is needed
     """
     return any(
         label in ("clean", "model")
-        for label in (*cube_products, *moment_products, *(peak_products or ()))
+        for label in (*cube_products, *moment_products, *peak_products)
     )
 
 
@@ -640,9 +640,9 @@ def write_rm_products(
     rmclean_options: RMCleanOptions,
     cube_products: list[FDFLabel],
     moment_products: list[FDFLabel],
+    peak_products: list[FDFLabel],
     output_prefix: Path,
     dask_client: Client | None = None,
-    peak_products: list[FDFLabel] | None = None,
 ) -> list[Path]:
     """Batch-compute and write the requested RM-synthesis/RM-CLEAN output products.
 
@@ -654,7 +654,7 @@ def write_rm_products(
         rmclean_options (RMCleanOptions): Options controlling RM-CLEAN
         cube_products (list[FDFLabel]): Which FDF cube(s) to write ('dirty', 'clean', 'model')
         moment_products (list[FDFLabel]): Which FDF(s) to compute Faraday moment maps from
-        peak_products (list[FDFLabel] | None, optional): Which FDF(s) to write peak-statistic maps from, nine per entry. Defaults to None.
+        peak_products (list[FDFLabel]): Which FDF(s) to write peak-statistic maps from, nine per entry
         output_prefix (Path): Common prefix for the output files
         dask_client (Client | None, optional): A distributed Client (e.g. the one backing a Prefect ``DaskTaskRunner``) to compute across, rather than just the local worker. Defaults to None.
 
@@ -767,7 +767,7 @@ def write_rm_products(
     # clean FDF and only under its own threshold. Deriving them here is what
     # lets any requested FDF have them -- the dirty one included, which needs no
     # RM-CLEAN at all -- under the same cut flint gives its moments.
-    for label in peak_products or ():
+    for label in peak_products:
         peaks = calc_faraday_peaks(
             fdf_sources[label],
             phi_arr_radm2=synth_results.phi_arr_radm2,
@@ -871,7 +871,7 @@ def write_rm_products(
             )
         )
 
-    for label in peak_products or ():
+    for label in peak_products:
         output_paths.extend(
             write_peak_maps_to_fits(
                 peaks=FaradayPeaks(

--- a/tests/test_rmsynth.py
+++ b/tests/test_rmsynth.py
@@ -129,7 +129,7 @@ def _synth_and_write(
     stokes_i_weight_cube: Path | None = None,
     stokes_q_weight_cube: Path | None = None,
     stokes_u_weight_cube: Path | None = None,
-    peak_products: list[FDFLabel] | None = None,
+    peak_products: list[FDFLabel] = [],
 ) -> list[Path]:
     if not cube_products and not moment_products and not peak_products:
         return []
@@ -381,6 +381,7 @@ def test_unnamed_stokes_i_model_terms_are_skipped_with_a_warning(
         rmclean_options=RMCleanOptions(),
         cube_products=[],
         moment_products=["dirty"],
+        peak_products=[],
         output_prefix=tmp_path / "test_field",
     )
 
@@ -423,6 +424,7 @@ def test_stokes_i_model_rebuilds_from_the_written_term_maps(
         rmclean_options=RMCleanOptions(),
         cube_products=[],
         moment_products=["dirty"],
+        peak_products=[],
         output_prefix=output_prefix,
     )
 
@@ -1160,6 +1162,7 @@ def test_rmclean_runs_once_per_chunk_whatever_is_requested(
         rmclean_options=RMCleanOptions(),
         cube_products=cube_products,
         moment_products=moment_products,
+        peak_products=[],
         output_prefix=tmp_path / "test_field",
     )
 
@@ -1240,6 +1243,7 @@ def test_rmclean_runs_once_per_chunk_on_a_distributed_client(
                 rmclean_options=RMCleanOptions(),
                 cube_products=[],
                 moment_products=["clean", "dirty", "model"],
+                peak_products=[],
                 output_prefix=tmp_path / "field",
                 dask_client=client,
             )


### PR DESCRIPTION
`peak_products` was landed on `RMCleanOptions`, so a product request that sits beside `cube_products` and `moment_products` in every signature was configured from the imaging strategy rather than the pipeline options. This brings it into line with the other two.

## Changes

- `RMSynthFieldOptions` gains `peak_products`, directly after `moment_products`; `RMCleanOptions` loses it, and the `rmclean` block of `flint/data/tests/test_config_pol.yaml` drops the key. It is now set from the CLI/flow options (and so flows through the racs-all pipeline, which forwards `RMSynthFieldOptions` wholesale) instead of the strategy YAML.
- `needs_rmclean` and `write_rm_products` (plus the `task_write_rm_products` wrapper) take `peak_products` as a required argument positioned after `moment_products`, rather than a trailing `| None = None` keyword. The `peak_products or ()` loop guards go away with it.
- The "no products requested, skipping" early exit in `process_rmsynth` moves back up next to the other input validation — it no longer has to wait for the strategy to be loaded and parsed just to learn whether peaks were asked for.

## Behaviour

No change to what gets written for a given set of requests. The one user-visible difference is where `peak_products` is specified: an existing strategy YAML carrying `peak_products` under `rmclean` will now fail strategy validation, and the request belongs on the pipeline options instead.

## Testing

- `pytest tests/test_rmsynth.py` — 36 passed
- `pytest tests/test_prefect_rmsynth_flow.py tests/test_racs_all_pipeline.py` — 28 passed
- `pytest tests/test_configuration.py tests/test_options.py` — 41 passed
- `ruff check` / `ruff format --check` clean

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bonk4muETYXyG3E6knCfDu


---
_Generated by [Claude Code](https://claude.ai/code/session_01Bonk4muETYXyG3E6knCfDu)_