### PR TITLE
Separate the FDF peak SNR cut from the moment one, and default it off

### DIFF
--- a/flint/options.py
+++ b/flint/options.py
@@ -298,6 +298,8 @@ class RMCleanOptions(BaseOptions):
     """CLEAN loop gain"""
     moment_threshold_snr: float = 5.0
     """SNR cut (times the theoretical FDF noise) applied before computing Faraday moment maps, the dirty ones included"""
+    peak_threshold_snr: float = 0.0
+    """SNR cut (times the theoretical FDF noise) below which FDF peak statistics are blanked. Zero applies no cut: unlike mom0, a peak is a single sample with no noise floor to integrate, and peak_pi_error is written beside it to judge significance downstream"""
 
 
 class SpiceOptions(BaseOptions):

--- a/flint/rmsynth.py
+++ b/flint/rmsynth.py
@@ -47,6 +47,9 @@ from flint.logging import logger
 from flint.options import RMCleanOptions, RMSynthOptions
 
 FDFLabel = Literal["dirty", "clean", "model"]
+# An FDF amplitude cut: one value for the cube, a lazy (ny, nx) map when the
+# noise is per-pixel, or None for no cut at all. See ``_snr_threshold``.
+FDFThreshold = float | np.ndarray | dask.array.Array | None
 _MOMENT_NAMES = ("mom0", "mom1", "mom2")
 
 # The FDF peak statistics, as {FaradayPeaks field: (file suffix, BUNIT, comment)}.
@@ -411,10 +414,27 @@ def write_stokes_i_coeff_maps_to_fits(
     return output_paths
 
 
+def _snr_threshold(snr: float, fdf_error_noise: FDFThreshold) -> FDFThreshold:
+    """An FDF amplitude cut ``snr`` times the theoretical noise, or None for no cut.
+
+    Zero means no cut, and has to short-circuit rather than multiply through:
+    the theoretical noise is ``inf`` wherever a pixel carries no weight at all
+    (linmos blanks the mosaic edge), and ``0 * inf`` is NaN, which blanks every
+    comparison against it instead of passing everything.
+
+    The noise is a scalar for per-channel weights and a lazy (ny, nx) map for
+    the per-pixel ones the linmos cubes give, so the cut comes back in whichever
+    form it arrived in.
+    """
+    if snr == 0:
+        return None
+    return snr * fdf_error_noise
+
+
 def _lazy_faraday_moments(
     fdf_cube: dask.array.Array,
     synth_results: RMSynth3DResults,
-    threshold: float | None,
+    threshold: FDFThreshold,
     debias: bool = False,
     debias_filter_size: int = 5,
 ) -> FaradayMoments:
@@ -735,9 +755,9 @@ def write_rm_products(
     # (mom1/mom2 are then weighted by that noise and mean nothing). rm-lite
     # applies this same cut inside RM-CLEAN to its own moment maps, which flint
     # does not use, so it is rederived here from the shared theoretical noise.
-    moment_threshold = (
-        rmclean_options.moment_threshold_snr
-        * synth_results.theoretical_noise.fdf_error_noise
+    moment_threshold = _snr_threshold(
+        rmclean_options.moment_threshold_snr,
+        synth_results.theoretical_noise.fdf_error_noise,
     )
     for label in moment_products:
         moments = _lazy_faraday_moments(
@@ -766,7 +786,16 @@ def write_rm_products(
     # rm-lite returns peaks of its own on RMClean3DResults, but only for the
     # clean FDF and only under its own threshold. Deriving them here is what
     # lets any requested FDF have them -- the dirty one included, which needs no
-    # RM-CLEAN at all -- under the same cut flint gives its moments.
+    # RM-CLEAN at all -- under a cut flint chooses.
+    #
+    # A separate cut from the moments, and off by default. The moment cut exists
+    # because mom0 integrates the whole Faraday depth axis; a peak is one sample
+    # and has no such floor, so blanking it discards a real measurement whose
+    # error (peak_pi_error) is written beside it.
+    peak_threshold = _snr_threshold(
+        rmclean_options.peak_threshold_snr,
+        synth_results.theoretical_noise.fdf_error_noise,
+    )
     for label in peak_products:
         peaks = calc_faraday_peaks(
             fdf_sources[label],
@@ -775,7 +804,7 @@ def write_rm_products(
             fdf_error=synth_results.theoretical_noise.fdf_error_noise,
             lam_sq_0_m2=synth_results.lam_sq_0_m2,
             lambda_sq_arr_m2=synth_results.lambda_sq_arr_m2,
-            threshold=moment_threshold,
+            threshold=peak_threshold,
         )
         for field in _PEAK_MAPS:
             compute_targets[f"peak.{label}.{field}"] = getattr(peaks, field).astype(

--- a/flint/rmsynth.py
+++ b/flint/rmsynth.py
@@ -10,9 +10,10 @@ import time
 from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Literal, TypeAlias
 
 import dask
+import dask.array as da
 import numpy as np
 import zarr
 from astropy.io import fits
@@ -46,10 +47,8 @@ from flint.exceptions import NotSupportedError
 from flint.logging import logger
 from flint.options import RMCleanOptions, RMSynthOptions
 
-FDFLabel = Literal["dirty", "clean", "model"]
-# An FDF amplitude cut: one value for the cube, a lazy (ny, nx) map when the
-# noise is per-pixel, or None for no cut at all. See ``_snr_threshold``.
-FDFThreshold = float | np.ndarray | dask.array.Array | None
+FDFLabel: TypeAlias = Literal["dirty", "clean", "model"]
+FDFThreshold: TypeAlias = float | np.ndarray | da.Array | None
 _MOMENT_NAMES = ("mom0", "mom1", "mom2")
 
 # The FDF peak statistics, as {FaradayPeaks field: (file suffix, BUNIT, comment)}.
@@ -426,7 +425,7 @@ def _snr_threshold(snr: float, fdf_error_noise: FDFThreshold) -> FDFThreshold:
     the per-pixel ones the linmos cubes give, so the cut comes back in whichever
     form it arrived in.
     """
-    if snr == 0:
+    if snr == 0 or fdf_error_noise is None:
         return None
     return snr * fdf_error_noise
 

--- a/tests/test_rmsynth.py
+++ b/tests/test_rmsynth.py
@@ -15,6 +15,7 @@ from flint.exceptions import NotSupportedError
 from flint.options import RMCleanOptions, RMSynthOptions
 from flint.rmsynth import (
     FDFLabel,
+    _snr_threshold,
     needs_rmclean,
     run_rmclean_3d,
     run_rmsynth_3d,
@@ -966,6 +967,81 @@ def test_every_fdf_can_have_cubes_moments_and_peaks(
     for label in labels:
         peak_rm = fits.getdata(Path(f"{output_prefix}.fdf.{label}.peak_rm.fits"))
         assert np.nanmedian(peak_rm) == pytest.approx(PHI_TRUE_RADM2, abs=5.0), label
+
+
+def test_the_peak_and_moment_snr_cuts_are_independent(
+    tmp_path: Path, qu_cubes: tuple[Path, Path]
+) -> None:
+    """One cut used to serve both, so a noise estimate that blanked the moments
+    took the peaks with it and the pair looked like a broken FDF rather than an
+    over-aggressive cut. They are separate options now, and each has to bite on
+    its own products only.
+    """
+    stokes_q_cube, stokes_u_cube = qu_cubes
+
+    def peak_pi_and_mom0(prefix: str, **snrs: float) -> tuple[np.ndarray, np.ndarray]:
+        output_prefix = tmp_path / prefix
+        _synth_and_write(
+            stokes_q_cube=stokes_q_cube,
+            stokes_u_cube=stokes_u_cube,
+            rmsynth_options=RMSynthOptions(),
+            rmclean_options=RMCleanOptions(**snrs),
+            cube_products=[],
+            moment_products=["dirty"],
+            peak_products=["dirty"],
+            output_prefix=output_prefix,
+        )
+        return (
+            fits.getdata(Path(f"{output_prefix}.fdf.dirty.peak_pi.fits")),
+            fits.getdata(Path(f"{output_prefix}.fdf.dirty.mom0.fits")),
+        )
+
+    # A cut nothing can clear on one side leaves the other untouched. mom0 is
+    # nansum, so a fully cut spectrum reads 0 rather than NaN; a cut peak is NaN
+    peak_pi, mom0 = peak_pi_and_mom0("moments_cut", moment_threshold_snr=1e6)
+    assert np.all(np.isfinite(peak_pi)), "the moment cut must not reach the peaks"
+    assert np.all(mom0 == 0.0)
+
+    peak_pi, mom0 = peak_pi_and_mom0("peaks_cut", peak_threshold_snr=1e6)
+    assert np.all(np.isnan(peak_pi))
+    assert np.all(mom0 > 0.0), "the peak cut must not reach the moments"
+
+
+def test_no_peak_cut_by_default_even_where_a_pixel_has_no_weight(
+    tmp_path: Path, qu_cubes: tuple[Path, Path]
+) -> None:
+    """``peak_threshold_snr`` defaults to 0, meaning no cut at all. It cannot be
+    applied as ``0 * noise``: the theoretical noise is inf for a pixel linmos
+    blanked, ``0 * inf`` is NaN, and every comparison against NaN is False -- so
+    the cut meant to pass everything would instead blank the whole map."""
+    assert RMCleanOptions().peak_threshold_snr == 0.0
+    assert _snr_threshold(0.0, np.float64(np.inf)) is None
+    assert _snr_threshold(0.0, np.array([1e-5, np.inf])) is None
+    assert _snr_threshold(5.0, np.float64(2.0)) == 10.0
+
+    stokes_q_cube, stokes_u_cube = qu_cubes
+    output_prefix = tmp_path / "default_cut"
+    _synth_and_write(
+        stokes_q_cube=stokes_q_cube,
+        stokes_u_cube=stokes_u_cube,
+        rmsynth_options=RMSynthOptions(),
+        rmclean_options=RMCleanOptions(),
+        cube_products=[],
+        moment_products=[],
+        peak_products=["dirty"],
+        output_prefix=output_prefix,
+        stokes_q_weight_cube=_make_linmos_weight_cube(tmp_path, "q", blank_outside=1.5),
+        stokes_u_weight_cube=_make_linmos_weight_cube(tmp_path, "u", blank_outside=1.5),
+    )
+
+    peak_pi = fits.getdata(Path(f"{output_prefix}.fdf.dirty.peak_pi.fits"))
+    inside_cutoff = _within_cutoff(1.5)
+    assert np.all(np.isfinite(peak_pi[inside_cutoff])), (
+        "no cut was asked for, so every pixel carrying weight keeps its peak"
+    )
+    assert np.all(np.isnan(peak_pi[~inside_cutoff])), (
+        "a pixel linmos blanked has no FDF to peak, cut or no cut"
+    )
 
 
 def test_dirty_peaks_alone_do_not_run_rmclean(


### PR DESCRIPTION
## Why

Chasing all-zero moment maps and all-NaN peak maps from a racs-all smoke test. Those two symptoms are the same event: `write_rm_products` computed one threshold and handed the same object to both `calc_faraday_moments` and `calc_faraday_peaks`, so the products could only ever be cut together.

```python
moment_threshold = rmclean_options.moment_threshold_snr * synth_results.theoretical_noise.fdf_error_noise
...
threshold=moment_threshold,   # moments
threshold=moment_threshold,   # peaks
```

A theoretical noise that comes out too high therefore blanks both at once, which reads as a broken FDF rather than an over-aggressive cut. `mom0` is a `nansum`, so a fully cut spectrum reads exactly 0 rather than NaN, which makes it look like valid data.

This does not fix the underlying noise question (still open, and pointing at whether the linmos weight cubes represent the noise properly). It separates the knobs so the two can be reasoned about independently.

## What

- `RMCleanOptions` gains `peak_threshold_snr`, defaulting to `0.0`, meaning no cut.
- `write_rm_products` derives the moment and peak thresholds separately through a new `_snr_threshold` helper.
- The two rm-lite functions already take independent `threshold` arguments and both accept `None`, so nothing had to move upstream.

## Why 0 for the peaks

The moment cut has a specific justification, already spelled out in the comment above it: `mom0` sums `|FDF|` over the whole Faraday depth axis, so with no cut an off-source pixel integrates hundreds of noise samples into a large positive floor, and mom1/mom2 are then weighted by that noise. A peak is a single sample and has no such floor. Blanking it by default discards a real measurement whose 1-sigma error is already written beside it as `peak_pi_error`, so significance can be judged downstream.

## The 0 * inf trap

Zero short-circuits to `None` rather than multiplying through. `fdf_error_noise` is `inf` wherever a pixel carries no weight at all (linmos blanks the mosaic edge), `0 * inf` is NaN, and every comparison against NaN is False. Applied naively, the cut meant to pass everything would blank the entire map. There is a test pinning this.

## Tests

Two added to `tests/test_rmsynth.py`:

- `test_the_peak_and_moment_snr_cuts_are_independent` drives each cut to a value nothing can clear and checks it bites only its own products.
- `test_no_peak_cut_by_default_even_where_a_pixel_has_no_weight` covers the default, the `_snr_threshold` short-circuit, and a run over linmos-shaped weight cubes with blanked pixels.

Not run locally: this session's environment has no astropy, so the suite could not execute here. Relying on CI.

## Note for reviewers

`peak_pi_error.fits` is `fdf_error_noise` written out pixel by pixel (`calc_peak_stats` computes it unconditionally, before any masking), so it is the map to compare against the Q/U channel rms when working out whether the noise estimate itself is right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MKV4YVPViaNXK1H6euKLhA

---
_Generated by [Claude Code](https://claude.ai/code/session_01MKV4YVPViaNXK1H6euKLhA)_