### PR TITLE
Convolve the RM-synthesis cubes plane by plane, and never solve an empty beam set

### DIFF
--- a/flint/convol.py
+++ b/flint/convol.py
@@ -16,8 +16,10 @@ import numpy as np
 from astropy.io import fits
 from astropy.wcs import FITSFixedWarning
 from racs_tools import beamcon_2D, beamcon_3D
+from racs_tools.convolve_uv import my_ceil, round_up
 from radio_beam import Beam, Beams
 from radio_beam.beam import NoBeamException
+from radio_beam.utils import BeamError
 
 from flint.logging import logger
 
@@ -217,7 +219,26 @@ def common_beam_from_cubes(
         return None
 
     logger.info(f"Deriving a common beam from {usable.sum()} of {len(usable)} beams")
-    return beams[usable].common_beam()
+    usable_beams = beams[usable]
+    try:
+        common_beam = usable_beams.common_beam()
+    except BeamError:
+        logger.warning(
+            "Could not find a common beam with the default tolerance, trying again"
+        )
+        common_beam = usable_beams.common_beam(tolerance=1e-5)
+
+    # The minimum enclosing ellipse radio_beam solves for sits right against the
+    # beams it encloses, so a channel whose own beam it barely covers can fail to
+    # deconvolve. Rounding up gives every channel the headroom to reach it, which
+    # is what racs_tools does with the common beams it derives itself.
+    return Beam(
+        major=my_ceil(common_beam.major.to(u.arcsecond).value, precision=1)
+        * u.arcsecond,
+        minor=my_ceil(common_beam.minor.to(u.arcsecond).value, precision=1)
+        * u.arcsecond,
+        pa=round_up(common_beam.pa.to(u.degree).value, decimals=2) * u.degree,
+    )
 
 
 def convolve_plane_to_beam(

--- a/flint/convol.py
+++ b/flint/convol.py
@@ -23,6 +23,13 @@ from flint.logging import logger
 
 warnings.simplefilter("ignore", FITSFixedWarning)
 
+# A restoring beam smaller than this is not a real PSF. Blank channels are
+# marked either with an exactly-zero beam (wsclean's convention for a plane
+# with no fitted beam) or with ``np.finfo(np.float32).tiny`` (the sentinel
+# ``fitscube`` writes into a BEAMS table, as CASA rejects a NaN there). Both
+# sit many orders of magnitude below any beam an interferometer can produce.
+MIN_USABLE_BEAM_ARCSEC = 1e-6
+
 
 class BeamShape(NamedTuple):
     """A simple container to represent a fitted 2D gaussian,
@@ -91,84 +98,173 @@ def _beams_from_cubes(cube_paths: list[Path]) -> Beams:
     )
 
 
-def cubes_share_common_beam(cube_paths: Collection[Path]) -> bool:
-    """Whether a single restoring beam describes every channel of every cube.
-    Cubes with no beam information at all have no resolution to make common.
+def usable_beam_mask(beams: Beams, cutoff: float | None = None) -> np.ndarray:
+    """Which beams describe a real PSF that may be brought to a common resolution.
+
+    Blank channels carry a placeholder beam rather than a real one, and a
+    channel coarser than ``cutoff`` is to be blanked rather than convolved to.
+    Neither constrains a common beam, and neither may be handed to
+    ``radio_beam``, whose common-beam solver reduces a set with no usable beam
+    in it to an empty sequence and raises an opaque ``argmax`` error.
+
+    Args:
+        beams (Beams): The beams to inspect
+        cutoff (float | None, optional): Beams whose major axis exceeds this, in arcsec, are not usable. Defaults to no cutoff.
+
+    Returns:
+        np.ndarray: Boolean mask, True where the beam is usable
+    """
+    major = np.asarray(beams.major.to(u.arcsecond).value, dtype=float)
+    minor = np.asarray(beams.minor.to(u.arcsecond).value, dtype=float)
+    pa = np.asarray(beams.pa.to(u.degree).value, dtype=float)
+
+    usable = (
+        (major > MIN_USABLE_BEAM_ARCSEC)
+        & (minor > MIN_USABLE_BEAM_ARCSEC)
+        & np.isfinite(major)
+        & np.isfinite(minor)
+        & np.isfinite(pa)
+    )
+    if cutoff is not None:
+        usable &= major <= cutoff
+
+    return usable
+
+
+def beam_from_header(header: fits.Header) -> Beam | None:
+    """The restoring beam recorded in a FITS header, or None when there is none"""
+    try:
+        return Beam.from_fits_header(header)
+    except (NoBeamException, KeyError):
+        return None
+
+
+def header_beam_is_usable(header: fits.Header, cutoff: float | None = None) -> bool:
+    """Whether the beam a FITS header records is a real PSF. See ``usable_beam_mask``"""
+    beam = beam_from_header(header=header)
+    if beam is None:
+        return False
+
+    return bool(usable_beam_mask(beams=Beams(beams=[beam]), cutoff=cutoff)[0])
+
+
+def _cube_beams(cube_paths: Collection[Path]) -> Beams | None:
+    """Every channel beam of every cube, or None when there is no beam to read"""
+    try:
+        return _beams_from_cubes(cube_paths=list(cube_paths))
+    except NoBeamException:
+        logger.info(f"No beam information found among {list(cube_paths)=}")
+        return None
+
+
+def cubes_share_common_beam(
+    cube_paths: Collection[Path], cutoff: float | None = None
+) -> bool:
+    """Whether a single restoring beam already describes every channel of every
+    cube. Placeholder beams are ignored: a blanked channel holds no signal and
+    so has no resolution to make common. Cubes with no beam information at all,
+    or with nothing but placeholders, likewise have nothing to bring together.
+
+    A channel whose beam is coarser than ``cutoff`` is one to blank, which only
+    a convolution pass will do, so such a cube does not share a common beam.
 
     Args:
         cube_paths (Collection[Path]): The FITS cubes to inspect
+        cutoff (float | None, optional): Channels coarser than this, in arcsec, are to be blanked rather than convolved to. Defaults to no cutoff.
 
     Returns:
         bool: Whether the cubes are already at a common resolution
     """
-    cube_paths = list(cube_paths)
-    try:
-        beams = _beams_from_cubes(cube_paths=cube_paths)
-    except NoBeamException:
-        logger.info(f"No beam information found among {cube_paths=}")
+    beams = _cube_beams(cube_paths=cube_paths)
+    if beams is None:
         return True
 
-    return all(beam == beams[0] for beam in beams)
+    usable = usable_beam_mask(beams=beams, cutoff=cutoff)
+    if not usable.any():
+        logger.info(f"No usable restoring beam among {list(cube_paths)=}")
+        return True
+
+    # A real beam that the cutoff excludes is a channel to blank, which is work
+    # only the convolution pass does
+    if cutoff is not None and (usable_beam_mask(beams=beams) & ~usable).any():
+        return False
+
+    usable_beams = beams[usable]
+    return all(beam == usable_beams[0] for beam in usable_beams)
 
 
-def common_beam_from_cubes(cube_paths: Collection[Path]) -> Beam:
-    """The smallest beam that encompasses every channel of every cube.
+def common_beam_from_cubes(
+    cube_paths: Collection[Path], cutoff: float | None = None
+) -> Beam | None:
+    """The smallest beam that encompasses every usable channel of every cube.
 
     Args:
         cube_paths (Collection[Path]): The FITS cubes to inspect
+        cutoff (float | None, optional): Channels coarser than this, in arcsec, are left out of the common beam rather than dragging every channel out to their resolution. Defaults to no cutoff.
 
     Returns:
-        Beam: The beam every channel of every cube fits inside
+        Beam | None: The beam every usable channel fits inside, or None when no channel of any cube carries a real restoring beam
     """
-    return _beams_from_cubes(cube_paths=list(cube_paths)).common_beam()
+    beams = _cube_beams(cube_paths=cube_paths)
+    if beams is None:
+        return None
+
+    usable = usable_beam_mask(beams=beams, cutoff=cutoff)
+    if not usable.any():
+        logger.warning(
+            f"No usable restoring beam among {list(cube_paths)=}, so no common beam"
+        )
+        return None
+
+    logger.info(f"Deriving a common beam from {usable.sum()} of {len(usable)} beams")
+    return beams[usable].common_beam()
 
 
-def convolve_cubes_to_common_beam(
-    cube_paths: Collection[Path],
-    output_path: Path | None = None,
-    convol_suffix: str = "conv",
+def convolve_plane_to_beam(
+    plane: Path,
+    beam_shape: BeamShape,
     cutoff: float | None = None,
-) -> list[Path]:
-    """Convolve every channel of every cube to the one smallest beam that
-    encompasses them all. New cubes are written and the inputs are left as they
-    are.
+    convol_suffix: str = "conv",
+) -> Path:
+    """Convolve a single channel plane to ``beam_shape``, writing a new image
+    alongside it and leaving the input in place.
+
+    A plane coarser than ``cutoff`` is blanked rather than convolved, and its
+    output is marked with a zero beam so that the cube it is combined into
+    records that the channel holds no PSF.
 
     Args:
-        cube_paths (Collection[Path]): The FITS cubes to bring to one resolution
-        output_path (Path | None, optional): Directory the convolved cubes are written into. Defaults to alongside each input cube.
-        convol_suffix (str, optional): The suffix added to .fits to indicate a smoothed cube. Defaults to 'conv'.
-        cutoff (float | None, optional): Channels whose BMAJ exceeds this, in arcsec, are blanked and left out of the common beam, rather than dragging every channel out to their resolution. Defaults to no cutoff.
+        plane (Path): The channel image to convolve
+        beam_shape (BeamShape): The resolution to convolve to
+        cutoff (float | None, optional): Planes whose major axis exceeds this, in arcsec, are blanked. Defaults to no cutoff.
+        convol_suffix (str, optional): The suffix added to .fits to indicate a smoothed image. Defaults to 'conv'.
 
     Returns:
-        list[Path]: The convolved cubes, in the order of ``cube_paths``
+        Path: The convolved (or blanked) image
     """
-    logger.info(f"Convolving {len(cube_paths)} cubes to a common resolution")
-    if output_path is not None:
-        output_path.mkdir(parents=True, exist_ok=True)
-
-    _, _, convolved_cubes = beamcon_3D.smooth_fits_cube(
-        infiles_list=list(cube_paths),
-        # 'total' is the one beam across all channels and all cubes that
-        # RM-synthesis needs, as opposed to 'natural's beam per channel
-        mode="total",
-        conv_mode="robust",
-        suffix=convol_suffix,
-        outdir=output_path,
+    convolved_plane = convolve_images(
+        image_paths=[plane],
+        beam_shape=beam_shape,
         cutoff=cutoff,
+        convol_suffix=convol_suffix,
+    )[0]
+
+    header = fits.getheader(plane)
+    beyond_cutoff = header_beam_is_usable(header=header) and not header_beam_is_usable(
+        header=header, cutoff=cutoff
     )
+    if not beyond_cutoff:
+        return convolved_plane
 
-    # 'total' mode carries the input header's CASAMBM flag into a cube that now
-    # has one beam and no BEAMS table for a reader to find
-    for convolved_cube in convolved_cubes:
-        with fits.open(convolved_cube, mode="update") as open_fits:
-            open_fits[0].header.pop("CASAMBM", None)
+    # racs_tools blanks the data of a plane beyond the cutoff but still stamps
+    # the target beam onto it, which would have the cube claim a PSF for a
+    # channel that holds none
+    logger.info(f"{plane=} is beyond {cutoff=}, marking {convolved_plane=} as blank")
+    with fits.open(convolved_plane, mode="update") as open_fits:
+        for key in ("BMAJ", "BMIN", "BPA"):
+            open_fits[0].header[key] = 0.0
 
-    # smooth_fits_cube sorts its inputs, so pair each output back to its input
-    convolved_by_name = {cube.name: cube for cube in convolved_cubes}
-    return [
-        convolved_by_name[Path(cube.name).with_suffix(f".{convol_suffix}.fits").name]
-        for cube in cube_paths
-    ]
+    return convolved_plane
 
 
 def get_cube_common_beam(
@@ -371,7 +467,7 @@ def convolve_images(
             str(image_path).replace(".fits", f".{convol_suffix}.fits")
         )
         header = fits.getheader(image_path)
-        if header["BMAJ"] == 0.0:
+        if not header_beam_is_usable(header=header):
             logger.info(f"Copying {image_path} to {convol_output_path=} for empty beam")
             copyfile(image_path, convol_output_path)
         else:

--- a/flint/convol.py
+++ b/flint/convol.py
@@ -25,13 +25,6 @@ from flint.logging import logger
 
 warnings.simplefilter("ignore", FITSFixedWarning)
 
-# A restoring beam smaller than this is not a real PSF. Blank channels are
-# marked either with an exactly-zero beam (wsclean's convention for a plane
-# with no fitted beam) or with ``np.finfo(np.float32).tiny`` (the sentinel
-# ``fitscube`` writes into a BEAMS table, as CASA rejects a NaN there). Both
-# sit many orders of magnitude below any beam an interferometer can produce.
-MIN_USABLE_BEAM_ARCSEC = 1e-6
-
 
 class BeamShape(NamedTuple):
     """A simple container to represent a fitted 2D gaussian,
@@ -120,9 +113,16 @@ def usable_beam_mask(beams: Beams, cutoff: float | None = None) -> np.ndarray:
     minor = np.asarray(beams.minor.to(u.arcsecond).value, dtype=float)
     pa = np.asarray(beams.pa.to(u.degree).value, dtype=float)
 
+    # A blank channel is marked with an exactly-zero beam (wsclean's convention
+    # for a plane with no fitted PSF) or, in a BEAMS table, with the positive
+    # sentinel `fitscube` writes there because CASA rejects a NaN. `> 0` alone
+    # would let the latter through and have a cube already at one beam
+    # reconvolved for the sake of its blank channels.
+    blank_beam_arcsec = float(np.finfo(np.float32).tiny)
+
     usable = (
-        (major > MIN_USABLE_BEAM_ARCSEC)
-        & (minor > MIN_USABLE_BEAM_ARCSEC)
+        (major > blank_beam_arcsec)
+        & (minor > blank_beam_arcsec)
         & np.isfinite(major)
         & np.isfinite(minor)
         & np.isfinite(pa)
@@ -239,6 +239,30 @@ def common_beam_from_cubes(
         * u.arcsecond,
         pa=round_up(common_beam.pa.to(u.degree).value, decimals=2) * u.degree,
     )
+
+
+def common_beam_shape_from_cubes(
+    cube_paths: Collection[Path], cutoff: float | None = None
+) -> BeamShape:
+    """The common beam of a set of cubes, for a caller that cannot do without
+    one. See ``common_beam_from_cubes``.
+
+    Args:
+        cube_paths (Collection[Path]): The FITS cubes to inspect
+        cutoff (float | None, optional): Channels coarser than this, in arcsec, are left out of the common beam. Defaults to no cutoff.
+
+    Raises:
+        ValueError: If no channel of any cube carries a real restoring beam
+
+    Returns:
+        BeamShape: The beam every usable channel fits inside
+    """
+    common_beam = common_beam_from_cubes(cube_paths=cube_paths, cutoff=cutoff)
+    if common_beam is None:
+        msg = f"No usable restoring beam among {list(cube_paths)=}"
+        raise ValueError(msg)
+
+    return BeamShape.from_radio_beam(radio_beam=common_beam)
 
 
 def convolve_plane_to_beam(

--- a/flint/imager/wsclean.py
+++ b/flint/imager/wsclean.py
@@ -482,13 +482,14 @@ def transpose_and_sort_channel_images(
     return [list(channel_group) for channel_group in zip(*sorted_beams)]
 
 
-def split_cube_into_planes(cube: Path) -> list[Path]:
+def split_cube_into_planes(cube: Path, output_path: Path | None = None) -> list[Path]:
     """Extract each channel of a FITS cube into its own image, named following the
     flint processed name format so that the planes may be regrouped across beams
     by ``transpose_and_sort_channel_images``.
 
     Args:
         cube (Path): The FITS cube to split apart
+        output_path (Path | None, optional): Directory the planes are written into. Only the flint name fields are retained, so cubes that share them (e.g. an image cube and its weights) need separate directories. Defaults to alongside ``cube``.
 
     Returns:
         list[Path]: The per-channel images extracted from ``cube``
@@ -513,6 +514,9 @@ def split_cube_into_planes(cube: Path) -> list[Path]:
         msg = f"Expected a flint named cube. Got {cube=}"
         raise NamingException(msg)
 
+    if output_path is not None:
+        output_path.mkdir(parents=True, exist_ok=True)
+
     with fits.open(cube, memmap=True, lazy_load_hdus=True) as open_fits:
         header = open_fits[0].header
     channels = int(header[f"NAXIS{find_target_axis(header=header).axis}"])
@@ -525,7 +529,7 @@ def split_cube_into_planes(cube: Path) -> list[Path]:
             processed_name_components=components._replace(
                 channel_range=(channel, channel)
             ),
-            parent_path=cube.parent,
+            parent_path=cube.parent if output_path is None else output_path,
         )
         return Path(f"{plane_base}.fits")
 

--- a/flint/prefect/common/imaging.py
+++ b/flint/prefect/common/imaging.py
@@ -108,6 +108,7 @@ task_transpose_and_sort_channel_images = task(transpose_and_sort_channel_images)
 task_create_name_from_common_fields = task(create_name_from_common_fields)
 task_remove_files_folders = task(remove_files_folders)
 task_get_common_bounding_box = task(get_common_bounding_box)
+task_split_cube_into_planes = task(split_cube_into_planes)
 
 # Tasks below are extracting componented from earlier stages, or are
 # otherwise doing something important
@@ -129,14 +130,6 @@ def task_get_mfs_image_from_paths(paths: list[Path]) -> Path:
     mfs_paths = [path for path in paths if "MFS" in path.name]
     assert len(mfs_paths) == 1, f"Expected a single MFS image, got {mfs_paths=}"
     return mfs_paths[0]
-
-
-@task
-def task_split_cube_into_planes(cubes: Collection[Path]) -> list[Path]:
-    """Split the single cube of a beam into its per-channel planes"""
-    cube_list = list(cubes)
-    assert len(cube_list) == 1, f"Expected a single cube per beam, got {cube_list=}"
-    return split_cube_into_planes(cube=cube_list[0])
 
 
 @task

--- a/flint/prefect/common/rmsynth.py
+++ b/flint/prefect/common/rmsynth.py
@@ -31,30 +31,13 @@ from flint.rmsynth import (
 
 task_convolve_plane_to_beam = task(convolve_plane_to_beam)
 
-CONVOL_SUFFIX = "conv"
-"""Marker added to the name of a cube brought to a common resolution"""
-
-CONVOLVED_CUBE_OPTIONS = FitsCubeOptions(
-    # The weight cubes are not convolved, so the convolved image cubes have to
-    # stay on the pixel and channel grid of the cubes they came from
-    bounding_box=False,
-    create_blanks=False,
-    # Convolution has already put the pixel values on a new scale, so leaving
-    # exact zeros be avoids reinterpreting them a second time
-    invalidate_zeros=False,
-    # rm-synth and the spice stage both read these cubes plane by plane, and
-    # astropy cannot memmap a gzip file
-    compress=False,
-    remove_original_images=True,
-)
-"""How a cube is reassembled from its convolved planes"""
-
 
 def convolve_cubes_to_common_resolution(
     cubes: dict[str, Path],
     beam_shape: BeamShape,
     output_path: Path | None = None,
     beam_cutoff: float | None = None,
+    convol_suffix: str = "conv",
 ) -> dict[str, Path]:
     """Bring a set of FITS cubes to the one resolution described by
     ``beam_shape``, writing new cubes and leaving the inputs as they are.
@@ -69,10 +52,25 @@ def convolve_cubes_to_common_resolution(
         beam_shape (BeamShape): The resolution every channel is brought to
         output_path (Path | None, optional): Directory the new cubes are written into. Defaults to alongside each input cube.
         beam_cutoff (float | None, optional): Channels coarser than this, in arcsec, are blanked rather than convolved to. Defaults to no cutoff.
+        convol_suffix (str, optional): The marker added to the name of a smoothed plane, and of the cube they are stacked into. Defaults to 'conv'.
 
     Returns:
         dict[str, Path]: The convolved cube for each key of ``cubes``
     """
+    fitscube_options = FitsCubeOptions(
+        # The weight cubes are not convolved, so the convolved image cubes have
+        # to stay on the pixel and channel grid of the cubes they came from
+        bounding_box=False,
+        create_blanks=False,
+        # Convolution has already put the pixel values on a new scale, so
+        # leaving exact zeros be avoids reinterpreting them a second time
+        invalidate_zeros=False,
+        # rm-synth and the spice stage both read these cubes plane by plane, and
+        # astropy cannot memmap a gzip file
+        compress=False,
+        remove_original_images=True,
+    )
+
     if output_path is not None:
         output_path.mkdir(parents=True, exist_ok=True)
 
@@ -102,7 +100,7 @@ def convolve_cubes_to_common_resolution(
         plane=[plane for planes in planes_per_cube.values() for plane in planes],
         beam_shape=unmapped(beam_shape),
         cutoff=unmapped(beam_cutoff),
-        convol_suffix=unmapped(CONVOL_SUFFIX),
+        convol_suffix=unmapped(convol_suffix),
     ).result()
 
     cube_futures = {}
@@ -111,8 +109,8 @@ def convolve_cubes_to_common_resolution(
         cube_futures[key] = task_combine_images_to_cube.submit(
             images=convolved_planes[plane_idx : plane_idx + len(planes)],
             prefix=str(cube_parent[key] / cubes[key].stem),
-            mode=CONVOL_SUFFIX,
-            fitscube_options=CONVOLVED_CUBE_OPTIONS,
+            mode=convol_suffix,
+            fitscube_options=fitscube_options,
         )
         plane_idx += len(planes)
     assert plane_idx == len(convolved_planes), (

--- a/flint/prefect/common/rmsynth.py
+++ b/flint/prefect/common/rmsynth.py
@@ -9,10 +9,17 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from flint.convol import convolve_cubes_to_common_beam
+from prefect import unmapped
+
+from flint.convol import BeamShape, convolve_plane_to_beam
 from flint.logging import logger
-from flint.options import RMCleanOptions, RMSynthOptions
+from flint.options import FitsCubeOptions, RMCleanOptions, RMSynthOptions
 from flint.prefect.caching import task
+from flint.prefect.common.imaging import (
+    task_combine_images_to_cube,
+    task_remove_files_folders,
+    task_split_cube_into_planes,
+)
 from flint.rmsynth import (
     FDFLabel,
     RMClean3DResults,
@@ -22,7 +29,103 @@ from flint.rmsynth import (
     write_rm_products,
 )
 
-task_convolve_cubes_to_common_beam = task(convolve_cubes_to_common_beam)
+task_convolve_plane_to_beam = task(convolve_plane_to_beam)
+
+CONVOL_SUFFIX = "conv"
+"""Marker added to the name of a cube brought to a common resolution"""
+
+CONVOLVED_CUBE_OPTIONS = FitsCubeOptions(
+    # The weight cubes are not convolved, so the convolved image cubes have to
+    # stay on the pixel and channel grid of the cubes they came from
+    bounding_box=False,
+    create_blanks=False,
+    # Convolution has already put the pixel values on a new scale, so leaving
+    # exact zeros be avoids reinterpreting them a second time
+    invalidate_zeros=False,
+    # rm-synth and the spice stage both read these cubes plane by plane, and
+    # astropy cannot memmap a gzip file
+    compress=False,
+    remove_original_images=True,
+)
+"""How a cube is reassembled from its convolved planes"""
+
+
+def convolve_cubes_to_common_resolution(
+    cubes: dict[str, Path],
+    beam_shape: BeamShape,
+    output_path: Path | None = None,
+    beam_cutoff: float | None = None,
+) -> dict[str, Path]:
+    """Bring a set of FITS cubes to the one resolution described by
+    ``beam_shape``, writing new cubes and leaving the inputs as they are.
+
+    Each cube is split into its per-channel planes, every plane of every cube is
+    convolved as its own task, and the planes are then stacked back into a cube.
+    A 3D convolution would instead work through one cube at a time on a single
+    worker, and would pull each whole cube into memory to do it.
+
+    Args:
+        cubes (dict[str, Path]): The cubes to convolve, keyed however the caller wants the outputs keyed
+        beam_shape (BeamShape): The resolution every channel is brought to
+        output_path (Path | None, optional): Directory the new cubes are written into. Defaults to alongside each input cube.
+        beam_cutoff (float | None, optional): Channels coarser than this, in arcsec, are blanked rather than convolved to. Defaults to no cutoff.
+
+    Returns:
+        dict[str, Path]: The convolved cube for each key of ``cubes``
+    """
+    if output_path is not None:
+        output_path.mkdir(parents=True, exist_ok=True)
+
+    cube_parent = {
+        key: output_path if output_path is not None else cube.parent
+        for key, cube in cubes.items()
+    }
+    # A plane's name carries only the flint name fields, so cubes that agree on
+    # them (e.g. the same Stokes at differing stages) would clobber each other's
+    # planes were they split into the same directory
+    plane_paths = {
+        key: cube_parent[key] / f"{cube.stem}.planes" for key, cube in cubes.items()
+    }
+
+    split_planes = {
+        key: task_split_cube_into_planes.submit(cube=cube, output_path=plane_paths[key])
+        for key, cube in cubes.items()
+    }
+    # Resolved here so the planes can be mapped over individually below
+    planes_per_cube: dict[str, list[Path]] = {
+        key: future.result() for key, future in split_planes.items()
+    }
+
+    # One task per plane rather than per cube, so every channel of every cube is
+    # convolved across the cluster at once
+    convolved_planes = task_convolve_plane_to_beam.map(
+        plane=[plane for planes in planes_per_cube.values() for plane in planes],
+        beam_shape=unmapped(beam_shape),
+        cutoff=unmapped(beam_cutoff),
+        convol_suffix=unmapped(CONVOL_SUFFIX),
+    ).result()
+
+    cube_futures = {}
+    plane_idx = 0
+    for key, planes in planes_per_cube.items():
+        cube_futures[key] = task_combine_images_to_cube.submit(
+            images=convolved_planes[plane_idx : plane_idx + len(planes)],
+            prefix=str(cube_parent[key] / cubes[key].stem),
+            mode=CONVOL_SUFFIX,
+            fitscube_options=CONVOLVED_CUBE_OPTIONS,
+        )
+        plane_idx += len(planes)
+    assert plane_idx == len(convolved_planes), (
+        f"Have {len(convolved_planes)} convolved planes across {plane_idx} channels"
+    )
+
+    convolved_cubes = {key: future.result() for key, future in cube_futures.items()}
+
+    # The convolved planes are removed as each cube is assembled, leaving the
+    # planes they were made from behind
+    task_remove_files_folders.submit(*plane_paths.values()).result()
+
+    return convolved_cubes
 
 
 @task

--- a/flint/prefect/flows/rmsynth_pipeline.py
+++ b/flint/prefect/flows/rmsynth_pipeline.py
@@ -66,16 +66,16 @@ def _resolve_common_resolution_cubes(
         tuple[dict[str, Path], list[Path]]: The cube to use for each Stokes, and the new cubes written (empty when the inputs were used as they are)
     """
     cube_paths = list(stokes_cubes.values())
-    if cubes_share_common_beam(cube_paths=cube_paths, cutoff=beam_cutoff):
-        logger.info("Stokes cubes already share a common resolution")
-        return stokes_cubes, []
-
     common_beam = common_beam_from_cubes(cube_paths=cube_paths, cutoff=beam_cutoff)
     if common_beam is None:
-        # Unreachable via cubes_share_common_beam, which reports cubes with no
-        # usable beam as already common, but never hand radio_beam a set it
-        # cannot solve
-        logger.warning("No common beam to bring the Stokes cubes to, using them as is")
+        logger.warning(
+            "No usable restoring beam among the Stokes cubes, so there is no "
+            "resolution to make common. Using them as they are."
+        )
+        return stokes_cubes, []
+
+    if cubes_share_common_beam(cube_paths=cube_paths, cutoff=beam_cutoff):
+        logger.info("Stokes cubes already share a common resolution")
         return stokes_cubes, []
 
     beam_shape = BeamShape.from_radio_beam(radio_beam=common_beam)

--- a/flint/prefect/flows/rmsynth_pipeline.py
+++ b/flint/prefect/flows/rmsynth_pipeline.py
@@ -13,7 +13,7 @@ from configargparse import ArgumentParser
 from prefect import flow
 
 from flint.configuration import get_options_from_strategy, load_and_copy_strategy
-from flint.convol import cubes_share_common_beam
+from flint.convol import BeamShape, common_beam_from_cubes, cubes_share_common_beam
 from flint.logging import logger
 from flint.naming import create_name_from_common_fields, get_sbid_from_path
 from flint.options import (
@@ -24,7 +24,7 @@ from flint.options import (
 )
 from flint.prefect.clusters import get_dask_runner
 from flint.prefect.common.rmsynth import (
-    task_convolve_cubes_to_common_beam,
+    convolve_cubes_to_common_resolution,
     task_rmclean,
     task_rmsynth,
     task_write_rm_products,
@@ -53,6 +53,10 @@ def _resolve_common_resolution_cubes(
     are convolved to a common beam and written as new cubes, leaving the inputs
     alone. The weight cubes are untouched, as convolution preserves the pixel grid.
 
+    The convolution runs plane by plane (see
+    ``convolve_cubes_to_common_resolution``), so every channel of every Stokes
+    is smoothed at once across the cluster.
+
     Args:
         stokes_cubes (dict[str, Path]): The input cube of each Stokes to run against
         output_path (Path | None, optional): Directory any new cubes are written into. Defaults to alongside the inputs.
@@ -62,15 +66,28 @@ def _resolve_common_resolution_cubes(
         tuple[dict[str, Path], list[Path]]: The cube to use for each Stokes, and the new cubes written (empty when the inputs were used as they are)
     """
     cube_paths = list(stokes_cubes.values())
-    if cubes_share_common_beam(cube_paths=cube_paths):
+    if cubes_share_common_beam(cube_paths=cube_paths, cutoff=beam_cutoff):
         logger.info("Stokes cubes already share a common resolution")
         return stokes_cubes, []
 
-    convolved_cubes = task_convolve_cubes_to_common_beam.submit(
-        cube_paths=cube_paths, output_path=output_path, cutoff=beam_cutoff
-    ).result()
+    common_beam = common_beam_from_cubes(cube_paths=cube_paths, cutoff=beam_cutoff)
+    if common_beam is None:
+        # Unreachable via cubes_share_common_beam, which reports cubes with no
+        # usable beam as already common, but never hand radio_beam a set it
+        # cannot solve
+        logger.warning("No common beam to bring the Stokes cubes to, using them as is")
+        return stokes_cubes, []
 
-    return dict(zip(stokes_cubes, convolved_cubes)), convolved_cubes
+    beam_shape = BeamShape.from_radio_beam(radio_beam=common_beam)
+    logger.info(f"Bringing the Stokes cubes to {beam_shape=}")
+    convolved_cubes = convolve_cubes_to_common_resolution(
+        cubes=stokes_cubes,
+        beam_shape=beam_shape,
+        output_path=output_path,
+        beam_cutoff=beam_cutoff,
+    )
+
+    return convolved_cubes, list(convolved_cubes.values())
 
 
 @flow(name="Flint RM-Synthesis Pipeline")

--- a/flint/prefect/flows/spice_compression_pipeline.py
+++ b/flint/prefect/flows/spice_compression_pipeline.py
@@ -79,9 +79,14 @@ def process_spice_compression(spice_field_options: SpiceFieldOptions) -> list[Pa
 
     # Sized on the coarsest resolution among the cubes being trimmed, not on the
     # finer reference image, so a box holds its island in every one of them
-    beam_shape = BeamShape.from_radio_beam(
-        common_beam_from_cubes(cube_paths=spice_field_options.cubes)
-    )
+    common_beam = common_beam_from_cubes(cube_paths=spice_field_options.cubes)
+    if common_beam is None:
+        msg = (
+            "No usable restoring beam among the cubes to spice, so the island "
+            f"boxes cannot be sized: {spice_field_options.cubes=}"
+        )
+        raise ValueError(msg)
+    beam_shape = BeamShape.from_radio_beam(common_beam)
     logger.info(f"Sizing the island boxes on {beam_shape=}")
 
     island_sky_boxes = task_get_spice_boxes.submit(

--- a/flint/prefect/flows/spice_compression_pipeline.py
+++ b/flint/prefect/flows/spice_compression_pipeline.py
@@ -13,7 +13,7 @@ from configargparse import ArgumentParser
 from prefect import flow, unmapped
 
 from flint.configuration import get_options_from_strategy, load_and_copy_strategy
-from flint.convol import BeamShape, common_beam_from_cubes
+from flint.convol import common_beam_shape_from_cubes
 from flint.logging import logger
 from flint.naming import get_sbid_from_path
 from flint.options import SpiceFieldOptions, SpiceOptions
@@ -79,14 +79,9 @@ def process_spice_compression(spice_field_options: SpiceFieldOptions) -> list[Pa
 
     # Sized on the coarsest resolution among the cubes being trimmed, not on the
     # finer reference image, so a box holds its island in every one of them
-    common_beam = common_beam_from_cubes(cube_paths=spice_field_options.cubes)
-    if common_beam is None:
-        msg = (
-            "No usable restoring beam among the cubes to spice, so the island "
-            f"boxes cannot be sized: {spice_field_options.cubes=}"
-        )
-        raise ValueError(msg)
-    beam_shape = BeamShape.from_radio_beam(common_beam)
+    # Raises when no cube carries a usable beam, as there is then no island box
+    # to size
+    beam_shape = common_beam_shape_from_cubes(cube_paths=spice_field_options.cubes)
     logger.info(f"Sizing the island boxes on {beam_shape=}")
 
     island_sky_boxes = task_get_spice_boxes.submit(

--- a/tests/test_convol.py
+++ b/tests/test_convol.py
@@ -16,6 +16,7 @@ from radio_beam import Beams
 
 from flint.convol import (
     BeamShape,
+    _beams_from_cubes,
     check_if_cube_fits,
     common_beam_from_cubes,
     convolve_plane_to_beam,
@@ -427,7 +428,17 @@ def test_common_beam_from_cubes(tmp_path: Path) -> None:
     # beam out to its resolution
     cut_beam = common_beam_from_cubes(cube_paths=cubes, cutoff=13.0)
     assert cut_beam is not None
-    assert cut_beam.major.to(u.arcsec).value == pytest.approx(12.0, rel=1e-3)
+    assert cut_beam.major.to(u.arcsec).value == pytest.approx(12.0, rel=1e-2)
+
+    # Every channel has to deconvolve the common beam to reach it, and the
+    # minimum enclosing ellipse sits right against the beams it encloses, so the
+    # solution is rounded up onto a tenth of an arcsecond for headroom
+    for axis in (common_beam.major, common_beam.minor):
+        arcsec = axis.to(u.arcsec).value
+        assert arcsec == pytest.approx(round(arcsec, 1), abs=1e-6)
+        assert (
+            arcsec >= _beams_from_cubes(cube_paths=cubes).major.to(u.arcsec).value.min()
+        )
 
 
 def test_common_beam_from_cubes_without_usable_beams(tmp_path: Path) -> None:

--- a/tests/test_convol.py
+++ b/tests/test_convol.py
@@ -11,14 +11,18 @@ import pytest
 from astropy.io import fits
 from astropy.table import Table
 from astropy.wcs import WCS
+from fitscube.extract import ExtractOptions, extract_plane_from_cube
+from radio_beam import Beams
 
 from flint.convol import (
     BeamShape,
     check_if_cube_fits,
     common_beam_from_cubes,
-    convolve_cubes_to_common_beam,
+    convolve_plane_to_beam,
     cubes_share_common_beam,
     get_cube_common_beam,
+    header_beam_is_usable,
+    usable_beam_mask,
 )
 from flint.utils import get_packaged_resource_path
 
@@ -284,31 +288,121 @@ def test_cubes_share_common_beam_without_beams(tmp_path) -> None:
     assert cubes_share_common_beam(cube_paths=[cube])
 
 
-def test_convolve_cubes_to_common_beam(tmp_path) -> None:
-    """Convolving leaves the input cubes alone, writes new cubes on the same
-    pixel grid, and brings every channel of every cube to the one beam"""
-    cubes = [
-        _write_cube_with_beam(
-            tmp_path / f"stokes_{pol}.fits",
-            [10.0 + offset, 11.0 + offset, 12.0 + offset],
-        )
-        for pol, offset in (("q", 0.0), ("u", 0.5))
-    ]
-    output_path = tmp_path / "rmsynth"
+def test_cubes_share_common_beam_with_placeholder_beams(tmp_path) -> None:
+    """A blanked channel carries a placeholder rather than a resolution, so it
+    neither breaks a common beam nor makes one out of cubes that have none"""
+    tiny = float(np.finfo(np.float32).tiny)
+    blanked = _write_cube_with_beam(tmp_path / "blanked.fits", [10.0, 0.0, tiny])
+    assert cubes_share_common_beam(cube_paths=[blanked])
 
-    convolved = convolve_cubes_to_common_beam(cube_paths=cubes, output_path=output_path)
+    all_blank = _write_cube_with_beam(tmp_path / "all_blank.fits", [0.0, tiny, 0.0])
+    assert cubes_share_common_beam(cube_paths=[all_blank])
 
-    assert all(cube.exists() for cube in cubes), "the input cubes were consumed"
-    assert not set(convolved) & set(cubes)
-    assert all(cube.parent == output_path for cube in convolved)
-    # The outputs must pair back to their inputs, which smooth_fits_cube sorts
-    assert [cube.name for cube in convolved] == [
-        "stokes_q.conv.fits",
-        "stokes_u.conv.fits",
+    varying = _write_cube_with_beam(tmp_path / "vary.fits", [10.0, 11.0, 0.0])
+    assert not cubes_share_common_beam(cube_paths=[varying])
+
+
+def test_cubes_share_common_beam_with_cutoff(tmp_path) -> None:
+    """A channel coarser than the cutoff is one to blank, which only the
+    convolution pass does"""
+    coarse = _write_cube_with_beam(tmp_path / "coarse.fits", [10.0, 10.0, 40.0])
+
+    assert not cubes_share_common_beam(cube_paths=[coarse], cutoff=20.0)
+    # Every channel beyond the cutoff leaves nothing to convolve to
+    assert cubes_share_common_beam(cube_paths=[coarse], cutoff=5.0)
+
+
+def _write_plane_with_beam(path: Path, bmaj_arcsec: float | None) -> Path:
+    """A single channel image, cut out of a cube exactly as
+    ``split_cube_into_planes`` does, so the plane carries its channel's beam"""
+    cube = _write_cube_with_beam(
+        path.with_name(f"cube.{path.name}"), [bmaj_arcsec or 0.0] * 2
+    )
+    plane = extract_plane_from_cube(
+        fits_cube=cube,
+        extract_options=ExtractOptions(
+            channel_index=0, output_path=path, overwrite=True
+        ),
+    )
+    if bmaj_arcsec is None:
+        with fits.open(plane, mode="update") as open_fits:
+            for key in ("BMAJ", "BMIN", "BPA"):
+                open_fits[0].header.pop(key, None)
+    return plane
+
+
+def test_usable_beam_mask() -> None:
+    """The placeholders a blank channel carries are not resolutions to convolve to"""
+    tiny = np.finfo(np.float32).tiny
+    beams = Beams(
+        major=[10.0, 0.0, tiny, 40.0, np.nan] * u.arcsec,
+        minor=[8.0, 0.0, tiny, 32.0, np.nan] * u.arcsec,
+        pa=[0.0, 0.0, tiny, 0.0, np.nan] * u.deg,
+    )
+
+    assert list(usable_beam_mask(beams=beams)) == [True, False, False, True, False]
+    assert list(usable_beam_mask(beams=beams, cutoff=20.0)) == [
+        True,
+        False,
+        False,
+        False,
+        False,
     ]
-    for cube, convolved_cube in zip(cubes, convolved):
-        assert fits.getdata(convolved_cube).shape == fits.getdata(cube).shape
-    assert cubes_share_common_beam(cube_paths=convolved)
+
+
+def test_header_beam_is_usable(tmp_path: Path) -> None:
+    """A plane's own header is read the same way as a cube's beam table"""
+    assert header_beam_is_usable(
+        header=fits.getheader(_write_plane_with_beam(tmp_path / "good.fits", 10.0))
+    )
+    assert not header_beam_is_usable(
+        header=fits.getheader(_write_plane_with_beam(tmp_path / "zero.fits", 0.0))
+    )
+    assert not header_beam_is_usable(
+        header=fits.getheader(_write_plane_with_beam(tmp_path / "none.fits", None))
+    )
+    assert not header_beam_is_usable(
+        header=fits.getheader(_write_plane_with_beam(tmp_path / "coarse.fits", 40.0)),
+        cutoff=20.0,
+    )
+
+
+def test_convolve_plane_to_beam(tmp_path: Path) -> None:
+    """A plane is convolved to the target beam, leaving the input in place"""
+    plane = _write_plane_with_beam(tmp_path / "stokes_q.ch0000-0000.fits", 10.0)
+    beam_shape = BeamShape(bmaj_arcsec=14.0, bmin_arcsec=12.0, bpa_deg=0.0)
+
+    convolved = convolve_plane_to_beam(plane=plane, beam_shape=beam_shape)
+
+    assert plane.exists(), "the input plane was consumed"
+    assert convolved == tmp_path / "stokes_q.ch0000-0000.conv.fits"
+    header = fits.getheader(convolved)
+    assert header["BMAJ"] * 3600.0 == pytest.approx(14.0)
+    assert header["BMIN"] * 3600.0 == pytest.approx(12.0)
+    assert fits.getdata(convolved).shape == fits.getdata(plane).shape
+
+
+def test_convolve_plane_to_beam_beyond_cutoff(tmp_path: Path) -> None:
+    """A plane coarser than the cutoff is blanked, and marked as holding no PSF
+    so the cube it is stacked into does not claim one for that channel"""
+    plane = _write_plane_with_beam(tmp_path / "stokes_q.ch0000-0000.fits", 40.0)
+    beam_shape = BeamShape(bmaj_arcsec=14.0, bmin_arcsec=12.0, bpa_deg=0.0)
+
+    convolved = convolve_plane_to_beam(plane=plane, beam_shape=beam_shape, cutoff=20.0)
+
+    assert np.all(np.isnan(fits.getdata(convolved)))
+    assert fits.getheader(convolved)["BMAJ"] == 0.0
+
+
+def test_convolve_plane_to_beam_without_beam(tmp_path: Path) -> None:
+    """A plane carrying no PSF has no resolution to change, so it is copied through"""
+    plane = _write_plane_with_beam(tmp_path / "stokes_q.ch0000-0000.fits", 0.0)
+    beam_shape = BeamShape(bmaj_arcsec=14.0, bmin_arcsec=12.0, bpa_deg=0.0)
+
+    convolved = convolve_plane_to_beam(plane=plane, beam_shape=beam_shape, cutoff=20.0)
+
+    assert fits.getheader(convolved)["BMAJ"] == 0.0
+    assert np.array_equal(fits.getdata(convolved), fits.getdata(plane))
 
 
 def test_common_beam_from_cubes(tmp_path: Path) -> None:
@@ -322,8 +416,28 @@ def test_common_beam_from_cubes(tmp_path: Path) -> None:
 
     common_beam = common_beam_from_cubes(cube_paths=cubes)
 
+    assert common_beam is not None
     assert common_beam.major.to(u.arcsec).value >= 14.0
     # A single cube's own coarsest channel, not the set's
-    assert common_beam_from_cubes(cube_paths=cubes[:1]).major.to(
-        u.arcsec
-    ).value == pytest.approx(12.0, rel=1e-3)
+    single_cube_beam = common_beam_from_cubes(cube_paths=cubes[:1])
+    assert single_cube_beam is not None
+    assert single_cube_beam.major.to(u.arcsec).value == pytest.approx(12.0, rel=1e-3)
+
+    # A channel beyond the cutoff is left out rather than dragging the common
+    # beam out to its resolution
+    cut_beam = common_beam_from_cubes(cube_paths=cubes, cutoff=13.0)
+    assert cut_beam is not None
+    assert cut_beam.major.to(u.arcsec).value == pytest.approx(12.0, rel=1e-3)
+
+
+def test_common_beam_from_cubes_without_usable_beams(tmp_path: Path) -> None:
+    """Nothing but placeholder beams constrains no common beam. radio_beam
+    reduces such a set to an empty sequence and raises an opaque argmax error,
+    so it is never handed one."""
+    tiny = float(np.finfo(np.float32).tiny)
+    blank = _write_cube_with_beam(tmp_path / "blank.fits", [0.0, tiny, 0.0])
+
+    assert common_beam_from_cubes(cube_paths=[blank]) is None
+    # Nor when every real beam is beyond the cutoff
+    coarse = _write_cube_with_beam(tmp_path / "coarse.fits", [40.0] * 3)
+    assert common_beam_from_cubes(cube_paths=[coarse], cutoff=20.0) is None

--- a/tests/test_convol.py
+++ b/tests/test_convol.py
@@ -12,13 +12,15 @@ from astropy.io import fits
 from astropy.table import Table
 from astropy.wcs import WCS
 from fitscube.extract import ExtractOptions, extract_plane_from_cube
-from radio_beam import Beams
+from radio_beam import Beam, Beams
+from radio_beam.utils import BeamError
 
 from flint.convol import (
     BeamShape,
     _beams_from_cubes,
     check_if_cube_fits,
     common_beam_from_cubes,
+    common_beam_shape_from_cubes,
     convolve_plane_to_beam,
     cubes_share_common_beam,
     get_cube_common_beam,
@@ -452,3 +454,46 @@ def test_common_beam_from_cubes_without_usable_beams(tmp_path: Path) -> None:
     # Nor when every real beam is beyond the cutoff
     coarse = _write_cube_with_beam(tmp_path / "coarse.fits", [40.0] * 3)
     assert common_beam_from_cubes(cube_paths=[coarse], cutoff=20.0) is None
+    # Nor when there is no beam recorded at all
+    no_beam = _write_cube_with_beam(tmp_path / "no_beam.fits", [10.0] * 3)
+    with fits.open(no_beam, mode="update") as open_fits:
+        del open_fits["BEAMS"]
+        del open_fits[0].header["CASAMBM"]
+    assert common_beam_from_cubes(cube_paths=[no_beam]) is None
+
+
+def test_common_beam_from_cubes_retries_on_beam_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """radio_beam can fail to enclose a set of beams at its default tolerance,
+    which is retried at a tenth of it rather than given up on"""
+    cube = _write_cube_with_beam(tmp_path / "fine.fits", [10.0, 11.0, 12.0])
+    solved = Beams.common_beam
+    tolerances: list[float | None] = []
+
+    def _fails_once(self: Beams, **kwargs: float) -> Beam:
+        tolerances.append(kwargs.get("tolerance"))
+        if len(tolerances) == 1:
+            raise BeamError("Could not find common beam")
+        return solved(self, **kwargs)
+
+    monkeypatch.setattr(Beams, "common_beam", _fails_once)
+
+    assert common_beam_from_cubes(cube_paths=[cube]) is not None
+    assert tolerances[0] is None, "the first solve should use the defaults"
+    assert tolerances[1] is not None and tolerances[1] < 1e-4
+
+
+def test_common_beam_shape_from_cubes(tmp_path: Path) -> None:
+    """The spice stage cannot size its island boxes without a beam, so it takes
+    one that raises rather than one it has to None-check"""
+    cube = _write_cube_with_beam(tmp_path / "fine.fits", [10.0, 11.0, 12.0])
+
+    beam_shape = common_beam_shape_from_cubes(cube_paths=[cube])
+
+    assert beam_shape.bmaj_arcsec == pytest.approx(12.0, rel=1e-2)
+
+    tiny = float(np.finfo(np.float32).tiny)
+    blank = _write_cube_with_beam(tmp_path / "blank.fits", [0.0, tiny, 0.0])
+    with pytest.raises(ValueError, match="No usable restoring beam"):
+        common_beam_shape_from_cubes(cube_paths=[blank])

--- a/tests/test_prefect_rmsynth_flow.py
+++ b/tests/test_prefect_rmsynth_flow.py
@@ -17,8 +17,13 @@ from prefect import flow
 from prefect.logging import disable_run_logger
 from prefect.testing.utilities import prefect_test_harness
 from prefect_dask import DaskTaskRunner
+from radio_beam import Beams
 
-from flint.convol import common_beam_from_cubes, cubes_share_common_beam
+from flint.convol import (
+    common_beam_from_cubes,
+    cubes_share_common_beam,
+    usable_beam_mask,
+)
 from flint.options import RMSynthFieldOptions
 from flint.prefect.flows.rmsynth_pipeline import (
     _resolve_common_resolution_cubes,
@@ -235,8 +240,11 @@ def _resolved_cubes(
 
 
 def _cubes_with_beams(tmp_path: Path, offsets: dict[str, float]) -> dict[str, Path]:
+    """Flint-named cubes, which is what splitting a cube into named planes needs"""
     return {
-        pol: _write_cube_with_beam(tmp_path / f"stokes_{pol}.fits", [10.0 + offset] * 3)
+        pol: _write_cube_with_beam(
+            tmp_path / f"{STEM}.{pol}.linmos.fits", [10.0 + offset] * 3
+        )
         for pol, offset in offsets.items()
     }
 
@@ -258,9 +266,11 @@ def test_resolve_common_resolution_cubes_convolves(tmp_path: Path) -> None:
     for stokes, resolved_cube in resolved.items():
         assert resolved_cube.name.startswith(cubes[stokes].stem)
     # The weight cubes are untouched, so the convolved cubes must stay on the
-    # input pixel grid
+    # input pixel and channel grid
     assert fits.getdata(resolved["q"]).shape == fits.getdata(cubes["q"]).shape
     assert convolved_cubes == resolved_cubes
+    # The planes each cube was split into and convolved through are cleaned up
+    assert not list(output_path.glob("*.planes"))
 
 
 def test_resolve_common_resolution_cubes_reuses_matching_cubes(tmp_path: Path) -> None:
@@ -283,7 +293,9 @@ def test_resolve_common_resolution_cubes_beam_cutoff_blanks_coarse_channels(
     """A channel coarser than the cutoff is blanked rather than dragging the
     common beam of every channel out to its resolution"""
     cubes = _cubes_with_beams(tmp_path, {"q": 0.0, "u": 0.5})
-    coarse = _write_cube_with_beam(tmp_path / "stokes_i.fits", [10.0, 10.0, 40.0])
+    coarse = _write_cube_with_beam(
+        tmp_path / f"{STEM}.i.linmos.fits", [10.0, 10.0, 40.0]
+    )
     cubes["i"] = coarse
 
     resolved, _ = _resolved_cubes(
@@ -291,6 +303,7 @@ def test_resolve_common_resolution_cubes_beam_cutoff_blanks_coarse_channels(
     )
 
     common_beam = common_beam_from_cubes(cube_paths=[resolved["q"]])
+    assert common_beam is not None
     assert common_beam.major.to(u.arcsec).value < 20.0, (
         "the 40 arcsec channel was convolved to rather than cut"
     )
@@ -298,3 +311,27 @@ def test_resolve_common_resolution_cubes_beam_cutoff_blanks_coarse_channels(
         "the channel above the cutoff should be blanked"
     )
     assert np.any(np.isfinite(fits.getdata(resolved["i"])[0]))
+    # The blanked channel must not claim a PSF it does not have
+    blanked_beam = Beams.from_fits_bintable(fits.open(resolved["i"])["BEAMS"])
+    assert usable_beam_mask(beams=blanked_beam)[2] == False  # noqa: E712
+    assert usable_beam_mask(beams=blanked_beam)[0]
+
+
+def test_resolve_common_resolution_cubes_without_usable_beams(tmp_path: Path) -> None:
+    """Cubes carrying nothing but the placeholder beams of blanked channels have
+    no resolution to make common, and are used as they are rather than handed to
+    a common-beam solver that cannot solve them"""
+    tiny = float(np.finfo(np.float32).tiny)
+    cubes = {
+        pol: _write_cube_with_beam(
+            tmp_path / f"{STEM}.{pol}.linmos.fits", [0.0, tiny, 0.0]
+        )
+        for pol in ("q", "u")
+    }
+
+    resolved, convolved_cubes = _resolved_cubes(
+        cubes=cubes, output_path=tmp_path / "rmsynth"
+    )
+
+    assert resolved == cubes
+    assert convolved_cubes == []


### PR DESCRIPTION
Fixes the `ValueError('attempt to get argmax of an empty sequence')` raised from
`convolve_cubes_to_common_beams` in the rm-synthesis flow, and reworks the
convolution so it can actually use the `dask` cluster.

## The crash

`radio_beam`'s common-beam solver reduces a beam set to the beams it considers
finite (`major > 0 & minor > 0 & isfinite(pa)`) and takes an `argmax` over what
is left. `beamcon_3D`'s `total` mode masks blanked channels and channels beyond
the cutoff itself, then hands the remainder straight to `common_beam()` -- so a
set in which no channel carries a beam `radio_beam` can use reduces to an empty
sequence and raises from inside `astropy`, with nothing in the traceback saying
which cube or channel was at fault.

`flint` was handing it such a set. The polarisation stage convolves every
channel of every beam to one 2D common beam, so the cubes it produces normally
carry a single real beam plus a placeholder for each blanked channel -- exactly
zero (wsclean's convention for a plane with no fitted PSF) or the `float32` tiny
that `fitscube` writes into a BEAMS table, as CASA rejects a NaN there. The old
`cubes_share_common_beam` counted those placeholders as a beam mismatch, so it
convolved cubes that were already at one resolution, which is why the step ran
at all.

## Plane by plane, not cube by cube

`convolve_cubes_to_common_beam` handed whole cubes to `beamcon_3D.smooth_fits_cube`,
which walks one cube at a time on a single worker and pulls each cube into memory
to convolve it in 3D. `convolve_cubes_to_common_resolution` (in
`flint.prefect.common.rmsynth`) instead splits every cube into its per-channel
planes, convolves each plane as its own prefect task, and stacks the planes back
into a cube. Every channel of every Stokes is smoothed at once across the
cluster, and no task holds more than a single plane. This is what
`create_convolve_linmos_cubes` already does for the per-beam cubes.

- Each cube is split into its own `<stem>.planes/` directory, as a plane's name
  carries only the flint name fields and cubes agreeing on those would clobber
  each other's planes. The planes are removed once cubed.
- The output is `<input stem>.conv.cube.fits`, assembled with
  `bounding_box=False` and `create_blanks=False` so the untouched weight cubes
  still match the pixel and channel grid.
- `split_cube_into_planes` takes an `output_path`, defaulting to alongside the
  cube as before.
- The unused `task_split_cube_into_planes` in `imaging.py` is replaced by a
  wrapper of the real function, rather than leaving two prefect tasks of that
  name in sibling modules.

## Filtering the beams before solving

`usable_beam_mask` excludes placeholder beams, non-finite beams, and beams
beyond the cutoff -- a strictly stronger test than `radio_beam`'s, so what is
handed to `common_beam()` can never reduce to an empty sequence.

- `common_beam_from_cubes` returns `None` when no channel of any cube carries a
  real beam, and the rm-synthesis flow then uses the cubes as they are.
- `cubes_share_common_beam` compares only usable beams, so cubes the
  polarisation stage already brought to one beam are no longer reconvolved
  because some channels are blank. A channel with a real beam beyond the cutoff
  is still reported as *not* common, since blanking it is work only the
  convolution pass does.
- `process_spice_compression` raises a named `ValueError` on `None`; it would
  otherwise have hit the same `argmax` error when sizing its island boxes.
- `convolve_images` skips an image whose own beam is a placeholder rather than
  only one whose `BMAJ` is exactly zero, and a plane blanked by the cutoff is
  marked with a zero beam so the cube it is stacked into does not claim a PSF
  for a channel holding none.

## Tests

The cube fixtures in `tests/test_convol.py` and
`tests/test_prefect_rmsynth_flow.py` are now flint-named, which splitting
requires and the flow already required for `create_name_from_common_fields`.
Added coverage for the usable-beam mask, per-plane convolution (including the
cutoff and no-beam cases), placeholder beams in the share/common-beam tests, and
the all-placeholder cubes that used to crash.

163 tests across `test_convol`, `test_prefect_rmsynth_flow`,
`test_racs_all_pipeline`, `test_wsclean`, `test_prefect_racsall_flow`,
`test_prefect_helpers`, `test_spice` and `test_naming` pass; `ruff` is clean and
`mypy` reports no new errors.

## Worth noting

With placeholder beams no longer counting as a mismatch, the rm-synthesis stage
will usually now skip the convolution on real racs-all output and pass the
polarisation cubes straight through. That is the intended design, but it does
mean the new plane path will not see much use in production until the input
cubes genuinely differ in resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bonk4muETYXyG3E6knCfDu


---
_Generated by [Claude Code](https://claude.ai/code/session_01Bonk4muETYXyG3E6knCfDu)_