### PR TITLE
Polarisation cubes at 'natural' resolution, rm-synthesis at 'total'

### DIFF
--- a/docs/quickstart/polarisation.md
+++ b/docs/quickstart/polarisation.md
@@ -31,6 +31,36 @@ polarisation:
     wsclean: {}
 ```
 
+## Angular resolution
+
+The restoring beam of an ASKAP image varies across the footprint and with
+frequency, so the per-beam channel images have to be brought to a common
+resolution before `linmos` co-adds them. `flint` does this in the 'natural'
+sense of [`RACS-tools`](https://github.com/AlecThomson/RACS-tools): one common
+beam is solved **per channel** and the cube keeps its frequency-dependent
+resolution, rather than every channel being dragged out to the coarsest beam in
+the band.
+
+A channel's beam is solved over every footprint beam of every Stokes at that
+channel, so channel N of I, Q and U share one resolution and a per-channel
+polarisation product (e.g. polarised intensity) is meaningful.
+
+Two options steer this:
+
+- `--beam-cutoff`: a beam coarser than this, in arcseconds, is left out of the
+  solve and its image is blanked instead of convolved. A channel where every
+  image is beyond the cutoff has no beam to convolve to at all, so the whole
+  channel is blanked and marked as carrying no PSF.
+- `--fixed-beam-shape`: convolve every channel to this `(arcsec, arcsec, deg)`
+  beam instead of solving one, which gives a cube of constant resolution.
+
+RM-synthesis is only meaningful when every channel shares one beam, so the
+rm-synth stage brings its own inputs to a single 'total' beam covering the whole
+band. It writes those as new `.conv.fits` cubes and leaves the natural-resolution
+cubes alone, so both are available: the natural cubes to archive, the total cubes
+to synthesise from. See `RMSynthFieldOptions.beam_cutoff` to drop the coarsest
+channels from that solve rather than smoothing the whole band to reach them.
+
 ## Spectro-polarimetric imaging in WSClean
 
 We encourage users to carefully read the [WSclean documentation](https://wsclean.readthedocs.io/en/latest/). In practice, we have encountered a few common 'gotchas' when producing polarisation cube. As always, a user should pay attention to the output logs to see e.g. how many iterations have been performed and what the stopping criterion was. We also encourage the inspection of image, model, and residual products to see how well (or not) deconvolution has performed.

--- a/flint/convol.py
+++ b/flint/convol.py
@@ -542,6 +542,84 @@ def convolve_images(
     return return_conv_image_paths
 
 
+def blank_images(
+    image_paths: Collection[Path], convol_suffix: str = "conv"
+) -> list[Path]:
+    """Write an all-NaN copy of each image, marked with a zero beam.
+
+    This stands in for a convolution that cannot be done: a channel whose every
+    image is beyond the beam cutoff has no common beam to convolve to, and
+    copying the images at their own resolutions would have whatever they are
+    co-added into claim a beam that describes none of them. The zero beam is the
+    marker ``usable_beam_mask`` and ``fitscube`` both read as 'no PSF here'.
+
+    Args:
+        image_paths (Collection[Path]): The images to blank
+        convol_suffix (str, optional): The suffix added to .fits, matching the convolved images these stand in for. Defaults to 'conv'.
+
+    Returns:
+        list[Path]: The blanked images
+    """
+    blank_image_paths: list[Path] = []
+
+    for image_path in image_paths:
+        blank_image_path = Path(
+            str(image_path).replace(".fits", f".{convol_suffix}.fits")
+        )
+        logger.info(f"Blanking {image_path} into {blank_image_path=}")
+
+        with fits.open(image_path) as open_fits:
+            header = open_fits[0].header.copy()
+            data = np.full_like(open_fits[0].data, np.nan, dtype=np.float32)
+
+        for key in ("BMAJ", "BMIN", "BPA"):
+            header[key] = 0.0
+
+        fits.writeto(blank_image_path, data=data, header=header, overwrite=True)
+        blank_image_paths.append(blank_image_path)
+
+    return blank_image_paths
+
+
+def convolve_images_or_blank(
+    image_paths: Collection[Path],
+    beam_shape: BeamShape,
+    cutoff: float | None = None,
+    convol_suffix: str = "conv",
+) -> list[Path]:
+    """Convolve images to ``beam_shape``, or blank them when it does not describe
+    a beam.
+
+    ``convolve_images`` copies its inputs through untouched when handed a
+    non-finite ``beam_shape``, which is what ``get_common_beam`` returns when
+    every input is beyond the cutoff. For a set that is about to be co-added and
+    cubed that copy is worse than nothing: the images keep their own differing
+    resolutions and the product claims the first of them. Blank instead.
+
+    Args:
+        image_paths (Collection[Path]): The images to convolve
+        beam_shape (BeamShape): The resolution to convolve to
+        cutoff (float | None, optional): Images whose major axis exceeds this, in arcsec, are blanked. Defaults to no cutoff.
+        convol_suffix (str, optional): The suffix added to .fits to indicate a smoothed image. Defaults to 'conv'.
+
+    Returns:
+        list[Path]: The convolved (or blanked) images
+    """
+    if np.isfinite(beam_shape.bmaj_arcsec):
+        return convolve_images(
+            image_paths=image_paths,
+            beam_shape=beam_shape,
+            cutoff=cutoff,
+            convol_suffix=convol_suffix,
+        )
+
+    logger.info(
+        f"No common beam over {len(image_paths)} images, likely all beyond "
+        f"{cutoff=}. Blanking them rather than copying them through."
+    )
+    return blank_images(image_paths=image_paths, convol_suffix=convol_suffix)
+
+
 def get_parser() -> ArgumentParser:
     parser = ArgumentParser(description=__doc__)
 

--- a/flint/prefect/common/imaging.py
+++ b/flint/prefect/common/imaging.py
@@ -6,7 +6,7 @@ imaging flows.
 
 from __future__ import annotations
 
-from collections.abc import Collection
+from collections.abc import Collection, Sequence
 from pathlib import Path
 from typing import Any, ParamSpec, TypeVar
 
@@ -31,6 +31,7 @@ from flint.coadd.linmos import (
 from flint.convol import (
     BeamShape,
     convolve_images,
+    convolve_images_or_blank,
     get_common_beam,
 )
 from flint.flagging import flag_ms_aoflagger
@@ -99,6 +100,7 @@ task_select_solution_for_ms: Task[P, R] = task(select_aosolution_for_ms)
 task_create_apply_solutions_cmd: Task[P, R] = task(create_apply_solutions_cmd)
 task_rename_column_in_ms: Task[P, R] = task(rename_column_in_ms)
 task_convolve_images = task(convolve_images)
+task_convolve_images_or_blank = task(convolve_images_or_blank)
 task_split_and_get_image_set = task(split_and_get_image_set)
 task_image_set_from_result = task(image_set_from_result)
 task_combine_images_to_cube = task(combine_images_to_cube)
@@ -1129,6 +1131,138 @@ def create_convolve_linmos_cubes(
         wait_for=cube_results,
     )
     return cube_results
+
+
+def convolve_channel_groups_to_natural_resolution(
+    stokes_channel_groups: dict[str, list[list[Path]]],
+    cutoff: float | None = None,
+    fixed_beam_shape: Sequence[float] | None = None,
+) -> dict[str, list[list[Path]]]:
+    """Convolve per-channel beam images to one common beam per channel, which is
+    the 'natural' resolution mode of racs_tools: resolution follows frequency
+    rather than every channel being dragged out to the coarsest in the band.
+    Contrast the 'total' mode of ``convolve_cubes_to_common_resolution``, which
+    RM-synthesis needs of its own inputs.
+
+    The beam of a channel is solved over every beam image of every Stokes at that
+    channel, so channel N of I, Q and U share one resolution and a per-channel
+    polarisation product is meaningful. Solving per Stokes would leave them at
+    differing resolutions in the same channel.
+
+    Args:
+        stokes_channel_groups (dict[str, list[list[Path]]]): For each Stokes, the beam images of each channel
+        cutoff (float | None, optional): Images whose major axis exceeds this, in arcsec, are blanked rather than convolved to. Defaults to no cutoff.
+        fixed_beam_shape (Sequence[float] | None, optional): Convolve every channel to this (arcsec, arcsec, deg) rather than a solved beam. Defaults to solving each channel.
+
+    Returns:
+        dict[str, list[list[Path]]]: The convolved beam images of each channel, for each Stokes
+    """
+    # Channel N has to be the same frequency in every Stokes, or a beam shared
+    # across them describes nothing. Differing channelisations already misalign
+    # the Stokes I images that linmos leakage-corrects Q/U against, so this is
+    # surfaced here rather than left to produce a quietly wrong mosaic.
+    channels_per_stokes = {
+        stokes: len(groups) for stokes, groups in stokes_channel_groups.items()
+    }
+    channel_counts = set(channels_per_stokes.values())
+    assert len(channel_counts) == 1, (
+        f"Stokes contribute differing channel counts: {channels_per_stokes}. "
+        "Every polarisation has to be imaged onto the same channel grid."
+    )
+    channels = channel_counts.pop()
+    logger.info(
+        f"Solving a natural common beam for each of {channels} channels over "
+        f"{list(stokes_channel_groups.keys())}"
+    )
+
+    # Left as futures and indexed per channel, so a channel's Stokes start
+    # convolving as soon as its own beam is solved rather than waiting on the
+    # slowest channel in the band
+    beam_shapes = task_get_common_beam_from_images.map(
+        image_paths=[
+            [
+                image
+                for channel_groups in stokes_channel_groups.values()
+                for image in channel_groups[channel]
+            ]
+            for channel in range(channels)
+        ],  # type: ignore
+        cutoff=unmapped(cutoff),  # type: ignore
+        fixed_beam_shape=unmapped(fixed_beam_shape),  # type: ignore
+    )
+
+    convolved_groups = {
+        stokes: [
+            task_convolve_images_or_blank.submit(
+                image_paths=channel_groups[channel],
+                beam_shape=beam_shapes[channel],
+                cutoff=cutoff,
+            )
+            for channel in range(channels)
+        ]
+        for stokes, channel_groups in stokes_channel_groups.items()
+    }
+
+    return {
+        stokes: [future.result() for future in futures]
+        for stokes, futures in convolved_groups.items()
+    }
+
+
+def convolve_mfs_beam_images_to_common_resolution(
+    mfs_beam_images: dict[str, dict[str, list[Path]]],
+    cutoff: float | None = None,
+    fixed_beam_shape: Sequence[float] | None = None,
+) -> dict[str, dict[str, list[Path]]]:
+    """Convolve the per-beam MFS products to a single common beam.
+
+    An MFS image has no frequency axis, so there is nothing for a natural,
+    per-channel beam to vary over: one beam is solved over the MFS images of
+    every beam and every Stokes. The beam is taken from the ``image`` products
+    alone and applied to the model and residual products too, which is what a
+    beam solved over ``ImageSet.image`` has always done here.
+
+    Args:
+        mfs_beam_images (dict[str, dict[str, list[Path]]]): For each Stokes, the per-beam MFS image of each product type
+        cutoff (float | None, optional): Images whose major axis exceeds this, in arcsec, are blanked rather than convolved to. Defaults to no cutoff.
+        fixed_beam_shape (Sequence[float] | None, optional): Convolve to this (arcsec, arcsec, deg) rather than a solved beam. Defaults to solving it.
+
+    Returns:
+        dict[str, dict[str, list[Path]]]: The convolved MFS products, keyed as the input
+    """
+    mfs_science_images = [
+        image
+        for product_type_images in mfs_beam_images.values()
+        for image in product_type_images.get("image", [])
+    ]
+    if not mfs_science_images:
+        logger.info("No MFS science images to solve a common beam over")
+        return mfs_beam_images
+
+    beam_shape: BeamShape = task_get_common_beam_from_images.submit(
+        image_paths=mfs_science_images,
+        cutoff=cutoff,
+        fixed_beam_shape=fixed_beam_shape,
+    ).result()
+    logger.info(f"Convolving the MFS products to {beam_shape=}")
+
+    convolved = {
+        stokes: {
+            product_type: task_convolve_images_or_blank.submit(
+                image_paths=images, beam_shape=beam_shape, cutoff=cutoff
+            )
+            for product_type, images in product_type_images.items()
+        }
+        for stokes, product_type_images in mfs_beam_images.items()
+    }
+
+    return {
+        stokes: {
+            product_type: future.result()
+            for product_type, future in product_type_futures.items()
+        }
+        for stokes, product_type_futures in convolved.items()
+    }
 
 
 @task

--- a/flint/prefect/common/rmsynth.py
+++ b/flint/prefect/common/rmsynth.py
@@ -40,7 +40,10 @@ def convolve_cubes_to_common_resolution(
     convol_suffix: str = "conv",
 ) -> dict[str, Path]:
     """Bring a set of FITS cubes to the one resolution described by
-    ``beam_shape``, writing new cubes and leaving the inputs as they are.
+    ``beam_shape``, writing new cubes and leaving the inputs as they are. This is
+    the 'total' resolution mode of racs_tools: one beam for every channel of
+    every cube. The polarisation stage instead leaves its cubes at a 'natural'
+    resolution, one beam per channel, which is what they are archived at.
 
     Each cube is split into its per-channel planes, every plane of every cube is
     convolved as its own task, and the planes are then stacked back into a cube.

--- a/flint/prefect/flows/polarisation_pipeline.py
+++ b/flint/prefect/flows/polarisation_pipeline.py
@@ -40,13 +40,12 @@ from flint.options import (
 )
 from flint.prefect.clusters import get_dask_runner
 from flint.prefect.common.imaging import (
+    convolve_channel_groups_to_natural_resolution,
+    convolve_mfs_beam_images_to_common_resolution,
     linmos_channel_groups_to_cubes,
-    task_convolve_images,
     task_get_channel_images_from_paths,
-    task_get_common_beam_from_image_set,
     task_get_mfs_image_from_paths,
     task_linmos_images,
-    task_merge_image_sets,
     task_preprocess_askap_ms,
     task_remove_files_folders,
     task_split_and_get_image_set,
@@ -231,7 +230,6 @@ def process_science_fields_pol(
         )
 
     image_sets_dict: dict[str, PrefectFuture[ImageSet]] = {}
-    image_sets_list: list[PrefectFuture[ImageSet]] = []
     for polarisation in polarisations.keys():
         _image_sets = []
         with tags(f"polarisation-{polarisation}"):
@@ -264,20 +262,14 @@ def process_science_fields_pol(
                     wsclean_result, "image_set"
                 )
                 _image_sets.append(_image_set)
-                image_sets_list.append(_image_set)
         image_sets_dict[polarisation] = _image_sets
 
-    merged_image_set = task_merge_image_sets.submit(image_sets=image_sets_list)
-
-    common_beam_shape = task_get_common_beam_from_image_set.submit(
-        image_set=merged_image_set,
-        cutoff=pol_field_options.beam_cutoff,
-        fixed_beam_shape=pol_field_options.fixed_beam_shape,
-    )
-
-    # Convolve every beam's sub-band images to the common beam, keeping the
-    # per-channel images (rather than cubing per beam) so we can co-add across
-    # beams one channel at a time.
+    # Split each beam's images out per Stokes, leaving them unconvolved. The
+    # cubes are brought to a 'natural' resolution, one common beam per channel,
+    # and a channel's beam is solved over every beam image of every Stokes at
+    # that channel, so nothing can be convolved until all of them are in hand.
+    # The RM-synthesis stage brings its own inputs to a single 'total' beam; that
+    # is a resolution to synthesise at, not one to archive the cubes at.
     stokes_beam_channel_images: dict[str, list[PrefectFuture[list[Path]]]] = {}
     # Per-beam MFS image/model/residual, collected per Stokes whenever that
     # Stokes' polarisation strategy sets flint_save_mfs_products. Co-added
@@ -312,21 +304,16 @@ def process_science_fields_pol(
                                 by="pol",
                                 mode=product_type,
                             )
-                            convolved_image_list = task_convolve_images.submit(
-                                image_paths=stokes_image_list,
-                                beam_shape=common_beam_shape,
-                                cutoff=pol_field_options.beam_cutoff,
-                            )
                             if save_mfs_products:
                                 beam_mfs_images.append(
                                     task_get_mfs_image_from_paths.submit(
-                                        paths=convolved_image_list
+                                        paths=stokes_image_list
                                     )
                                 )
                             if product_type == "image":
                                 beam_channel_images.append(
                                     task_get_channel_images_from_paths.submit(
-                                        paths=convolved_image_list
+                                        paths=stokes_image_list
                                     )
                                 )
                         if save_mfs_products:
@@ -336,14 +323,20 @@ def process_science_fields_pol(
                     stokes_beam_channel_images[stokes] = beam_channel_images
 
     # Regroup each Stokes' per-beam channel images into per-channel beam groups
-    # so linmos can run one channel at a time in parallel. Resolving here blocks
-    # until the convolutions above have completed.
+    # so a beam can be solved for each channel, and so linmos can then run one
+    # channel at a time in parallel. Resolving here blocks until the imaging
+    # above has completed.
     stokes_channel_groups: dict[str, list[list[Path]]] = {
         stokes: task_transpose_and_sort_channel_images.submit(
             beam_channel_images=beam_channel_images
         ).result()
         for stokes, beam_channel_images in stokes_beam_channel_images.items()
     }
+    stokes_channel_groups = convolve_channel_groups_to_natural_resolution(
+        stokes_channel_groups=stokes_channel_groups,
+        cutoff=pol_field_options.beam_cutoff,
+        fixed_beam_shape=pol_field_options.fixed_beam_shape,
+    )
 
     # Stokes I beam images (per channel) are needed to correct widefield leakage
     # in the Stokes Q/U mosaics. If Stokes I was not imaged we cannot do this.
@@ -394,24 +387,37 @@ def process_science_fields_pol(
         *all_input_images, wait_for=cube_results
     )
 
+    # An MFS product has no frequency axis for a natural beam to vary over, so
+    # the MFS images get a single common beam of their own rather than the one
+    # the coarsest channel of the cube needed. Resolving the futures here blocks
+    # until the imaging has completed, which the beam solve needs regardless.
+    mfs_beam_paths: dict[str, dict[str, list[Path]]] = {
+        stokes: {
+            product_type: [future.result() for future in beam_images]
+            for product_type, beam_images in product_type_images.items()
+        }
+        for stokes, product_type_images in mfs_beam_images.items()
+    }
+    mfs_beam_paths = convolve_mfs_beam_images_to_common_resolution(
+        mfs_beam_images=mfs_beam_paths,
+        cutoff=pol_field_options.beam_cutoff,
+        fixed_beam_shape=pol_field_options.fixed_beam_shape,
+    )
+
     # Co-add the MFS image/model/residual products collected above the same way
     # as the science cube: PB-correct via linmos, leakage-correct against the
     # matching Stokes I MFS product where available, then clean up the
     # per-beam convolved intermediates.
     mfs_products: dict[str, dict[str, PrefectFuture[Path]]] = {}
-    all_mfs_input_images: list[PrefectFuture[Path]] = []
+    all_mfs_input_images: list[Path] = []
     mfs_linmos_results: list[PrefectFuture[Path]] = []
-    for stokes, product_type_images in mfs_beam_images.items():
+    for stokes, product_type_images in mfs_beam_paths.items():
         with tags(f"stokes-{stokes}"):
             for product_type, beam_images in product_type_images.items():
                 with tags(f"product-{product_type}"):
                     stokesi_images: list[Path] | None = None
                     if stokes != "i":
-                        i_beam_images = mfs_beam_images.get("i", {}).get(product_type)
-                        if i_beam_images is not None:
-                            stokesi_images = [
-                                future.result() for future in i_beam_images
-                            ]
+                        stokesi_images = mfs_beam_paths.get("i", {}).get(product_type)
 
                     mfs_linmos_result = task_linmos_images.submit(
                         image_list=beam_images,

--- a/flint/prefect/flows/rmsynth_pipeline.py
+++ b/flint/prefect/flows/rmsynth_pipeline.py
@@ -49,9 +49,13 @@ def _resolve_common_resolution_cubes(
     beam_cutoff: float | None = None,
 ) -> tuple[dict[str, Path], list[Path]]:
     """RM-synthesis is only meaningful when every channel of every Stokes shares
-    one resolution. Cubes that already do are used as they are; otherwise they
-    are convolved to a common beam and written as new cubes, leaving the inputs
-    alone. The weight cubes are untouched, as convolution preserves the pixel grid.
+    one resolution, the 'total' mode of racs_tools. Cubes that already do are
+    used as they are; otherwise they are convolved to a common beam and written
+    as new cubes, leaving the inputs alone. The polarisation stage hands over
+    cubes at a 'natural' resolution, one beam per channel, so in the racs-all
+    flow this is the pass that makes them synthesisable while the cubes to
+    archive keep their frequency-dependent resolution. The weight cubes are
+    untouched, as convolution preserves the pixel grid.
 
     The convolution runs plane by plane (see
     ``convolve_cubes_to_common_resolution``), so every channel of every Stokes

--- a/tests/test_convol.py
+++ b/tests/test_convol.py
@@ -18,9 +18,11 @@ from radio_beam.utils import BeamError
 from flint.convol import (
     BeamShape,
     _beams_from_cubes,
+    blank_images,
     check_if_cube_fits,
     common_beam_from_cubes,
     common_beam_shape_from_cubes,
+    convolve_images_or_blank,
     convolve_plane_to_beam,
     cubes_share_common_beam,
     get_cube_common_beam,
@@ -497,3 +499,54 @@ def test_common_beam_shape_from_cubes(tmp_path: Path) -> None:
     blank = _write_cube_with_beam(tmp_path / "blank.fits", [0.0, tiny, 0.0])
     with pytest.raises(ValueError, match="No usable restoring beam"):
         common_beam_shape_from_cubes(cube_paths=[blank])
+
+
+def test_blank_images(tmp_path: Path) -> None:
+    """A blanked image holds no data and claims no PSF"""
+    planes = [
+        _write_plane_with_beam(tmp_path / f"stokes_q.ch000{idx}-000{idx}.fits", 10.0)
+        for idx in range(2)
+    ]
+
+    blanked = blank_images(image_paths=planes)
+
+    assert blanked == [
+        tmp_path / "stokes_q.ch0000-0000.conv.fits",
+        tmp_path / "stokes_q.ch0001-0001.conv.fits",
+    ]
+    for plane, blank in zip(planes, blanked):
+        assert plane.exists(), "the input image was consumed"
+        assert np.all(np.isnan(fits.getdata(blank)))
+        assert fits.getdata(blank).shape == fits.getdata(plane).shape
+        assert not header_beam_is_usable(header=fits.getheader(blank))
+
+
+def test_convolve_images_or_blank(tmp_path: Path) -> None:
+    """A defined beam is convolved to, as convolve_images would"""
+    plane = _write_plane_with_beam(tmp_path / "stokes_q.ch0000-0000.fits", 10.0)
+    beam_shape = BeamShape(bmaj_arcsec=14.0, bmin_arcsec=12.0, bpa_deg=0.0)
+
+    convolved = convolve_images_or_blank(image_paths=[plane], beam_shape=beam_shape)
+
+    assert convolved == [tmp_path / "stokes_q.ch0000-0000.conv.fits"]
+    assert fits.getheader(convolved[0])["BMAJ"] * 3600.0 == pytest.approx(14.0)
+    assert np.isfinite(fits.getdata(convolved[0])).any()
+
+
+def test_convolve_images_or_blank_without_a_beam(tmp_path: Path) -> None:
+    """An undefined beam blanks rather than copying the images through at their
+    own differing resolutions, which whatever they are co-added into would then
+    misreport as a single beam"""
+    planes = [
+        _write_plane_with_beam(tmp_path / "stokes_q.ch0000-0000.fits", 40.0),
+        _write_plane_with_beam(tmp_path / "stokes_q.ch0001-0001.fits", 50.0),
+    ]
+    beam_shape = BeamShape(bmaj_arcsec=np.nan, bmin_arcsec=np.nan, bpa_deg=np.nan)
+
+    convolved = convolve_images_or_blank(
+        image_paths=planes, beam_shape=beam_shape, cutoff=20.0
+    )
+
+    for blank in convolved:
+        assert np.all(np.isnan(fits.getdata(blank)))
+        assert not header_beam_is_usable(header=fits.getheader(blank))

--- a/tests/test_natural_resolution.py
+++ b/tests/test_natural_resolution.py
@@ -1,0 +1,226 @@
+"""Tests around the 'natural' resolution convolution the polarisation flow uses:
+one common beam per channel, rather than the single 'total' beam RM-synthesis
+brings its own inputs to.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import astropy.units as u
+import numpy as np
+import pytest
+from astropy.io import fits
+from astropy.wcs import WCS
+from prefect import flow
+from prefect.logging import disable_run_logger
+from prefect.testing.utilities import prefect_test_harness
+from radio_beam import Beam
+
+from flint.prefect.common.imaging import (
+    convolve_channel_groups_to_natural_resolution,
+    convolve_mfs_beam_images_to_common_resolution,
+)
+
+
+def _write_image_with_beam(path: Path, bmaj_arcsec: float) -> Path:
+    """A small ASKAP-shaped (stokes, dec, ra) plane carrying the requested beam"""
+    wcs = WCS(naxis=3)
+    wcs.wcs.ctype = ["RA---SIN", "DEC--SIN", "STOKES"]
+    wcs.wcs.crval = [180.0, -30.0, 1.0]
+    wcs.wcs.crpix = [8, 8, 1]
+    wcs.wcs.cdelt = [-1e-3, 1e-3, 1.0]
+    wcs.wcs.cunit = ["deg", "deg", ""]
+
+    rng = np.random.default_rng(0)
+    header = wcs.to_header()
+    header["BUNIT"] = "Jy/beam"
+    beam = Beam(
+        major=bmaj_arcsec * u.arcsec, minor=bmaj_arcsec * 0.8 * u.arcsec, pa=0.0 * u.deg
+    )
+    header = beam.attach_to_header(header)
+
+    fits.writeto(
+        path,
+        data=rng.normal(0, 1e-3, (1, 16, 16)).astype(np.float32),
+        header=header,
+        overwrite=True,
+    )
+    return path
+
+
+def _bmaj_arcsec(path: Path) -> float:
+    return float(fits.getheader(path)["BMAJ"]) * 3600.0
+
+
+def _channel_groups(
+    tmp_path: Path, beams_per_stokes: dict[str, list[list[float]]]
+) -> dict[str, list[list[Path]]]:
+    """For each Stokes, the per-beam images of each channel, at the given majors"""
+    return {
+        stokes: [
+            [
+                _write_image_with_beam(
+                    tmp_path / f"{stokes}.ch{channel}.beam{beam}.fits", bmaj_arcsec
+                )
+                for beam, bmaj_arcsec in enumerate(channel_beams)
+            ]
+            for channel, channel_beams in enumerate(channels)
+        ]
+        for stokes, channels in beams_per_stokes.items()
+    }
+
+
+def _convolved_naturally(
+    stokes_channel_groups: dict[str, list[list[Path]]],
+    cutoff: float | None = None,
+    fixed_beam_shape: tuple[float, float, float] | None = None,
+) -> dict[str, list[list[Path]]]:
+    @flow
+    def _convolve() -> dict[str, list[list[Path]]]:
+        return convolve_channel_groups_to_natural_resolution(
+            stokes_channel_groups=stokes_channel_groups,
+            cutoff=cutoff,
+            fixed_beam_shape=fixed_beam_shape,
+        )
+
+    with prefect_test_harness(), disable_run_logger():
+        return _convolve()
+
+
+def test_natural_resolution_varies_by_channel(tmp_path: Path) -> None:
+    """Each channel is brought to its own common beam, so a fine channel is not
+    dragged out to the resolution of a coarse one elsewhere in the band"""
+    groups = _channel_groups(
+        tmp_path, {"q": [[10.0, 10.5], [20.0, 20.5]], "u": [[10.2, 10.1], [20.2, 20.1]]}
+    )
+
+    convolved = _convolved_naturally(groups)
+
+    assert set(convolved) == {"q", "u"}
+    channel_majors = [
+        {
+            _bmaj_arcsec(image)
+            for images in (convolved["q"][channel], convolved["u"][channel])
+            for image in images
+        }
+        for channel in range(2)
+    ]
+    # One resolution within a channel, across every beam and both Stokes
+    assert all(len(majors) == 1 for majors in channel_majors)
+    # But a different one between channels, which is what 'natural' means
+    fine, coarse = (majors.pop() for majors in channel_majors)
+    assert fine < coarse
+    assert fine == pytest.approx(10.6, abs=0.15)
+    assert coarse == pytest.approx(20.6, abs=0.15)
+
+
+def test_natural_resolution_shares_a_beam_across_stokes(tmp_path: Path) -> None:
+    """The beam of a channel is solved over every Stokes at that channel, so a
+    per-channel polarisation product is meaningful. A Stokes solved on its own
+    would land on its own resolution."""
+    groups = _channel_groups(tmp_path, {"q": [[10.0]], "u": [[18.0]]})
+
+    convolved = _convolved_naturally(groups)
+
+    assert _bmaj_arcsec(convolved["q"][0][0]) == pytest.approx(
+        _bmaj_arcsec(convolved["u"][0][0])
+    )
+    assert _bmaj_arcsec(convolved["q"][0][0]) >= 18.0, (
+        "the shared beam must cover the coarsest Stokes of the channel"
+    )
+
+
+def test_natural_resolution_blanks_a_channel_beyond_the_cutoff(tmp_path: Path) -> None:
+    """A channel whose every image is beyond the cutoff has no beam to convolve
+    to. It is blanked and marked as holding no PSF, rather than co-added at its
+    own differing resolutions under a beam that describes none of them."""
+    groups = _channel_groups(
+        tmp_path, {"q": [[10.0, 10.5], [40.0, 50.0]], "u": [[10.2, 10.1], [45.0, 55.0]]}
+    )
+
+    convolved = _convolved_naturally(groups, cutoff=20.0)
+
+    for stokes in ("q", "u"):
+        for image in convolved[stokes][0]:
+            assert np.isfinite(fits.getdata(image)).any()
+            assert _bmaj_arcsec(image) > 0.0
+        for image in convolved[stokes][1]:
+            assert np.all(np.isnan(fits.getdata(image)))
+            assert fits.getheader(image)["BMAJ"] == 0.0
+
+
+def test_natural_resolution_honours_a_fixed_beam(tmp_path: Path) -> None:
+    """A fixed beam shape overrides the per-channel solve, as it did the single
+    beam it replaces"""
+    groups = _channel_groups(tmp_path, {"q": [[10.0], [20.0]]})
+
+    convolved = _convolved_naturally(groups, fixed_beam_shape=(25.0, 25.0, 0.0))
+
+    assert [_bmaj_arcsec(images[0]) for images in convolved["q"]] == [
+        pytest.approx(25.0),
+        pytest.approx(25.0),
+    ]
+
+
+def test_natural_resolution_rejects_mismatched_channel_counts(tmp_path: Path) -> None:
+    """Every Stokes has to contribute the same channels, or a channel's beam
+    would be solved over the wrong frequencies"""
+    groups = _channel_groups(tmp_path, {"q": [[10.0], [20.0]], "u": [[10.0]]})
+
+    with pytest.raises(AssertionError, match="differing channel counts"):
+        _convolved_naturally(groups)
+
+
+def _convolved_mfs(
+    mfs_beam_images: dict[str, dict[str, list[Path]]],
+    cutoff: float | None = None,
+) -> dict[str, dict[str, list[Path]]]:
+    @flow
+    def _convolve() -> dict[str, dict[str, list[Path]]]:
+        return convolve_mfs_beam_images_to_common_resolution(
+            mfs_beam_images=mfs_beam_images, cutoff=cutoff
+        )
+
+    with prefect_test_harness(), disable_run_logger():
+        return _convolve()
+
+
+def test_mfs_products_share_one_beam(tmp_path: Path) -> None:
+    """An MFS product has no frequency axis for a natural beam to vary over, so
+    one beam covers every beam, Stokes and product type"""
+    # wsclean gives a residual the same restoring beam as its image, so the beam
+    # solved over the image products covers the residuals it is applied to. The
+    # coarsest, 12.5, is a Stokes Q beam rather than a Stokes I one.
+    beams_per_stokes = {
+        "i": {"image": [10.0, 11.0], "residual": [10.0, 11.0]},
+        "q": {"image": [12.0, 12.5], "residual": [12.0, 12.5]},
+    }
+    mfs_beam_images = {
+        stokes: {
+            product_type: [
+                _write_image_with_beam(
+                    tmp_path / f"{stokes}.{product_type}.beam{beam}.fits", bmaj_arcsec
+                )
+                for beam, bmaj_arcsec in enumerate(majors)
+            ]
+            for product_type, majors in product_type_majors.items()
+        }
+        for stokes, product_type_majors in beams_per_stokes.items()
+    }
+
+    convolved = _convolved_mfs(mfs_beam_images)
+
+    majors = {
+        _bmaj_arcsec(image)
+        for product_type_images in convolved.values()
+        for images in product_type_images.values()
+        for image in images
+    }
+    assert len(majors) == 1, "the MFS products landed on differing resolutions"
+    assert majors.pop() >= 12.5, "the one beam must cover the coarsest MFS image"
+
+
+def test_mfs_products_without_images_are_left_alone(tmp_path: Path) -> None:
+    """No MFS science image means no beam to solve, so nothing is convolved"""
+    assert _convolved_mfs({}) == {}

--- a/tests/test_prefect_rmsynth_flow.py
+++ b/tests/test_prefect_rmsynth_flow.py
@@ -287,6 +287,37 @@ def test_resolve_common_resolution_cubes_reuses_matching_cubes(tmp_path: Path) -
     assert convolved_cubes == []
 
 
+def test_resolve_common_resolution_cubes_from_natural_resolution(
+    tmp_path: Path,
+) -> None:
+    """The handoff from the polarisation stage: cubes at a 'natural' resolution,
+    one beam per channel, are brought to a single 'total' beam covering the whole
+    band, and the natural cubes they came from are left alone to be archived"""
+    cubes = {
+        pol: _write_cube_with_beam(
+            tmp_path / f"{STEM}.{pol}.linmos.fits", [10.0, 15.0, 20.0]
+        )
+        for pol in ("q", "u")
+    }
+    assert not cubes_share_common_beam(cube_paths=list(cubes.values())), (
+        "the inputs must vary with channel for this to be the case under test"
+    )
+
+    resolved, convolved_cubes = _resolved_cubes(
+        cubes=cubes, output_path=tmp_path / "rmsynth"
+    )
+
+    assert convolved_cubes == list(resolved.values())
+    assert cubes_share_common_beam(cube_paths=list(resolved.values()))
+    # The natural-resolution cubes survive, still varying with channel
+    assert all(cube.exists() for cube in cubes.values())
+    assert not cubes_share_common_beam(cube_paths=list(cubes.values()))
+    # And the one beam has to cover the coarsest channel of the band
+    total_beam = common_beam_from_cubes(cube_paths=list(resolved.values()))
+    assert total_beam is not None
+    assert total_beam.major.to(u.arcsec).value >= 20.0
+
+
 def test_resolve_common_resolution_cubes_beam_cutoff_blanks_coarse_channels(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Why

The smoke test showed the polarisation cubes already at one resolution across the whole band, which is why the rm-synthesis common-beam pass from #409/#412 never fired.

That was not the check misreporting. `polarisation_pipeline.py` solved a **single** common beam over `merge_image_sets` of every footprint beam, every sub-band and every Stokes, then convolved every plane to it. Two things followed:

- The cubes genuinely were at one beam across all channels.
- `fitscube` only writes `CASAMBM`/`BEAMS` when the plane beams differ, so the cubes carried a single header beam. `beamcon_3D.get_beams` then fell through to "using header beam - assuming a constant beam", so `cubes_share_common_beam` could only ever answer yes.

Note the per-channel behaviour that was expected is the **continuum** flow's: `create_convolve_linmos_cubes` transposes into channel groups and solves a beam per channel. The premise in #409's commit message ("the polarisation stage convolves each channel of each Stokes to its own common beam") described that path, not this one.

One resolution across the band is what RM-synthesis needs. It is not what we want to archive: every high-frequency channel was being smoothed out to whatever the coarsest channel in the band demanded.

## What

The two now split along racs_tools' own resolution modes.

**Polarisation stage produces `natural`** - one common beam per channel, so the cubes keep their frequency-dependent resolution. `convolve_channel_groups_to_natural_resolution` solves a beam per channel and convolves that channel's images to it. The convolution moved after the transpose into per-channel beam groups, since a channel's beam cannot be solved until every image at that channel is in hand. Beam shapes stay as futures and are indexed per channel, so a channel starts convolving as soon as its own beam is solved rather than waiting on the slowest channel in the band.

**rm-synthesis stage produces and uses `total`** - the existing `_resolve_common_resolution_cubes` path, unchanged, but it now actually has work to do. The cubes it is handed vary with channel, so it writes `.conv.fits` copies at one band-wide beam and synthesises from those, leaving the natural-resolution cubes alone. racs-all already appends the copies to the spice stage, so both sets are trimmed and compressed.

The resulting RM-synthesis resolution should land about where it did before: the old global beam covered every channel within `beam_cutoff`, and so does the new total solve over the natural per-channel beams.

## Three things worth a look

1. **Matched channel grids are now required.** A channel's beam is solved over every beam image of every Stokes at that channel, not per Stokes, so channel N of I, Q and U share one resolution and a per-channel polarisation product stays meaningful. That needs every polarisation on the same channel grid - which linmos' Stokes I leakage correction already assumed, since it pairs channel indices. A mismatch now asserts with the counts per Stokes instead of producing a quietly misaligned mosaic. If a configuration legitimately images Stokes V on a different grid, say so and I will group by channel count instead.

2. **`convolve_images` copy-through on an unsolved beam is now reachable.** It copies inputs untouched when the target beam is not finite, which is what `get_common_beam` returns when every input is beyond the cutoff. Under a single band-wide solve that needed *every channel* to be beyond the cutoff. Per channel it is reachable at the low-frequency end, and the copy would leave a channel's images at their own differing resolutions for linmos to co-add under a beam describing none of them. `convolve_images_or_blank` blanks that channel and marks it with a zero beam, which `usable_beam_mask` and `fitscube` both already read as carrying no PSF. Other callers of `convolve_images` are untouched.

3. **`RMSynthFieldOptions.beam_cutoff` is live for the first time.** Against single-beam cubes it could never do anything (either the cutoff was above the one beam, or nothing was usable and the cubes were used as they are). Now that the inputs vary with channel it does what it says: drop the coarsest channels from the total solve rather than smoothing the whole band to reach them. Still unset by default, and racs-all still does not thread `PolFieldOptions.beam_cutoff` into it - a science call rather than mine.

Also: MFS products have no frequency axis for a natural beam to vary over, so `convolve_mfs_beam_images_to_common_resolution` gives them one beam of their own rather than the one the coarsest channel of the cube needed. As before, the beam comes from the image products and is applied to the model and residual products too.

## Testing

`tests/test_natural_resolution.py` is new: resolution varies between channels but is shared within one across every beam and Stokes; a channel entirely beyond the cutoff is blanked and marked as carrying no PSF; `fixed_beam_shape` still overrides; mismatched channel counts assert; MFS products land on one beam.

Added to `tests/test_convol.py`: `blank_images` and both branches of `convolve_images_or_blank`. Added to `tests/test_prefect_rmsynth_flow.py`: the natural-to-total handoff, checking the natural cubes survive still varying with channel while the total copies share one beam covering the coarsest.

`uv run pytest --skip-slow -n auto`: 506 passed, 3 failed. All three fail for environment reasons unrelated to this change - `tests/test_catalogue.py` (2) cannot reach `vizier.cds.unistra.fr` through the sandbox proxy, and `tests/test_utils.py::test_copy_directory` needs an `rsync` binary that is not installed here.

`pre-commit run --hook-stage manual --all-files`: all hooks pass.

## Docs

`docs/quickstart/polarisation.md` gains an "Angular resolution" section covering the natural/total split, what `--beam-cutoff` and `--fixed-beam-shape` do to it, and why both cube sets exist. Nothing described this behaviour before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LWfbjm7f9FrUXuEiMmZQab


---
_Generated by [Claude Code](https://claude.ai/code/session_01LWfbjm7f9FrUXuEiMmZQab)_