### PR TITLE
Measure the polarisation noise with BANE, and feed it to rm-synthesis

### DIFF
--- a/flint/bane.py
+++ b/flint/bane.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from pathlib import Path
-from typing import Any
+from typing import Any, NamedTuple
 
 import astropy.units as u
 import numba as nb
@@ -27,7 +27,6 @@ from astropy.io import fits
 from astropy.stats import mad_std
 from astropy.wcs import WCS
 from astropy.wcs.utils import proj_plane_pixel_scales
-from capn_crunch import BaseOptions
 from numpy import fft
 from numpy.typing import NDArray
 from radio_beam import Beam
@@ -36,21 +35,16 @@ from scipy import ndimage
 
 from flint.logging import logger
 from flint.naming import create_aegean_names
+from flint.options import FFTBANEOptions
 
 
-class FFTBANEOptions(BaseOptions):
-    """Options for ``robust_bane``. Named apart from
-    ``flint.source_finding.aegean.BANEOptions``, which drives the containerised
-    aegean BANE instead."""
+class BANEMaps(NamedTuple):
+    """The pair of maps ``bane_fits_image`` writes"""
 
-    step_size: int | None = None
-    """Downsampling factor in pixels. None uses 3 beams; a negative value sets the beams per step"""
-    box_size: int | None = None
-    """Convolution kernel size in pixels. None uses 10 beams; a negative value sets the beams per box"""
-    clip_sigma: float = 5.0
-    """Pixels above this SNR are replaced by noise before the background is fitted"""
-    seed: int = 1234
-    """Seed for the noise the clipped pixels are filled with, so a rerun reproduces the maps"""
+    bkg_image: Path
+    """Background map"""
+    rms_image: Path
+    """RMS noise map"""
 
 
 @nb.njit(fastmath=True, cache=True)
@@ -384,7 +378,7 @@ def robust_bane(
 def bane_fits_image(
     image: Path,
     fft_bane_options: FFTBANEOptions | None = None,
-) -> tuple[Path, Path]:
+) -> BANEMaps:
     """Write the background and RMS maps of a single-plane FITS image.
 
     Named ``_bkg.fits`` and ``_rms.fits`` beside the input, matching what the
@@ -396,7 +390,7 @@ def bane_fits_image(
         fft_bane_options (FFTBANEOptions | None, optional): Step, box, clip and seed. Defaults to ``FFTBANEOptions()``.
 
     Returns:
-        tuple[Path, Path]: The background and RMS maps written
+        BANEMaps: The background and RMS maps written
     """
     logger.info(f"Running FFT BANE on {image}")
     with fits.open(image, memmap=True, mode="denywrite") as hdul:
@@ -422,4 +416,4 @@ def bane_fits_image(
         fits.writeto(path, data_out.reshape(original_shape), header, overwrite=True)
         logger.info(f"Wrote {path}")
 
-    return names.bkg_image, names.rms_image
+    return BANEMaps(bkg_image=names.bkg_image, rms_image=names.rms_image)

--- a/flint/bane.py
+++ b/flint/bane.py
@@ -1,0 +1,425 @@
+"""BANE, the background and noise estimator, computed with FFTs.
+
+Ported from ``AegeanTools.BANE_fft`` (AlecThomson/Aegean, ``dask`` branch), which
+is a faster reimplementation of the ``BANE`` shipped with aegean. Unlike that
+one, ``step`` here is a downsampling factor and ``box`` a kernel size, and the
+box average is a convolution rather than a grid of sigma clips.
+
+Only the 2D single-plane routines are ported: the polarisation flow runs this
+per linmos-ed channel, so the cube handling upstream is not needed.
+
+``rocket_fft`` is imported for its side effect of teaching numba ``numpy.fft``.
+Without it every ``njit`` here fails to compile, eagerly at import for those
+carrying an explicit signature.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import astropy.units as u
+import numba as nb
+import numpy as np
+import rocket_fft  # noqa: F401
+from astropy.io import fits
+from astropy.stats import mad_std
+from astropy.wcs import WCS
+from astropy.wcs.utils import proj_plane_pixel_scales
+from capn_crunch import BaseOptions
+from numpy import fft
+from numpy.typing import NDArray
+from radio_beam import Beam
+from radio_beam.beam import NoBeamException
+from scipy import ndimage
+
+from flint.logging import logger
+from flint.naming import create_aegean_names
+
+
+class FFTBANEOptions(BaseOptions):
+    """Options for ``robust_bane``. Named apart from
+    ``flint.source_finding.aegean.BANEOptions``, which drives the containerised
+    aegean BANE instead."""
+
+    step_size: int | None = None
+    """Downsampling factor in pixels. None uses 3 beams; a negative value sets the beams per step"""
+    box_size: int | None = None
+    """Convolution kernel size in pixels. None uses 10 beams; a negative value sets the beams per box"""
+    clip_sigma: float = 5.0
+    """Pixels above this SNR are replaced by noise before the background is fitted"""
+    seed: int = 1234
+    """Seed for the noise the clipped pixels are filled with, so a rerun reproduces the maps"""
+
+
+@nb.njit(fastmath=True, cache=True)
+def _ft_kernel(kernel: NDArray[np.float32], shape: tuple) -> NDArray[np.float32]:
+    """FFT of `kernel`, zero-padded out to `shape`"""
+    return fft.rfft2(kernel, s=shape)
+
+
+@nb.njit(
+    nb.float32[:, :](
+        nb.float32[:, :],
+        nb.types.UniTuple(nb.int64, 2),
+    ),
+    fastmath=True,
+    cache=True,
+)
+def pad_reflect(
+    array: NDArray[np.float32],
+    pad_width: tuple[int, int],
+) -> NDArray[np.float32]:
+    """``np.pad(array, pad_width, mode="reflect")``, in a form numba can compile"""
+    nx, ny = array.shape
+    px, py = pad_width
+
+    padded = np.empty((nx + 2 * px, ny + 2 * py), dtype=array.dtype)
+    padded[px : px + nx, py : py + ny] = array
+
+    for i in range(px):
+        padded[px - 1 - i, py : py + ny] = array[i + 1, :]
+        padded[nx + px + i, py : py + ny] = array[nx - 2 - i, :]
+
+    for j in range(py):
+        padded[:, py - 1 - j] = padded[:, py + j + 1]
+        padded[:, ny + py + j] = padded[:, ny + py - 2 - j]
+
+    return padded
+
+
+@nb.njit(
+    nb.float32[:, :](nb.float32[:, :], nb.float32[:, :]),
+    fastmath=True,
+    cache=True,
+)
+def fft_average(
+    image: NDArray[np.float32], kernel: NDArray[np.float32]
+) -> NDArray[np.float32]:
+    """Convolve `image` by `kernel`, normalised so a flat image is unchanged.
+
+    Reflect-padded by the kernel size so the FFT's periodic wrap does not fold
+    the far edge of the image back onto the near one.
+    """
+    pad_x, pad_y = kernel.shape
+    image_padded = pad_reflect(array=image, pad_width=(pad_x, pad_y))
+
+    image_fft = fft.rfft2(image_padded)
+    kernel_fft = _ft_kernel(kernel, shape=image_padded.shape)
+    smooth = fft.irfft2(image_fft * kernel_fft, s=image_padded.shape) / kernel.sum()
+
+    return smooth[pad_x:-pad_x, pad_y:-pad_y]
+
+
+@nb.njit(
+    nb.types.UniTuple(nb.float32[:, :], 2)(
+        nb.float32[:, :], nb.float32[:, :], nb.float32[:, :]
+    ),
+    fastmath=True,
+    cache=True,
+)
+def bane_fft(
+    image: NDArray[np.float32],
+    kernel: NDArray[np.float32],
+    valid: NDArray[np.float32],
+) -> tuple[NDArray[np.float32], NDArray[np.float32]]:
+    """Background and RMS of `image`, as `kernel`-weighted local averages.
+
+    `image` must be zero wherever `valid` is zero. Smoothing the validity mask
+    with the same kernel gives the fraction of each average that came from real
+    data, and dividing by it stops a blanked pixel counting as a measured zero:
+    without that the background collapses toward zero within a kernel width of
+    a blank, which for a linmos mosaic is the whole primary-beam border.
+    """
+    weight = fft_average(valid, kernel)
+    weight = np.where(weight > 0, weight, np.nan).astype(np.float32)
+
+    mean = (fft_average(image, kernel) / weight).astype(np.float32)
+    # Blanked pixels hold zero, not the mean, so their residual has to be
+    # zeroed too or it would enter the sum as the full mean squared. Selected
+    # rather than multiplied by `valid`: `mean` is NaN where nothing was valid,
+    # and NaN * 0 is NaN, which the FFT would then spread over the whole plane
+    resid = np.where(valid > 0, (image - mean) ** 2, np.float32(0.0)).astype(np.float32)
+    rms = np.sqrt(fft_average(resid, kernel) / weight).astype(np.float32)
+
+    return mean, rms
+
+
+def tophat_kernel(diameter: int) -> NDArray[np.float32]:
+    """Circular tophat kernel of `diameter` pixels"""
+    radius = diameter // 2
+    kernel = np.zeros((radius * 2 + 1, radius * 2 + 1), dtype=np.float32)
+    xx = np.arange(-radius, radius + 1)
+    X, Y = np.meshgrid(xx, xx)
+    kernel[radius**2 >= X**2 + Y**2] = 1
+    return kernel
+
+
+def gaussian_kernel(fwhm: int) -> NDArray[np.float32]:
+    """Gaussian kernel of `fwhm` pixels"""
+    xx = np.arange(-fwhm, fwhm + 1)
+    X, Y = np.meshgrid(xx, xx)
+    kernel = np.exp(-4 * np.log(2) * (X**2 + Y**2) / fwhm**2)
+    return kernel.astype(np.float32)
+
+
+def get_kernel(
+    header: fits.Header | dict[str, Any],
+    step_size: int | None = None,
+    box_size: int | None = None,
+    kernel_func: Callable[[int], NDArray[np.float32]] = gaussian_kernel,
+) -> tuple[NDArray[np.float32], int]:
+    """The convolution kernel and downsampling factor, in pixels.
+
+    ``step_size`` is the downsampling factor and ``box_size`` the kernel size.
+    Either being None or negative sizes it from the restoring beam instead, at
+    3 and 10 beams respectively, or at ``abs(value)`` beams when negative.
+
+    Args:
+        header (fits.Header | dict[str, Any]): Header of the image, for the beam and pixel scale
+        step_size (int | None, optional): Downsampling factor in pixels. Defaults to 3 beams.
+        box_size (int | None, optional): Kernel size in pixels. Defaults to 10 beams.
+        kernel_func (Callable, optional): Kernel shape. Defaults to ``gaussian_kernel``.
+
+    Returns:
+        tuple[NDArray[np.float32], int]: The kernel, peak-normalised, and the step size in pixels
+    """
+    if step_size is None or step_size < 0 or box_size is None or box_size < 0:
+        try:
+            beam = Beam.from_fits_header(header)
+            scales = proj_plane_pixel_scales(WCS(header)) * u.deg / u.pixel
+            pix_per_beam = beam.minor / scales.min()
+        except (ValueError, NoBeamException) as error:
+            # radio_beam raises NoBeamException, which is not a ValueError, so
+            # catching ValueError alone lets a header with no beam through
+            msg = "Could not parse beam from header - try specifying step size"
+            raise ValueError(msg) from error
+        logger.info(f"{beam!r}, {pix_per_beam:0.1f} pixels per beam")
+
+    if step_size is None or step_size < 0:
+        nbeam_step = 3 if step_size is None else abs(step_size)
+        step_size_pix = int(np.ceil((nbeam_step * pix_per_beam).to(u.pix).value))
+    else:
+        step_size_pix = step_size
+
+    if box_size is None or box_size < 0:
+        nbeam_box = 10 if box_size is None else abs(box_size)
+        scaler = step_size_pix if step_size_pix > 0 else 1
+        box_size_pix = abs(int(np.ceil(pix_per_beam.value * nbeam_box / scaler)))
+    else:
+        box_size_pix = box_size
+
+    logger.info(f"BANE {step_size_pix=} {box_size_pix=} (box is post-downsampling)")
+
+    kernel = kernel_func(box_size_pix)
+    kernel /= kernel.max()
+
+    return kernel, step_size_pix
+
+
+def _downsample_slices(
+    shape: tuple[int, int], step_size_pix: int
+) -> tuple[slice, slice]:
+    """Slices taking every `step_size_pix` pixel, trimmed to an even count.
+
+    The FFT is cheapest on an even grid, and the kernel is defined against the
+    downsampled image, so a trailing odd row or column is dropped rather than
+    kept.
+
+    Note the sampled region runs from `step_size_pix` to `length -
+    step_size_pix`, not the full image, while the zoom back up stretches it
+    across the full image. That misregistration is the likely cause of the
+    offset upstream records as a TODO; sampling half a cell in instead was
+    measured and made the background worse, so this keeps upstream's grid.
+    """
+    slices = []
+    for length in (shape[0], shape[1]):
+        stop = length - step_size_pix
+        while (stop // step_size_pix) % 2 != 0:
+            stop -= 1
+        slices.append(slice(step_size_pix, stop, step_size_pix))
+    return slices[0], slices[1]
+
+
+def _bane_round(
+    filled: NDArray[np.float32],
+    valid: NDArray[np.float32],
+    nan_mask: NDArray[np.bool_],
+    background: NDArray[np.float32],
+    rms: NDArray[np.float32],
+    kernel: NDArray[np.float32],
+    step_size_pix: int,
+    clip_sigma: float,
+    rng: np.random.Generator,
+    round_number: int,
+) -> tuple[NDArray[np.float32], NDArray[np.float32]]:
+    """One clip-refill-smooth pass, given the background and RMS to clip against.
+
+    Sources bias a local average, so they are replaced by noise drawn from the
+    incoming maps before the convolution that measures the background. The
+    replacement carries the local background too: filling with zero-mean noise
+    would drag the background down wherever a source was removed.
+    """
+    with np.errstate(invalid="ignore", divide="ignore"):
+        source_mask = (np.abs(filled - background) / rms > clip_sigma) & ~nan_mask
+    logger.info(
+        f"BANE round {round_number}: refilling {source_mask.sum()} "
+        f"({source_mask.sum() / filled.size * 100:0.1f}%) source pixels with noise"
+    )
+
+    clipped = filled.copy()
+    clipped[source_mask] = (
+        background[source_mask]
+        + rng.normal(loc=0, scale=1, size=source_mask.sum()) * rms[source_mask]
+    )
+    # Blanked pixels must stay at zero: bane_fft normalises by the smoothed
+    # validity mask and assumes they contribute nothing
+    clipped[nan_mask] = 0.0
+
+    zoom: tuple[float, float] | None = None
+    round_valid = valid
+    if step_size_pix > 0:
+        y_slice, x_slice = _downsample_slices(clipped.shape, step_size_pix)
+        zoom = (
+            clipped.shape[0] / clipped[y_slice, x_slice].shape[0],
+            clipped.shape[1] / clipped[y_slice, x_slice].shape[1],
+        )
+        clipped, round_valid = clipped[y_slice, x_slice], valid[y_slice, x_slice]
+
+    # pad_reflect reflects by the kernel size and is njit-ed without bounds
+    # checking, so a kernel wider than the image it pads reads off the end and
+    # returns quietly wrong maps rather than raising
+    if any(pad >= length for pad, length in zip(kernel.shape, clipped.shape)):
+        msg = (
+            f"A {kernel.shape} kernel does not fit the {clipped.shape} image it "
+            "smooths. Lower step_size so less is downsampled away, or box_size "
+            "for a smaller kernel."
+        )
+        raise ValueError(msg)
+
+    background, rms = bane_fft(
+        np.ascontiguousarray(clipped), kernel, np.ascontiguousarray(round_valid)
+    )
+    background = np.nan_to_num(background, nan=0.0)
+    rms = np.nan_to_num(rms, nan=0.0)
+
+    if zoom is not None:
+        background = ndimage.zoom(
+            background, zoom, order=3, grid_mode=True, mode="reflect"
+        )
+        rms = ndimage.zoom(rms, zoom, order=3, grid_mode=True, mode="reflect")
+
+    return background, rms
+
+
+def robust_bane(
+    image: NDArray[np.float32],
+    header: fits.Header | dict[str, Any],
+    fft_bane_options: FFTBANEOptions | None = None,
+    kernel_func: Callable[[int], NDArray[np.float32]] = gaussian_kernel,
+    rms_estimator: Callable[[NDArray[np.float32]], float] = mad_std,
+) -> tuple[NDArray[np.float32], NDArray[np.float32]]:
+    """Background and RMS maps of a single image plane.
+
+    Sources bias a local average, so they are clipped against a first-pass RMS
+    and refilled with noise before the convolution that measures the background.
+    The work happens on the downsampled image and is zoomed back up, which is
+    where the speed over a per-pixel box comes from.
+
+    Args:
+        image (NDArray[np.float32]): The image plane to measure
+        header (fits.Header | dict[str, Any]): Its header, for the beam and pixel scale
+        fft_bane_options (FFTBANEOptions | None, optional): Step, box, clip and seed. Defaults to ``FFTBANEOptions()``.
+        kernel_func (Callable, optional): Kernel shape. Defaults to ``gaussian_kernel``.
+        rms_estimator (Callable, optional): First-pass RMS estimator. Defaults to ``mad_std``.
+
+    Returns:
+        tuple[NDArray[np.float32], NDArray[np.float32]]: Background and RMS, shaped like `image`
+    """
+    fft_bane_options = fft_bane_options or FFTBANEOptions()
+    kernel, step_size_pix = get_kernel(
+        header=header,
+        step_size=fft_bane_options.step_size,
+        box_size=fft_bane_options.box_size,
+        kernel_func=kernel_func,
+    )
+
+    nan_mask = ~np.isfinite(image)
+    valid = (~nan_mask).astype(np.float32)
+    filled = np.where(nan_mask, 0.0, image).astype(np.float32)
+    finite = image[~nan_mask].ravel()
+
+    # First pass finds the sources against one background and noise for the
+    # whole plane, which is all there is to go on before a map exists. The
+    # median matters: testing |image| rather than |image - background| makes
+    # every pixel a source as soon as the plane carries any DC offset.
+    background = np.full_like(filled, float(np.median(finite)))
+    rms = np.full_like(filled, float(rms_estimator(finite)))
+
+    # Second pass repeats the cut against those maps. A linmos mosaic's noise
+    # rises with the primary beam, so a single threshold clips real noise at the
+    # edge while missing faint sources in the middle.
+    rng = np.random.default_rng(fft_bane_options.seed)
+    for round_number in (1, 2):
+        background, rms = _bane_round(
+            filled=filled,
+            valid=valid,
+            nan_mask=nan_mask,
+            background=background,
+            rms=rms,
+            kernel=kernel,
+            step_size_pix=step_size_pix,
+            clip_sigma=fft_bane_options.clip_sigma,
+            rng=rng,
+            round_number=round_number,
+        )
+
+    background[nan_mask] = np.nan
+    rms[nan_mask] = np.nan
+
+    return background, rms
+
+
+def bane_fits_image(
+    image: Path,
+    fft_bane_options: FFTBANEOptions | None = None,
+) -> tuple[Path, Path]:
+    """Write the background and RMS maps of a single-plane FITS image.
+
+    Named ``_bkg.fits`` and ``_rms.fits`` beside the input, matching what the
+    aegean BANE produces (see ``flint.naming.create_aegean_names``) so the two
+    are interchangeable downstream.
+
+    Args:
+        image (Path): Single-plane FITS image to measure
+        fft_bane_options (FFTBANEOptions | None, optional): Step, box, clip and seed. Defaults to ``FFTBANEOptions()``.
+
+    Returns:
+        tuple[Path, Path]: The background and RMS maps written
+    """
+    logger.info(f"Running FFT BANE on {image}")
+    with fits.open(image, memmap=True, mode="denywrite") as hdul:
+        header = hdul[0].header
+        # Squeezed rather than indexed: a linmos plane carries degenerate
+        # Stokes/frequency axes that robust_bane has no use for, but the maps
+        # are written back with them so they stack like the image they came from
+        original_shape = hdul[0].data.shape
+        data = np.squeeze(hdul[0].data).astype(np.float32)
+
+    if data.ndim != 2:
+        msg = f"{image} has a {data.ndim}D image once squeezed, expected a single plane"
+        raise ValueError(msg)
+
+    background, rms = robust_bane(
+        image=data, header=header, fft_bane_options=fft_bane_options
+    )
+
+    names = create_aegean_names(base_output=str(image.parent / image.stem))
+    for data_out, path in ((background, names.bkg_image), (rms, names.rms_image)):
+        # The input header, so the maps land on the input's pixel grid and can
+        # be stacked into a cube alongside it
+        fits.writeto(path, data_out.reshape(original_shape), header, overwrite=True)
+        logger.info(f"Wrote {path}")
+
+    return names.bkg_image, names.rms_image

--- a/flint/bane.py
+++ b/flint/bane.py
@@ -1,16 +1,11 @@
 """BANE, the background and noise estimator, computed with FFTs.
 
-Ported from ``AegeanTools.BANE_fft`` (AlecThomson/Aegean, ``dask`` branch), which
-is a faster reimplementation of the ``BANE`` shipped with aegean. Unlike that
-one, ``step`` here is a downsampling factor and ``box`` a kernel size, and the
-box average is a convolution rather than a grid of sigma clips.
+Ported from ``AegeanTools.BANE_fft`` (AlecThomson/Aegean, ``dask`` branch). Here
+``step`` is a downsampling factor and ``box`` a kernel size, and the box average
+is a convolution. Only the 2D single-plane routines: callers run this per channel.
 
-Only the 2D single-plane routines are ported: the polarisation flow runs this
-per linmos-ed channel, so the cube handling upstream is not needed.
-
-``rocket_fft`` is imported for its side effect of teaching numba ``numpy.fft``.
-Without it every ``njit`` here fails to compile, eagerly at import for those
-carrying an explicit signature.
+``rocket_fft`` is imported for its side effect of teaching numba ``numpy.fft``,
+without which every ``njit`` here fails to compile.
 """
 
 from __future__ import annotations
@@ -120,11 +115,9 @@ def bane_fft(
 ) -> tuple[NDArray[np.float32], NDArray[np.float32]]:
     """Background and RMS of `image`, as `kernel`-weighted local averages.
 
-    `image` must be zero wherever `valid` is zero. Smoothing the validity mask
-    with the same kernel gives the fraction of each average that came from real
-    data, and dividing by it stops a blanked pixel counting as a measured zero:
-    without that the background collapses toward zero within a kernel width of
-    a blank, which for a linmos mosaic is the whole primary-beam border.
+    `image` must be zero wherever `valid` is zero. Dividing by the smoothed
+    validity mask stops a blank counting as a measured zero, which would
+    otherwise drag the background down within a kernel width of every blank.
     """
     weight = fft_average(valid, kernel)
     weight = np.where(weight > 0, weight, np.nan).astype(np.float32)
@@ -217,15 +210,10 @@ def _downsample_slices(
 ) -> tuple[slice, slice]:
     """Slices taking every `step_size_pix` pixel, trimmed to an even count.
 
-    The FFT is cheapest on an even grid, and the kernel is defined against the
-    downsampled image, so a trailing odd row or column is dropped rather than
-    kept.
-
-    Note the sampled region runs from `step_size_pix` to `length -
-    step_size_pix`, not the full image, while the zoom back up stretches it
-    across the full image. That misregistration is the likely cause of the
-    offset upstream records as a TODO; sampling half a cell in instead was
-    measured and made the background worse, so this keeps upstream's grid.
+    The sampled region runs from `step_size_pix` to `length - step_size_pix`
+    while the zoom back up stretches it over the whole image. That is the likely
+    cause of the offset upstream records as a TODO; sampling half a cell in
+    instead measured worse, so this keeps upstream's grid.
     """
     slices = []
     for length in (shape[0], shape[1]):
@@ -248,12 +236,10 @@ def _bane_round(
     rng: np.random.Generator,
     round_number: int,
 ) -> tuple[NDArray[np.float32], NDArray[np.float32]]:
-    """One clip-refill-smooth pass, given the background and RMS to clip against.
+    """One clip-refill-smooth pass, clipping against the given background and RMS.
 
-    Sources bias a local average, so they are replaced by noise drawn from the
-    incoming maps before the convolution that measures the background. The
-    replacement carries the local background too: filling with zero-mean noise
-    would drag the background down wherever a source was removed.
+    The refill carries the local background: zero-mean noise would drag the
+    background down wherever a source was removed.
     """
     with np.errstate(invalid="ignore", divide="ignore"):
         source_mask = (np.abs(filled - background) / rms > clip_sigma) & ~nan_mask
@@ -281,9 +267,8 @@ def _bane_round(
         )
         clipped, round_valid = clipped[y_slice, x_slice], valid[y_slice, x_slice]
 
-    # pad_reflect reflects by the kernel size and is njit-ed without bounds
-    # checking, so a kernel wider than the image it pads reads off the end and
-    # returns quietly wrong maps rather than raising
+    # pad_reflect is njit-ed without bounds checking, so a kernel wider than the
+    # image reads off the end and returns quietly wrong maps rather than raising
     if any(pad >= length for pad, length in zip(kernel.shape, clipped.shape)):
         msg = (
             f"A {kernel.shape} kernel does not fit the {clipped.shape} image it "
@@ -316,10 +301,8 @@ def robust_bane(
 ) -> tuple[NDArray[np.float32], NDArray[np.float32]]:
     """Background and RMS maps of a single image plane.
 
-    Sources bias a local average, so they are clipped against a first-pass RMS
-    and refilled with noise before the convolution that measures the background.
-    The work happens on the downsampled image and is zoomed back up, which is
-    where the speed over a per-pixel box comes from.
+    Two passes: the first clips sources against one background and noise for the
+    plane, the second against the maps the first produced.
 
     Args:
         image (NDArray[np.float32]): The image plane to measure
@@ -344,16 +327,13 @@ def robust_bane(
     filled = np.where(nan_mask, 0.0, image).astype(np.float32)
     finite = image[~nan_mask].ravel()
 
-    # First pass finds the sources against one background and noise for the
-    # whole plane, which is all there is to go on before a map exists. The
-    # median matters: testing |image| rather than |image - background| makes
-    # every pixel a source as soon as the plane carries any DC offset.
+    # The median matters: testing |image| rather than |image - background| makes
+    # every pixel a source as soon as the plane carries a DC offset
     background = np.full_like(filled, float(np.median(finite)))
     rms = np.full_like(filled, float(rms_estimator(finite)))
 
-    # Second pass repeats the cut against those maps. A linmos mosaic's noise
-    # rises with the primary beam, so a single threshold clips real noise at the
-    # edge while missing faint sources in the middle.
+    # A mosaic's noise rises with the primary beam, so one threshold clips real
+    # noise at the edge while missing faint sources in the middle
     rng = np.random.default_rng(fft_bane_options.seed)
     for round_number in (1, 2):
         background, rms = _bane_round(
@@ -381,9 +361,8 @@ def bane_fits_image(
 ) -> BANEMaps:
     """Write the background and RMS maps of a single-plane FITS image.
 
-    Named ``_bkg.fits`` and ``_rms.fits`` beside the input, matching what the
-    aegean BANE produces (see ``flint.naming.create_aegean_names``) so the two
-    are interchangeable downstream.
+    Named ``_bkg.fits`` and ``_rms.fits`` beside the input, as the aegean BANE
+    names them, so the two are interchangeable downstream.
 
     Args:
         image (Path): Single-plane FITS image to measure
@@ -395,9 +374,8 @@ def bane_fits_image(
     logger.info(f"Running FFT BANE on {image}")
     with fits.open(image, memmap=True, mode="denywrite") as hdul:
         header = hdul[0].header
-        # Squeezed rather than indexed: a linmos plane carries degenerate
-        # Stokes/frequency axes that robust_bane has no use for, but the maps
-        # are written back with them so they stack like the image they came from
+        # A linmos plane carries degenerate Stokes/frequency axes; the maps are
+        # written back with them so they stack like the image they came from
         original_shape = hdul[0].data.shape
         data = np.squeeze(hdul[0].data).astype(np.float32)
 
@@ -411,8 +389,7 @@ def bane_fits_image(
 
     names = create_aegean_names(base_output=str(image.parent / image.stem))
     for data_out, path in ((background, names.bkg_image), (rms, names.rms_image)):
-        # The input header, so the maps land on the input's pixel grid and can
-        # be stacked into a cube alongside it
+        # The input header, so the maps stay on its pixel grid
         fits.writeto(path, data_out.reshape(original_shape), header, overwrite=True)
         logger.info(f"Wrote {path}")
 

--- a/flint/configuration.py
+++ b/flint/configuration.py
@@ -21,6 +21,7 @@ from flint.misc.holo import ConcatHoloOptions
 from flint.naming import add_timestamp_to_path
 from flint.options import (
     ArchiveOptions,
+    FFTBANEOptions,
     FitsCubeOptions,
     RMCleanOptions,
     RMSynthOptions,
@@ -54,6 +55,8 @@ MODE_OPTIONS_MAPPING = {
     "tukeytractor": TukeyTractorOptions,
     "rmsynth": RMSynthOptions,
     "rmclean": RMCleanOptions,
+    # "bane" is the containerised aegean BANE; this is the FFT one in flint.bane
+    "fftbane": FFTBANEOptions,
     "concatholo": ConcatHoloOptions,
     "spice": SpiceOptions,
 }

--- a/flint/options.py
+++ b/flint/options.py
@@ -231,7 +231,7 @@ class PolFieldOptions(BaseOptions):
     pb_cutoff: float = 0.1
     """Primary beam attenuation cutoff to use during linmos"""
     bane_noise: FFTBANEOptions | None = None
-    """Opt in to measuring a background and RMS cube off the co-added planes with BANE (see ``flint.bane``). These describe the natural-resolution cubes this stage archives. None, the default, skips it. Independent of ``RMSynthFieldOptions.bane_noise``, which is the one the FDF noise comes from"""
+    """Measure a background and RMS cube off the co-added planes with BANE. Off by default, and independent of ``RMSynthFieldOptions.bane_noise``"""
     imaging_strategy: Path | None = None
     """Path to a FLINT imaging yaml file that contains settings to use throughout imaging"""
     pol_cube_channel_width: float | None = None
@@ -241,13 +241,8 @@ class PolFieldOptions(BaseOptions):
 
 
 class FFTBANEOptions(BaseOptions):
-    """Options for ``flint.bane.robust_bane``. Named apart from
-    ``flint.source_finding.aegean.BANEOptions``, which drives the containerised
-    aegean BANE instead.
-
-    Defined here rather than in ``flint.bane`` so that strategy validation
-    (``flint.configuration``) does not pull in numba, as ``RMSynthOptions`` does
-    for rm_lite."""
+    """Options for ``flint.bane.robust_bane``. Lives here, not in ``flint.bane``,
+    so strategy validation does not pull in numba"""
 
     step_size: int | None = None
     """Downsampling factor in pixels. None uses 3 beams; a negative value sets the beams per step"""
@@ -256,31 +251,22 @@ class FFTBANEOptions(BaseOptions):
     clip_sigma: float = 5.0
     """Pixels above this SNR are replaced by noise before the background is fitted"""
     seed: int = 1234
-    """Seed for the noise the clipped pixels are filled with, so a rerun reproduces the maps"""
+    """Seeds the noise clipped pixels are filled with, so a rerun reproduces the maps"""
 
 
 class _StokesTrio(BaseOptions):
-    """One path per Stokes, shared by the containers below.
-
-    Never annotate with this directly: the whole point of the three concrete
-    types is that a cube cannot be mistaken for a noise or a weight, and a base
-    they all satisfy would let exactly that through.
-    """
+    """One path per Stokes. Never annotate with this: the types below exist to be told apart"""
 
     q: Path
     """Stokes Q"""
     u: Path
     """Stokes U"""
     i: Path | None = None
-    """Stokes I. Optional throughout: rm-synthesis runs without the fractional-polarisation correction"""
+    """Stokes I, optional: rm-synthesis runs without it"""
 
     @classmethod
     def from_mapping(cls, cubes: Mapping[str, Path]) -> Self:
-        """From a per-Stokes dict, as the polarisation stage keys them.
-
-        Anything but q/u/i is dropped, and a missing q or u is refused here
-        rather than surfacing as a KeyError from the call site.
-        """
+        """From a per-Stokes dict, dropping anything but q/u/i"""
         missing = {"q", "u"} - cubes.keys()
         if missing:
             msg = f"Need a cube for every one of q and u, missing {sorted(missing)}."
@@ -289,36 +275,33 @@ class _StokesTrio(BaseOptions):
 
     @property
     def paths(self) -> list[Path]:
-        """Every path set, for callers that only validate or clean them up"""
+        """Every path set"""
         return [path for path in (self.q, self.u, self.i) if path is not None]
 
 
 class StokesCubes(_StokesTrio):
-    """The Stokes image cubes rm-synthesis reads"""
+    """The Stokes image cubes"""
 
 
 class StokesWeightCubes(_StokesTrio):
-    """Per-pixel inverse variance, 1/sigma**2, as linmos writes it"""
+    """Inverse variance, 1/sigma**2, as linmos writes it"""
 
     kind: Literal["weight"] = "weight"
-    """Discriminates the union below. Never set it by hand"""
+    """Union discriminator"""
 
 
 class StokesNoiseCubes(_StokesTrio):
-    """Per-pixel noise, sigma, as BANE measures it"""
+    """Noise, sigma, as BANE measures it"""
 
     kind: Literal["noise"] = "noise"
-    """Discriminates the union below. Never set it by hand"""
+    """Union discriminator"""
 
 
 StokesErrorCubes: TypeAlias = Annotated[
     StokesWeightCubes | StokesNoiseCubes, Field(discriminator="kind")
 ]
-"""The error cubes rm-synthesis weights by: an inverse variance or a noise, never
-both and never something ambiguous. rm-lite takes either through one argument and
-is told which by a flag, so mixing them inverts the noise by 1/sigma**2. The
-discriminator is what keeps that straight across a serialisation round trip, which
-prefect does to every task input."""
+"""A weight or a noise, never both. Confusing them inverts the noise by 1/sigma**2,
+so the tag keeps them apart across the serialisation prefect does to task inputs."""
 
 
 class RMSynthOptions(BaseOptions):
@@ -434,11 +417,11 @@ class RMSynthFieldOptions(BaseOptions):
     than exposed here."""
 
     stokes_cubes: StokesCubes | None = None
-    """The Stokes Q/U (and optionally I) FITS cubes. Computed by the racs-all flow, so required only when running this pipeline standalone"""
+    """The Stokes cubes. Set by the racs-all flow"""
     error_cubes: StokesErrorCubes | None = None
-    """The linmos weight cubes or a set of noise cubes, never both: see ``StokesErrorCubes``. None leaves rm-lite to estimate a per-channel noise from Q/U itself. Superseded by ``bane_noise``, which measures the noise at the resolution the FDF is built at"""
+    """Weight or noise cubes, never both. None lets rm-lite estimate from Q/U itself"""
     bane_noise: FFTBANEOptions | None = None
-    """Opt in to measuring BANE background and RMS cubes off the common-resolution cubes this stage writes, and using the RMS for the FDF noise (see ``flint.bane``). Measured after the convolution, so they describe the resolution the FDF is built at and supersede ``error_cubes``, which describe the unconvolved inputs. None, the default, falls back to whatever cubes the caller passed"""
+    """Measure BANE cubes off the common-resolution cubes and take the FDF noise from the RMS. Supersedes ``error_cubes``, which describe the unconvolved inputs"""
     imaging_strategy: Path | None = None
     """Path to a FLINT imaging yaml file that contains the RMSynthOptions/RMCleanOptions settings to use"""
     beam_cutoff: float | None = None

--- a/flint/options.py
+++ b/flint/options.py
@@ -229,12 +229,33 @@ class PolFieldOptions(BaseOptions):
     """Specify the final beamsize of linmos field images in (arcsec, arcsec, deg)"""
     pb_cutoff: float = 0.1
     """Primary beam attenuation cutoff to use during linmos"""
+    bane_noise: FFTBANEOptions | None = None
+    """Measure a background and RMS cube off the co-added planes with BANE (see ``flint.bane``). None skips it, leaving the linmos weight cubes as the only noise estimate"""
     imaging_strategy: Path | None = None
     """Path to a FLINT imaging yaml file that contains settings to use throughout imaging"""
     pol_cube_channel_width: float | None = None
     """Desired width, in Hz, of each plane of the polarisation cubes. The wsclean channel division is solved for this target so the cubes have a single linear frequency axis, overriding the strategy ``channels_out``. Deliberately separate from ``RACSAllOptions.cube_channel_width``, as the continuum and polarisation cubes need not share a channelisation. See ``flint.imager.channel_division``"""
     sbid_copy_path: Path | None = None
     """Path that final processed products will be copied into. If None no copying of file products is performed. See ArchiveOptions. """
+
+
+class FFTBANEOptions(BaseOptions):
+    """Options for ``flint.bane.robust_bane``. Named apart from
+    ``flint.source_finding.aegean.BANEOptions``, which drives the containerised
+    aegean BANE instead.
+
+    Defined here rather than in ``flint.bane`` so that strategy validation
+    (``flint.configuration``) does not pull in numba, as ``RMSynthOptions`` does
+    for rm_lite."""
+
+    step_size: int | None = None
+    """Downsampling factor in pixels. None uses 3 beams; a negative value sets the beams per step"""
+    box_size: int | None = None
+    """Convolution kernel size in pixels. None uses 10 beams; a negative value sets the beams per box"""
+    clip_sigma: float = 5.0
+    """Pixels above this SNR are replaced by noise before the background is fitted"""
+    seed: int = 1234
+    """Seed for the noise the clipped pixels are filled with, so a rerun reproduces the maps"""
 
 
 class RMSynthOptions(BaseOptions):
@@ -361,6 +382,12 @@ class RMSynthFieldOptions(BaseOptions):
     """Path to Stokes U weights cube produced by LINMOS"""
     stokes_i_weight_cube: Path | None = None
     """Path to Stokes I weights cube produced by LINMOS"""
+    stokes_q_noise_cube: Path | None = None
+    """Path to a Stokes Q noise (sigma) cube, e.g. the BANE RMS cube from the polarisation stage. Takes precedence over ``stokes_q_weight_cube``, which is an inverse variance rather than a noise"""
+    stokes_u_noise_cube: Path | None = None
+    """Path to a Stokes U noise (sigma) cube. See ``stokes_q_noise_cube``"""
+    stokes_i_noise_cube: Path | None = None
+    """Path to a Stokes I noise (sigma) cube. See ``stokes_q_noise_cube``"""
     imaging_strategy: Path | None = None
     """Path to a FLINT imaging yaml file that contains the RMSynthOptions/RMCleanOptions settings to use"""
     beam_cutoff: float | None = None
@@ -386,7 +413,7 @@ class SpiceFieldOptions(BaseOptions):
     cubes: list[Path] = []
     """Stokes image cubes to trim and compress. Computed by the racs-all flow, so required only when running this pipeline standalone"""
     weight_cubes: list[Path] = []
-    """LINMOS weight cubes to trim and compress alongside ``cubes``, spiced with the same boxes so they stay on a matching grid. Computed by the racs-all flow"""
+    """Ancillary cubes to trim and compress alongside ``cubes``, spiced with the same boxes so they stay on a matching grid: the LINMOS weight cubes, and the BANE background/RMS cubes when the polarisation stage made them. Computed by the racs-all flow"""
     reference_image: Path | None = None
     """A 2D MFS image whose WCS/shape sources the source-finding boxes. Required only when catalogue is not set (built-in aegean source finding)"""
     catalogue: Path | None = None

--- a/flint/options.py
+++ b/flint/options.py
@@ -261,11 +261,11 @@ class _CubesForRMSynth(BaseOptions):
     Never annotate with this: the types below exist to be told apart.
     """
 
-    q: Path
+    q_path: Path
     """Stokes Q"""
-    u: Path
+    u_path: Path
     """Stokes U"""
-    i: Path | None = None
+    i_path: Path | None = None
     """Stokes I, optional: rm-synthesis runs without it"""
 
     @classmethod
@@ -275,12 +275,14 @@ class _CubesForRMSynth(BaseOptions):
         if missing:
             msg = f"Need a cube for every one of q and u, missing {sorted(missing)}."
             raise ValueError(msg)
-        return cls(q=cubes["q"], u=cubes["u"], i=cubes.get("i"))
+        return cls(q_path=cubes["q"], u_path=cubes["u"], i_path=cubes.get("i"))
 
     @property
     def paths(self) -> list[Path]:
         """Every path set"""
-        return [path for path in (self.q, self.u, self.i) if path is not None]
+        return [
+            path for path in (self.q_path, self.u_path, self.i_path) if path is not None
+        ]
 
 
 class CubesForRMSynth(_CubesForRMSynth):

--- a/flint/options.py
+++ b/flint/options.py
@@ -230,7 +230,7 @@ class PolFieldOptions(BaseOptions):
     pb_cutoff: float = 0.1
     """Primary beam attenuation cutoff to use during linmos"""
     bane_noise: FFTBANEOptions | None = None
-    """Measure a background and RMS cube off the co-added planes with BANE (see ``flint.bane``). None skips it, leaving the linmos weight cubes as the only noise estimate"""
+    """Opt in to measuring a background and RMS cube off the co-added planes with BANE (see ``flint.bane``). These describe the natural-resolution cubes this stage archives. None, the default, skips it. Independent of ``RMSynthFieldOptions.bane_noise``, which is the one the FDF noise comes from"""
     imaging_strategy: Path | None = None
     """Path to a FLINT imaging yaml file that contains settings to use throughout imaging"""
     pol_cube_channel_width: float | None = None
@@ -388,6 +388,8 @@ class RMSynthFieldOptions(BaseOptions):
     """Path to a Stokes U noise (sigma) cube. See ``stokes_q_noise_cube``"""
     stokes_i_noise_cube: Path | None = None
     """Path to a Stokes I noise (sigma) cube. See ``stokes_q_noise_cube``"""
+    bane_noise: FFTBANEOptions | None = None
+    """Opt in to measuring BANE background and RMS cubes off the common-resolution cubes this stage writes, and using the RMS for the FDF noise (see ``flint.bane``). Measured after the convolution, so they describe the resolution the FDF is built at and supersede ``stokes_*_noise_cube``, which describe the unconvolved inputs. None, the default, falls back to whatever cubes the caller passed"""
     imaging_strategy: Path | None = None
     """Path to a FLINT imaging yaml file that contains the RMSynthOptions/RMCleanOptions settings to use"""
     beam_cutoff: float | None = None

--- a/flint/options.py
+++ b/flint/options.py
@@ -254,8 +254,12 @@ class FFTBANEOptions(BaseOptions):
     """Seeds the noise clipped pixels are filled with, so a rerun reproduces the maps"""
 
 
-class _StokesTrio(BaseOptions):
-    """One path per Stokes. Never annotate with this: the types below exist to be told apart"""
+class _CubesForRMSynth(BaseOptions):
+    """The Stokes RM-synthesis reads: Q and U, and I for the fractional
+    correction. No V, which has no part in a Faraday spectrum.
+
+    Never annotate with this: the types below exist to be told apart.
+    """
 
     q: Path
     """Stokes Q"""
@@ -279,26 +283,26 @@ class _StokesTrio(BaseOptions):
         return [path for path in (self.q, self.u, self.i) if path is not None]
 
 
-class StokesCubes(_StokesTrio):
+class CubesForRMSynth(_CubesForRMSynth):
     """The Stokes image cubes"""
 
 
-class StokesWeightCubes(_StokesTrio):
+class WeightCubesForRMSynth(_CubesForRMSynth):
     """Inverse variance, 1/sigma**2, as linmos writes it"""
 
     kind: Literal["weight"] = "weight"
     """Union discriminator"""
 
 
-class StokesNoiseCubes(_StokesTrio):
+class NoiseCubesForRMSynth(_CubesForRMSynth):
     """Noise, sigma, as BANE measures it"""
 
     kind: Literal["noise"] = "noise"
     """Union discriminator"""
 
 
-StokesErrorCubes: TypeAlias = Annotated[
-    StokesWeightCubes | StokesNoiseCubes, Field(discriminator="kind")
+ErrorCubesForRMSynth: TypeAlias = Annotated[
+    WeightCubesForRMSynth | NoiseCubesForRMSynth, Field(discriminator="kind")
 ]
 """A weight or a noise, never both. Confusing them inverts the noise by 1/sigma**2,
 so the tag keeps them apart across the serialisation prefect does to task inputs."""
@@ -416,9 +420,9 @@ class RMSynthFieldOptions(BaseOptions):
     algorithm parameters, which are drawn from ``imaging_strategy`` rather
     than exposed here."""
 
-    stokes_cubes: StokesCubes | None = None
+    stokes_cubes: CubesForRMSynth | None = None
     """The Stokes cubes. Set by the racs-all flow"""
-    error_cubes: StokesErrorCubes | None = None
+    error_cubes: ErrorCubesForRMSynth | None = None
     """Weight or noise cubes, never both. None lets rm-lite estimate from Q/U itself"""
     bane_noise: FFTBANEOptions | None = None
     """Measure BANE cubes off the common-resolution cubes and take the FDF noise from the RMS. Supersedes ``error_cubes``, which describe the unconvolved inputs"""

--- a/flint/options.py
+++ b/flint/options.py
@@ -353,10 +353,6 @@ class RMSynthOptions(BaseOptions):
     per_pixel_rmsf: bool = False
     """Compute the RMSF for each pixel rather than one shared by the cube. Roughly doubles the FDF's size. rm-lite turns this on itself when the weights make pixels disagree, as the linmos weight cubes do"""
     estimate_stokes_i_noise: bool = True
-    moment_threshold_snr: float = 5.0
-    """SNR cut (times the theoretical FDF noise) applied before computing Faraday moment maps, the dirty ones included"""
-    peak_threshold_snr: float = 0.0
-    """SNR cut (times the theoretical FDF noise) below which FDF peak statistics are blanked. Zero applies no cut: a peak is a single sample with no noise floor to integrate, and peak_pi_error is written beside it"""
     """Derive the per-channel Stokes I error from the Stokes I cube when no Stokes I weight cube is given. A weight cube takes precedence"""
 
 
@@ -436,6 +432,10 @@ class RMSynthFieldOptions(BaseOptions):
     """Which Faraday dispersion function (FDF) cubes to write as FITS. Nothing by default, as these cubes can be large."""
     moment_products: list[Literal["dirty", "clean", "model"]] = ["clean"]
     """Which FDF(s) to compute Faraday moment maps from."""
+    moment_threshold_snr: float = 5.0
+    """SNR cut (times the theoretical FDF noise) applied before the moment maps are computed, the dirty ones included"""
+    peak_threshold_snr: float = 0.0
+    """SNR cut (times the theoretical FDF noise) below which peak statistics are blanked. Zero applies no cut: a peak is a single sample with no noise floor to integrate, and peak_pi_error is written beside it"""
     peak_products: list[Literal["dirty", "clean", "model"]] = []
     """Which FDF(s) to measure peak statistics from: peak polarised intensity (raw and debiased), Faraday depth, polarisation angle and intrinsic angle, each with its error. Nine (ny, nx) maps per FDF, so empty by default -- at 16032^2 that is ~9 GB per entry"""
     output_path: Path | None = None

--- a/flint/options.py
+++ b/flint/options.py
@@ -230,8 +230,8 @@ class PolFieldOptions(BaseOptions):
     """Specify the final beamsize of linmos field images in (arcsec, arcsec, deg)"""
     pb_cutoff: float = 0.1
     """Primary beam attenuation cutoff to use during linmos"""
-    bane_noise: FFTBANEOptions | None = None
-    """Measure a background and RMS cube off the co-added planes with BANE. Off by default, and independent of ``RMSynthFieldOptions.bane_noise``"""
+    bane_noise: bool = False
+    """Measure a background and RMS cube off the co-added planes with BANE. Parameters come from the strategy's ``fftbane`` mode. Independent of ``RMSynthFieldOptions.bane_noise``"""
     imaging_strategy: Path | None = None
     """Path to a FLINT imaging yaml file that contains settings to use throughout imaging"""
     pol_cube_channel_width: float | None = None
@@ -426,8 +426,8 @@ class RMSynthFieldOptions(BaseOptions):
     """The Stokes cubes. Set by the racs-all flow"""
     error_cubes: ErrorCubesForRMSynth | None = None
     """Weight or noise cubes, never both. None lets rm-lite estimate from Q/U itself"""
-    bane_noise: FFTBANEOptions | None = None
-    """Measure BANE cubes off the common-resolution cubes and take the FDF noise from the RMS. Supersedes ``error_cubes``, which describe the unconvolved inputs"""
+    bane_noise: bool = False
+    """Measure BANE cubes off the common-resolution cubes and take the FDF noise from the RMS. Parameters come from the strategy's ``fftbane`` mode. Supersedes ``error_cubes``, which describe the unconvolved inputs"""
     imaging_strategy: Path | None = None
     """Path to a FLINT imaging yaml file that contains the RMSynthOptions/RMCleanOptions settings to use"""
     beam_cutoff: float | None = None

--- a/flint/options.py
+++ b/flint/options.py
@@ -9,15 +9,16 @@ hold stateful properties throughout the flint codebase.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from pathlib import Path
-from typing import Literal, Protocol
+from typing import Annotated, Literal, Protocol, Self, TypeAlias
 
 import numpy as np
 import yaml
 from astropy.coordinates import EarthLocation, SkyCoord
 from astropy.time import Time
 from capn_crunch import BaseOptions
-from pydantic import create_model
+from pydantic import Field, create_model
 
 from flint.exceptions import MSError
 from flint.logging import logger
@@ -258,6 +259,68 @@ class FFTBANEOptions(BaseOptions):
     """Seed for the noise the clipped pixels are filled with, so a rerun reproduces the maps"""
 
 
+class _StokesTrio(BaseOptions):
+    """One path per Stokes, shared by the containers below.
+
+    Never annotate with this directly: the whole point of the three concrete
+    types is that a cube cannot be mistaken for a noise or a weight, and a base
+    they all satisfy would let exactly that through.
+    """
+
+    q: Path
+    """Stokes Q"""
+    u: Path
+    """Stokes U"""
+    i: Path | None = None
+    """Stokes I. Optional throughout: rm-synthesis runs without the fractional-polarisation correction"""
+
+    @classmethod
+    def from_mapping(cls, cubes: Mapping[str, Path]) -> Self:
+        """From a per-Stokes dict, as the polarisation stage keys them.
+
+        Anything but q/u/i is dropped, and a missing q or u is refused here
+        rather than surfacing as a KeyError from the call site.
+        """
+        missing = {"q", "u"} - cubes.keys()
+        if missing:
+            msg = f"Need a cube for every one of q and u, missing {sorted(missing)}."
+            raise ValueError(msg)
+        return cls(q=cubes["q"], u=cubes["u"], i=cubes.get("i"))
+
+    @property
+    def paths(self) -> list[Path]:
+        """Every path set, for callers that only validate or clean them up"""
+        return [path for path in (self.q, self.u, self.i) if path is not None]
+
+
+class StokesCubes(_StokesTrio):
+    """The Stokes image cubes rm-synthesis reads"""
+
+
+class StokesWeightCubes(_StokesTrio):
+    """Per-pixel inverse variance, 1/sigma**2, as linmos writes it"""
+
+    kind: Literal["weight"] = "weight"
+    """Discriminates the union below. Never set it by hand"""
+
+
+class StokesNoiseCubes(_StokesTrio):
+    """Per-pixel noise, sigma, as BANE measures it"""
+
+    kind: Literal["noise"] = "noise"
+    """Discriminates the union below. Never set it by hand"""
+
+
+StokesErrorCubes: TypeAlias = Annotated[
+    StokesWeightCubes | StokesNoiseCubes, Field(discriminator="kind")
+]
+"""The error cubes rm-synthesis weights by: an inverse variance or a noise, never
+both and never something ambiguous. rm-lite takes either through one argument and
+is told which by a flag, so mixing them inverts the noise by 1/sigma**2. The
+discriminator is what keeps that straight across a serialisation round trip, which
+prefect does to every task input."""
+
+
 class RMSynthOptions(BaseOptions):
     """Options controlling ``rm_lite.tools_3d.rmsynth.rmsynth_3d_from_fits``.
 
@@ -370,26 +433,12 @@ class RMSynthFieldOptions(BaseOptions):
     algorithm parameters, which are drawn from ``imaging_strategy`` rather
     than exposed here."""
 
-    stokes_q_cube: Path | None = None
-    """Path to the Stokes Q FITS cube. Computed by the racs-all flow, so required only when running this pipeline standalone"""
-    stokes_u_cube: Path | None = None
-    """Path to the Stokes U FITS cube. Computed by the racs-all flow, so required only when running this pipeline standalone"""
-    stokes_i_cube: Path | None = None
-    """Path to a Stokes I FITS cube, used to fit a per-pixel fractional-polarisation correction. Defaults to None."""
-    stokes_q_weight_cube: Path | None = None
-    """Path to Stokes Q weights cube produced by LINMOS"""
-    stokes_u_weight_cube: Path | None = None
-    """Path to Stokes U weights cube produced by LINMOS"""
-    stokes_i_weight_cube: Path | None = None
-    """Path to Stokes I weights cube produced by LINMOS"""
-    stokes_q_noise_cube: Path | None = None
-    """Path to a Stokes Q noise (sigma) cube, e.g. the BANE RMS cube from the polarisation stage. Takes precedence over ``stokes_q_weight_cube``, which is an inverse variance rather than a noise"""
-    stokes_u_noise_cube: Path | None = None
-    """Path to a Stokes U noise (sigma) cube. See ``stokes_q_noise_cube``"""
-    stokes_i_noise_cube: Path | None = None
-    """Path to a Stokes I noise (sigma) cube. See ``stokes_q_noise_cube``"""
+    stokes_cubes: StokesCubes | None = None
+    """The Stokes Q/U (and optionally I) FITS cubes. Computed by the racs-all flow, so required only when running this pipeline standalone"""
+    error_cubes: StokesErrorCubes | None = None
+    """The linmos weight cubes or a set of noise cubes, never both: see ``StokesErrorCubes``. None leaves rm-lite to estimate a per-channel noise from Q/U itself. Superseded by ``bane_noise``, which measures the noise at the resolution the FDF is built at"""
     bane_noise: FFTBANEOptions | None = None
-    """Opt in to measuring BANE background and RMS cubes off the common-resolution cubes this stage writes, and using the RMS for the FDF noise (see ``flint.bane``). Measured after the convolution, so they describe the resolution the FDF is built at and supersede ``stokes_*_noise_cube``, which describe the unconvolved inputs. None, the default, falls back to whatever cubes the caller passed"""
+    """Opt in to measuring BANE background and RMS cubes off the common-resolution cubes this stage writes, and using the RMS for the FDF noise (see ``flint.bane``). Measured after the convolution, so they describe the resolution the FDF is built at and supersede ``error_cubes``, which describe the unconvolved inputs. None, the default, falls back to whatever cubes the caller passed"""
     imaging_strategy: Path | None = None
     """Path to a FLINT imaging yaml file that contains the RMSynthOptions/RMCleanOptions settings to use"""
     beam_cutoff: float | None = None

--- a/flint/options.py
+++ b/flint/options.py
@@ -353,6 +353,10 @@ class RMSynthOptions(BaseOptions):
     per_pixel_rmsf: bool = False
     """Compute the RMSF for each pixel rather than one shared by the cube. Roughly doubles the FDF's size. rm-lite turns this on itself when the weights make pixels disagree, as the linmos weight cubes do"""
     estimate_stokes_i_noise: bool = True
+    moment_threshold_snr: float = 5.0
+    """SNR cut (times the theoretical FDF noise) applied before computing Faraday moment maps, the dirty ones included"""
+    peak_threshold_snr: float = 0.0
+    """SNR cut (times the theoretical FDF noise) below which FDF peak statistics are blanked. Zero applies no cut: a peak is a single sample with no noise floor to integrate, and peak_pi_error is written beside it"""
     """Derive the per-channel Stokes I error from the Stokes I cube when no Stokes I weight cube is given. A weight cube takes precedence"""
 
 
@@ -369,10 +373,6 @@ class RMCleanOptions(BaseOptions):
     """Maximum CLEAN iterations"""
     gain: float = 0.1
     """CLEAN loop gain"""
-    moment_threshold_snr: float = 5.0
-    """SNR cut (times the theoretical FDF noise) applied before computing Faraday moment maps, the dirty ones included"""
-    peak_threshold_snr: float = 0.0
-    """SNR cut (times the theoretical FDF noise) below which FDF peak statistics are blanked. Zero applies no cut: unlike mom0, a peak is a single sample with no noise floor to integrate, and peak_pi_error is written beside it to judge significance downstream"""
 
 
 class SpiceOptions(BaseOptions):

--- a/flint/prefect/common/imaging.py
+++ b/flint/prefect/common/imaging.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from collections.abc import Collection, Sequence
 from pathlib import Path
-from typing import Any, ParamSpec, TypeVar
+from typing import Any, NamedTuple, ParamSpec, TypeVar
 
 import numpy as np
 import pandas as pd
@@ -17,6 +17,7 @@ from prefect import Task, unmapped
 from prefect.artifacts import create_table_artifact
 from prefect.futures import PrefectFuture
 
+from flint.bane import FFTBANEOptions, bane_fits_image
 from flint.calibrate.aocalibrate import (
     ApplySolutions,
     CalibrateCommand,
@@ -111,6 +112,7 @@ task_create_name_from_common_fields = task(create_name_from_common_fields)
 task_remove_files_folders = task(remove_files_folders)
 task_get_common_bounding_box = task(get_common_bounding_box)
 task_split_cube_into_planes = task(split_cube_into_planes)
+task_bane_fits_image = task(bane_fits_image)
 
 # Tasks below are extracting componented from earlier stages, or are
 # otherwise doing something important
@@ -986,6 +988,24 @@ def task_convolve_linmos_to_fixed_shape(
     return linmos_result.with_options(image_fits=output_image_path)
 
 
+class LinmosCubes(NamedTuple):
+    """The cubes ``linmos_channel_groups_to_cubes`` builds from one Stokes"""
+
+    image: PrefectFuture[Path]
+    """The co-added image cube"""
+    weight: PrefectFuture[Path]
+    """The linmos weight cube"""
+    bkg: PrefectFuture[Path] | None = None
+    """Background cube, None unless BANE was asked for"""
+    rms: PrefectFuture[Path] | None = None
+    """RMS noise cube, None unless BANE was asked for"""
+
+    @property
+    def futures(self) -> list[PrefectFuture[Path]]:
+        """Every cube actually being made, for callers that only need to wait"""
+        return [future for future in self if future is not None]
+
+
 def linmos_channel_groups_to_cubes(
     channel_groups: Collection[Collection[Path]],
     container: Path,
@@ -995,7 +1015,8 @@ def linmos_channel_groups_to_cubes(
     field_summary: FieldSummary | None = None,
     suffix_str: str | None = None,
     holofile: Path | None = None,
-) -> list[PrefectFuture[Path]]:
+    fft_bane_options: FFTBANEOptions | None = None,
+) -> LinmosCubes:
     """Co-add beam images one channel at a time, in parallel, then stack the
     resulting mosaics back into image and weight cubes.
 
@@ -1013,9 +1034,10 @@ def linmos_channel_groups_to_cubes(
         field_summary (FieldSummary | None, optional): Description of the field, used to get the ``pol_axis``. Defaults to None.
         suffix_str (str | None, optional): Additional suffix added to the linmos and cube names. Defaults to None.
         holofile (Path | None, optional): Holography file overriding the one in ``linmos_options``. Defaults to None.
+        fft_bane_options (FFTBANEOptions | None, optional): When given, each co-added channel also gets a BANE background and RMS map, stacked into their own cubes. Defaults to None, i.e. no BANE.
 
     Returns:
-        list[PrefectFuture[Path]]: The image and weight cubes being created
+        LinmosCubes: The cubes being created
     """
     stokesi_groups = (
         list(stokesi_channel_groups) if stokesi_channel_groups is not None else None
@@ -1027,6 +1049,8 @@ def linmos_channel_groups_to_cubes(
 
     image_planes: list[PrefectFuture[Path]] = []
     weight_planes: list[PrefectFuture[Path]] = []
+    bkg_planes: list[PrefectFuture[Path]] = []
+    rms_planes: list[PrefectFuture[Path]] = []
     for channel_idx, beam_images in enumerate(channel_groups):
         linmos_result = task_linmos_images.submit(
             image_list=list(beam_images),
@@ -1048,6 +1072,15 @@ def linmos_channel_groups_to_cubes(
         image_planes.append(image_plane)
         weight_planes.append(weight_plane)
 
+        if fft_bane_options is not None:
+            # One task per channel, so every plane's background and noise is
+            # measured across the cluster while the other channels co-add
+            bane_maps = task_bane_fits_image.submit(
+                image=image_plane, fft_bane_options=fft_bane_options
+            )
+            bkg_planes.append(task_getattr.submit(bane_maps, "bkg_image"))
+            rms_planes.append(task_getattr.submit(bane_maps, "rms_image"))
+
     bounding_box: bool | PrefectFuture[BoundingBox] = False
     if fitscube_options.bounding_box:
         # Passing the future in is what forms the barrier - every channel has to
@@ -1062,16 +1095,28 @@ def linmos_channel_groups_to_cubes(
     cube_prefix = task_create_name_from_common_fields.submit(
         in_paths=image_planes, additional_suffixes=suffix_str
     )
-    return [
-        task_combine_images_to_cube.submit(
+    cubes = {
+        mode: task_combine_images_to_cube.submit(
             images=planes,
             prefix=cube_prefix,
             mode=mode,
             fitscube_options=fitscube_options,
             bounding_box=bounding_box,
         )
-        for planes, mode in ((image_planes, "image"), (weight_planes, "weight"))
-    ]
+        for planes, mode in (
+            (image_planes, "image"),
+            (weight_planes, "weight"),
+            (bkg_planes, "bkg"),
+            (rms_planes, "rms"),
+        )
+        if planes
+    }
+    return LinmosCubes(
+        image=cubes["image"],
+        weight=cubes["weight"],
+        bkg=cubes.get("bkg"),
+        rms=cubes.get("rms"),
+    )
 
 
 def create_convolve_linmos_cubes(
@@ -1123,7 +1168,7 @@ def create_convolve_linmos_cubes(
         fitscube_options=fitscube_options,
         suffix_str=linmos_suffix_str,
         holofile=holofile,
-    )
+    ).futures
 
     # Remove the convolved planes once every cube has been formed
     task_remove_files_folders.submit(

--- a/flint/prefect/common/rmsynth.py
+++ b/flint/prefect/common/rmsynth.py
@@ -8,14 +8,23 @@ that actually import this module.
 from __future__ import annotations
 
 from pathlib import Path
+from typing import NamedTuple
 
 from prefect import unmapped
+from prefect.futures import PrefectFuture
 
+from flint.bane import BANEMaps
 from flint.convol import BeamShape, convolve_plane_to_beam
 from flint.logging import logger
-from flint.options import FitsCubeOptions, RMCleanOptions, RMSynthOptions
+from flint.options import (
+    FFTBANEOptions,
+    FitsCubeOptions,
+    RMCleanOptions,
+    RMSynthOptions,
+)
 from flint.prefect.caching import task
 from flint.prefect.common.imaging import (
+    task_bane_fits_image,
     task_combine_images_to_cube,
     task_remove_files_folders,
     task_split_cube_into_planes,
@@ -32,13 +41,38 @@ from flint.rmsynth import (
 task_convolve_plane_to_beam = task(convolve_plane_to_beam)
 
 
+class CommonResolutionCubes(NamedTuple):
+    """The cubes ``convolve_cubes_to_common_resolution`` writes, keyed by Stokes"""
+
+    cubes: dict[str, Path]
+    """The cube to use per Stokes: the convolved one, or the input unchanged when ``convolved`` is False"""
+    convolved: bool = False
+    """Whether these are new cubes. False means the inputs already shared a resolution and were used as they are, so nothing new was written"""
+    bkg_cubes: dict[str, Path] = {}
+    """BANE background cube per Stokes, measured on the convolved planes. Empty unless BANE was asked for"""
+    rms_cubes: dict[str, Path] = {}
+    """BANE RMS cube per Stokes, measured on the convolved planes so it describes the resolution the FDF is built at. Empty unless BANE was asked for"""
+
+    @property
+    def all_cubes(self) -> list[Path]:
+        """Every cube written, for the callers that only trim and compress them"""
+        if not self.convolved:
+            return []
+        return [
+            *self.cubes.values(),
+            *self.bkg_cubes.values(),
+            *self.rms_cubes.values(),
+        ]
+
+
 def convolve_cubes_to_common_resolution(
     cubes: dict[str, Path],
     beam_shape: BeamShape,
     output_path: Path | None = None,
     beam_cutoff: float | None = None,
     convol_suffix: str = "conv",
-) -> dict[str, Path]:
+    fft_bane_options: FFTBANEOptions | None = None,
+) -> CommonResolutionCubes:
     """Bring a set of FITS cubes to the one resolution described by
     ``beam_shape``, writing new cubes and leaving the inputs as they are. This is
     the 'total' resolution mode of racs_tools: one beam for every channel of
@@ -56,9 +90,10 @@ def convolve_cubes_to_common_resolution(
         output_path (Path | None, optional): Directory the new cubes are written into. Defaults to alongside each input cube.
         beam_cutoff (float | None, optional): Channels coarser than this, in arcsec, are blanked rather than convolved to. Defaults to no cutoff.
         convol_suffix (str, optional): The marker added to the name of a smoothed plane, and of the cube they are stacked into. Defaults to 'conv'.
+        fft_bane_options (FFTBANEOptions | None, optional): When given, each convolved plane also gets a BANE background and RMS map, stacked into their own cubes. Measured after the convolution, so they describe the resolution rm-synthesis actually builds the FDF at. Defaults to None.
 
     Returns:
-        dict[str, Path]: The convolved cube for each key of ``cubes``
+        CommonResolutionCubes: The convolved cube for each key of ``cubes``, and the BANE cubes when asked for
     """
     fitscube_options = FitsCubeOptions(
         # The weight cubes are not convolved, so the convolved image cubes have
@@ -106,21 +141,56 @@ def convolve_cubes_to_common_resolution(
         convol_suffix=unmapped(convol_suffix),
     ).result()
 
-    cube_futures = {}
+    # Measured on the convolved planes, not the ones they came from: these
+    # describe the resolution rm-synthesis builds the FDF at, which is the whole
+    # point of making them here rather than reusing the polarisation stage's.
+    # Resolved before the cubes are assembled because `fitscube_options` removes
+    # each plane once it has been cubed.
+    bane_maps: list[BANEMaps] = []
+    if fft_bane_options is not None:
+        bane_maps = task_bane_fits_image.map(
+            image=convolved_planes,
+            fft_bane_options=unmapped(fft_bane_options),
+        ).result()
+
+    cube_futures: dict[str, dict[str, PrefectFuture[Path]]] = {
+        mode: {} for mode in (convol_suffix, "bkg", "rms")
+    }
     plane_idx = 0
     for key, planes in planes_per_cube.items():
-        cube_futures[key] = task_combine_images_to_cube.submit(
-            images=convolved_planes[plane_idx : plane_idx + len(planes)],
-            prefix=str(cube_parent[key] / cubes[key].stem),
+        plane_slice = slice(plane_idx, plane_idx + len(planes))
+        prefix = str(cube_parent[key] / cubes[key].stem)
+        cube_futures[convol_suffix][key] = task_combine_images_to_cube.submit(
+            images=convolved_planes[plane_slice],
+            prefix=prefix,
             mode=convol_suffix,
             fitscube_options=fitscube_options,
         )
+        for mode, attribute in (("bkg", "bkg_image"), ("rms", "rms_image")):
+            if bane_maps:
+                cube_futures[mode][key] = task_combine_images_to_cube.submit(
+                    images=[
+                        getattr(maps, attribute) for maps in bane_maps[plane_slice]
+                    ],
+                    prefix=prefix,
+                    mode=f"{convol_suffix}.{mode}",
+                    fitscube_options=fitscube_options,
+                )
         plane_idx += len(planes)
     assert plane_idx == len(convolved_planes), (
         f"Have {len(convolved_planes)} convolved planes across {plane_idx} channels"
     )
 
-    convolved_cubes = {key: future.result() for key, future in cube_futures.items()}
+    resolved = {
+        mode: {key: future.result() for key, future in futures.items()}
+        for mode, futures in cube_futures.items()
+    }
+    convolved_cubes = CommonResolutionCubes(
+        cubes=resolved[convol_suffix],
+        convolved=True,
+        bkg_cubes=resolved["bkg"],
+        rms_cubes=resolved["rms"],
+    )
 
     # The convolved planes are removed as each cube is assembled, leaving the
     # planes they were made from behind

--- a/flint/prefect/common/rmsynth.py
+++ b/flint/prefect/common/rmsynth.py
@@ -47,17 +47,17 @@ class CommonResolutionCubes(NamedTuple):
     """The cubes ``convolve_cubes_to_common_resolution`` writes, keyed by Stokes"""
 
     cubes: dict[str, Path]
-    """The cube to use per Stokes: the convolved one, or the input unchanged when ``convolved`` is False"""
+    """The cube to use per Stokes: convolved, or the input unchanged"""
     convolved: bool = False
-    """Whether these are new cubes. False means the inputs already shared a resolution and were used as they are, so nothing new was written"""
+    """False when the inputs already shared a resolution and nothing new was written"""
     bkg_cubes: dict[str, Path] = {}
-    """BANE background cube per Stokes, measured on the convolved planes. Empty unless BANE was asked for"""
+    """BANE background cube per Stokes. Empty unless BANE was asked for"""
     rms_cubes: dict[str, Path] = {}
-    """BANE RMS cube per Stokes, measured on the convolved planes so it describes the resolution the FDF is built at. Empty unless BANE was asked for"""
+    """BANE RMS cube per Stokes. Empty unless BANE was asked for"""
 
     @property
     def all_cubes(self) -> list[Path]:
-        """Every cube written, for the callers that only trim and compress them"""
+        """Every cube written"""
         if not self.convolved:
             return []
         return [
@@ -143,11 +143,9 @@ def convolve_cubes_to_common_resolution(
         convol_suffix=unmapped(convol_suffix),
     ).result()
 
-    # Measured on the convolved planes, not the ones they came from: these
-    # describe the resolution rm-synthesis builds the FDF at, which is the whole
-    # point of making them here rather than reusing the polarisation stage's.
-    # Resolved before the cubes are assembled because `fitscube_options` removes
-    # each plane once it has been cubed.
+    # Measured on the convolved planes, which is the resolution the FDF is
+    # built at. Resolved before the cubes are assembled, since `fitscube_options`
+    # removes each plane once cubed.
     bane_maps: list[BANEMaps] = []
     if fft_bane_options is not None:
         bane_maps = task_bane_fits_image.map(

--- a/flint/prefect/common/rmsynth.py
+++ b/flint/prefect/common/rmsynth.py
@@ -17,12 +17,12 @@ from flint.bane import BANEMaps
 from flint.convol import BeamShape, convolve_plane_to_beam
 from flint.logging import logger
 from flint.options import (
+    CubesForRMSynth,
+    ErrorCubesForRMSynth,
     FFTBANEOptions,
     FitsCubeOptions,
     RMCleanOptions,
     RMSynthOptions,
-    StokesCubes,
-    StokesErrorCubes,
 )
 from flint.prefect.caching import task
 from flint.prefect.common.imaging import (
@@ -201,9 +201,9 @@ def convolve_cubes_to_common_resolution(
 
 @task
 def task_rmsynth(
-    stokes_cubes: StokesCubes,
+    stokes_cubes: CubesForRMSynth,
     rmsynth_options: RMSynthOptions,
-    error_cubes: StokesErrorCubes | None = None,
+    error_cubes: ErrorCubesForRMSynth | None = None,
 ) -> RMSynth3DResults:
     from prefect_dask import get_dask_client
 

--- a/flint/prefect/common/rmsynth.py
+++ b/flint/prefect/common/rmsynth.py
@@ -242,6 +242,8 @@ def task_write_rm_products(
     moment_products: list[FDFLabel],
     peak_products: list[FDFLabel],
     output_prefix: Path,
+    moment_threshold_snr: float = 5.0,
+    peak_threshold_snr: float = 0.0,
 ) -> list[Path]:
     """Batch-compute and write the requested RM-synthesis/RM-CLEAN products"""
     from prefect_dask import get_dask_client
@@ -258,5 +260,7 @@ def task_write_rm_products(
             moment_products=moment_products,
             peak_products=peak_products,
             output_prefix=output_prefix,
+            moment_threshold_snr=moment_threshold_snr,
+            peak_threshold_snr=peak_threshold_snr,
             dask_client=client,
         )

--- a/flint/prefect/common/rmsynth.py
+++ b/flint/prefect/common/rmsynth.py
@@ -138,6 +138,9 @@ def task_rmsynth(
     stokes_q_weight_cube: Path | None = None,
     stokes_u_weight_cube: Path | None = None,
     stokes_i_weight_cube: Path | None = None,
+    stokes_q_noise_cube: Path | None = None,
+    stokes_u_noise_cube: Path | None = None,
+    stokes_i_noise_cube: Path | None = None,
 ) -> RMSynth3DResults:
     from prefect_dask import get_dask_client
 
@@ -153,6 +156,9 @@ def task_rmsynth(
             rmsynth_options=rmsynth_options,
             stokes_i_cube=stokes_i_cube,
             stokes_i_weight_cube=stokes_i_weight_cube,
+            stokes_q_noise_cube=stokes_q_noise_cube,
+            stokes_u_noise_cube=stokes_u_noise_cube,
+            stokes_i_noise_cube=stokes_i_noise_cube,
         )
 
 

--- a/flint/prefect/common/rmsynth.py
+++ b/flint/prefect/common/rmsynth.py
@@ -21,6 +21,8 @@ from flint.options import (
     FitsCubeOptions,
     RMCleanOptions,
     RMSynthOptions,
+    StokesCubes,
+    StokesErrorCubes,
 )
 from flint.prefect.caching import task
 from flint.prefect.common.imaging import (
@@ -201,16 +203,9 @@ def convolve_cubes_to_common_resolution(
 
 @task
 def task_rmsynth(
-    stokes_q_cube: Path,
-    stokes_u_cube: Path,
+    stokes_cubes: StokesCubes,
     rmsynth_options: RMSynthOptions,
-    stokes_i_cube: Path | None = None,
-    stokes_q_weight_cube: Path | None = None,
-    stokes_u_weight_cube: Path | None = None,
-    stokes_i_weight_cube: Path | None = None,
-    stokes_q_noise_cube: Path | None = None,
-    stokes_u_noise_cube: Path | None = None,
-    stokes_i_noise_cube: Path | None = None,
+    error_cubes: StokesErrorCubes | None = None,
 ) -> RMSynth3DResults:
     from prefect_dask import get_dask_client
 
@@ -219,16 +214,9 @@ def task_rmsynth(
     # client they would read whole cubes on this one worker.
     with get_dask_client():
         return run_rmsynth_3d(
-            stokes_q_cube=stokes_q_cube,
-            stokes_u_cube=stokes_u_cube,
-            stokes_q_weight_cube=stokes_q_weight_cube,
-            stokes_u_weight_cube=stokes_u_weight_cube,
+            stokes_cubes=stokes_cubes,
             rmsynth_options=rmsynth_options,
-            stokes_i_cube=stokes_i_cube,
-            stokes_i_weight_cube=stokes_i_weight_cube,
-            stokes_q_noise_cube=stokes_q_noise_cube,
-            stokes_u_noise_cube=stokes_u_noise_cube,
-            stokes_i_noise_cube=stokes_i_noise_cube,
+            error_cubes=error_cubes,
         )
 
 

--- a/flint/prefect/flows/polarisation_pipeline.py
+++ b/flint/prefect/flows/polarisation_pipeline.py
@@ -71,6 +71,10 @@ class PolPipelineResult(BaseOptions):
     """The full, unspiced Stokes cube written for each imaged polarisation (e.g. 'i', 'q', 'u', 'v')"""
     weight_cubes: dict[str, Path]
     """The full Stokes weights written for each imaged polarisation (e.g. 'i', 'q', 'u', 'v')"""
+    bkg_cubes: dict[str, Path] = {}
+    """BANE background cube per imaged polarisation. Empty unless ``PolFieldOptions.bane_noise`` is set"""
+    rms_cubes: dict[str, Path] = {}
+    """BANE RMS noise cube per imaged polarisation, measured off the co-added planes rather than inferred from the linmos weights. Empty unless ``PolFieldOptions.bane_noise`` is set"""
     mfs_products: dict[str, dict[str, Path]]
     """MFS image/model/residual products co-added per Stokes parameter, keyed by Stokes ('i', 'q', 'u', 'v') then product type ('image', 'model', 'residual'). Only populated for Stokes imaged under a polarisation with ``WSCleanOptions.flint_save_mfs_products`` set"""
     terminal_futures: list[PrefectFuture[Any]]
@@ -96,6 +100,8 @@ def _no_products(
     return PolPipelineResult(
         stokes_cubes={},
         weight_cubes={},
+        bkg_cubes={},
+        rms_cubes={},
         mfs_products={},
         terminal_futures=terminal_futures or [],
     )
@@ -358,6 +364,8 @@ def process_science_fields_pol(
     cube_results: list[PrefectFuture[Path]] = []
     stokes_image_cubes: dict[str, PrefectFuture[Path]] = {}
     stokes_weight_cubes: dict[str, PrefectFuture[Path]] = {}
+    stokes_bkg_cubes: dict[str, PrefectFuture[Path]] = {}
+    stokes_rms_cubes: dict[str, PrefectFuture[Path]] = {}
     all_input_images: list[Path] = []
     for stokes, channel_groups in stokes_channel_groups.items():
         with tags(f"stokes-{stokes}"):
@@ -377,9 +385,14 @@ def process_science_fields_pol(
                 field_summary=field_summary,
                 fitscube_options=fitscube_options,
                 suffix_str=POL_NAME_SUFFIX,
+                fft_bane_options=pol_field_options.bane_noise,
             )
-            stokes_image_cubes[stokes], stokes_weight_cubes[stokes] = stokes_cubes
-            cube_results.extend(stokes_cubes)
+            stokes_image_cubes[stokes] = stokes_cubes.image
+            stokes_weight_cubes[stokes] = stokes_cubes.weight
+            if stokes_cubes.bkg is not None and stokes_cubes.rms is not None:
+                stokes_bkg_cubes[stokes] = stokes_cubes.bkg
+                stokes_rms_cubes[stokes] = stokes_cubes.rms
+            cube_results.extend(stokes_cubes.futures)
 
     # Remove the convolved per-beam channel images now that every cube is built.
     # Stokes I images are kept until here as they feed the Q/U leakage correction.
@@ -455,6 +468,12 @@ def process_science_fields_pol(
     return PolPipelineResult(
         stokes_cubes={
             stokes: future.result() for stokes, future in stokes_image_cubes.items()
+        },
+        bkg_cubes={
+            stokes: future.result() for stokes, future in stokes_bkg_cubes.items()
+        },
+        rms_cubes={
+            stokes: future.result() for stokes, future in stokes_rms_cubes.items()
         },
         weight_cubes={
             stokes: future.result() for stokes, future in stokes_weight_cubes.items()

--- a/flint/prefect/flows/polarisation_pipeline.py
+++ b/flint/prefect/flows/polarisation_pipeline.py
@@ -34,6 +34,7 @@ from flint.naming import (
     get_sbid_from_path,
 )
 from flint.options import (
+    FFTBANEOptions,
     FitsCubeOptions,
     PolFieldOptions,
     dump_field_options_to_yaml,
@@ -361,6 +362,18 @@ def process_science_fields_pol(
     if compress_cubes is not None:
         fitscube_options = fitscube_options.with_options(compress=compress_cubes)
 
+    # Parameters from the strategy, the switch from the flow options, as with
+    # every other stage
+    fft_bane_options = (
+        FFTBANEOptions(
+            **get_options_from_strategy(
+                strategy=strategy, operation="polarisation", mode="fftbane"
+            )
+        )
+        if pol_field_options.bane_noise
+        else None
+    )
+
     cube_results: list[PrefectFuture[Path]] = []
     stokes_image_cubes: dict[str, PrefectFuture[Path]] = {}
     stokes_weight_cubes: dict[str, PrefectFuture[Path]] = {}
@@ -385,7 +398,7 @@ def process_science_fields_pol(
                 field_summary=field_summary,
                 fitscube_options=fitscube_options,
                 suffix_str=POL_NAME_SUFFIX,
-                fft_bane_options=pol_field_options.bane_noise,
+                fft_bane_options=fft_bane_options,
             )
             stokes_image_cubes[stokes] = stokes_cubes.image
             stokes_weight_cubes[stokes] = stokes_cubes.weight

--- a/flint/prefect/flows/polarisation_pipeline.py
+++ b/flint/prefect/flows/polarisation_pipeline.py
@@ -72,9 +72,9 @@ class PolPipelineResult(BaseOptions):
     weight_cubes: dict[str, Path]
     """The full Stokes weights written for each imaged polarisation (e.g. 'i', 'q', 'u', 'v')"""
     bkg_cubes: dict[str, Path] = {}
-    """BANE background cube per imaged polarisation. Empty unless ``PolFieldOptions.bane_noise`` is set"""
+    """BANE background cube per imaged polarisation. Empty unless asked for"""
     rms_cubes: dict[str, Path] = {}
-    """BANE RMS noise cube per imaged polarisation, measured off the co-added planes rather than inferred from the linmos weights. Empty unless ``PolFieldOptions.bane_noise`` is set"""
+    """BANE RMS cube per imaged polarisation, measured off the co-added planes. Empty unless asked for"""
     mfs_products: dict[str, dict[str, Path]]
     """MFS image/model/residual products co-added per Stokes parameter, keyed by Stokes ('i', 'q', 'u', 'v') then product type ('image', 'model', 'residual'). Only populated for Stokes imaged under a polarisation with ``WSCleanOptions.flint_save_mfs_products`` set"""
     terminal_futures: list[PrefectFuture[Any]]

--- a/flint/prefect/flows/racs_all_pipeline.py
+++ b/flint/prefect/flows/racs_all_pipeline.py
@@ -129,21 +129,25 @@ def _check_racs_all_pipeline_options(pipeline_options: RACSAllPipelineOptions) -
 
 def _check_rmsynth_has_linear_stokes(
     pipeline_options: RACSAllPipelineOptions,
-    racs_all_options: RACSAllOptions,
+    pol_field_options: PolFieldOptions,
 ) -> None:
-    """RM-synthesis builds its FDF from Q+iU, so the polarisation strategy has to
-    image the linear Stokes. A circular-only strategy would otherwise fail once
-    imaging had already run.
+    """RM-synthesis builds its FDF from Q+iU, so a polarisation strategy that
+    names its Stokes has to include the linear ones. A circular-only strategy
+    would otherwise fail once imaging had already run.
+
+    Only checked when the strategy says: without one the polarisation stage has
+    its own say, and guessing here would refuse runs it would have served.
     """
     if pipeline_options.skip_rmsynth or pipeline_options.skip_polarisation:
         return
+    if pol_field_options.imaging_strategy is None:
+        return
 
-    strategy = (
-        load_strategy_yaml(input_yaml=racs_all_options.imaging_strategy)
-        if racs_all_options.imaging_strategy is not None
-        else None
-    )
-    polarisations = (strategy or {}).get("polarisation", {"total": {}})
+    strategy = load_strategy_yaml(input_yaml=pol_field_options.imaging_strategy)
+    polarisations = strategy.get("polarisation")
+    if not polarisations:
+        return
+
     imaged = {
         stokes
         for mode in polarisations
@@ -234,7 +238,7 @@ def process_racs_all(
         spice_field_options=spice_field_options,
     )
     _check_rmsynth_has_linear_stokes(
-        pipeline_options=pipeline_options, racs_all_options=racs_all_options
+        pipeline_options=pipeline_options, pol_field_options=pol_field_options
     )
 
     terminal_results: list[Any] = []

--- a/flint/prefect/flows/racs_all_pipeline.py
+++ b/flint/prefect/flows/racs_all_pipeline.py
@@ -15,20 +15,24 @@ from fitscube.combine_fits import compress_cube
 from prefect import flow
 from pydantic import create_model
 
-from flint.configuration import get_options_from_strategy, load_strategy_yaml
+from flint.configuration import (
+    POLARISATION_MAPPING,
+    get_options_from_strategy,
+    load_strategy_yaml,
+)
 from flint.logging import logger
 from flint.naming import get_sbid_from_path
 from flint.options import (
+    CubesForRMSynth,
+    ErrorCubesForRMSynth,
     FitsCubeOptions,
+    NoiseCubesForRMSynth,
     PolFieldOptions,
     RACSAllOptions,
     RACSAllPipelineOptions,
     RMSynthFieldOptions,
     SpiceFieldOptions,
-    StokesCubes,
-    StokesErrorCubes,
-    StokesNoiseCubes,
-    StokesWeightCubes,
+    WeightCubesForRMSynth,
     pol_field_options_cli_class,
 )
 from flint.prefect.clusters import get_dask_runner
@@ -123,6 +127,37 @@ def _check_racs_all_pipeline_options(pipeline_options: RACSAllPipelineOptions) -
         )
 
 
+def _check_rmsynth_has_linear_stokes(
+    pipeline_options: RACSAllPipelineOptions,
+    racs_all_options: RACSAllOptions,
+) -> None:
+    """RM-synthesis builds its FDF from Q+iU, so the polarisation strategy has to
+    image the linear Stokes. A circular-only strategy would otherwise fail once
+    imaging had already run.
+    """
+    if pipeline_options.skip_rmsynth or pipeline_options.skip_polarisation:
+        return
+
+    strategy = (
+        load_strategy_yaml(input_yaml=racs_all_options.imaging_strategy)
+        if racs_all_options.imaging_strategy is not None
+        else None
+    )
+    polarisations = (strategy or {}).get("polarisation", {"total": {}})
+    imaged = {
+        stokes
+        for mode in polarisations
+        for stokes in POLARISATION_MAPPING.get(mode, "")
+    }
+    missing = {"q", "u"} - imaged
+    if missing:
+        raise ValueError(
+            f"rm-synthesis needs Stokes {sorted(missing)}, which the polarisation "
+            f"strategy does not image (modes: {sorted(polarisations)}). Add the "
+            "'linear' polarisation, or pass --skip-rmsynth."
+        )
+
+
 def _check_spice_mfs_dependency(
     pipeline_options: RACSAllPipelineOptions,
     racs_all_options: RACSAllOptions,
@@ -198,6 +233,9 @@ def process_racs_all(
         pol_field_options=pol_field_options,
         spice_field_options=spice_field_options,
     )
+    _check_rmsynth_has_linear_stokes(
+        pipeline_options=pipeline_options, racs_all_options=racs_all_options
+    )
 
     terminal_results: list[Any] = []
 
@@ -257,13 +295,13 @@ def process_racs_all(
     if not pipeline_options.skip_rmsynth:
         # BANE RMS if the polarisation stage measured it, else the linmos
         # weights. rm-synth supersedes both once it convolves to a common beam.
-        error_cubes: StokesErrorCubes = (
-            StokesNoiseCubes.from_mapping(pol_result.rms_cubes)
+        error_cubes: ErrorCubesForRMSynth = (
+            NoiseCubesForRMSynth.from_mapping(pol_result.rms_cubes)
             if pol_result.rms_cubes
-            else StokesWeightCubes.from_mapping(pol_result.weight_cubes)
+            else WeightCubesForRMSynth.from_mapping(pol_result.weight_cubes)
         )
         resolved_rmsynth_field_options = rmsynth_field_options.with_options(
-            stokes_cubes=StokesCubes.from_mapping(pol_result.stokes_cubes),
+            stokes_cubes=CubesForRMSynth.from_mapping(pol_result.stokes_cubes),
             error_cubes=error_cubes,
             output_path=rmsynth_field_options.output_path or output_root / "rmsynth",
         )

--- a/flint/prefect/flows/racs_all_pipeline.py
+++ b/flint/prefect/flows/racs_all_pipeline.py
@@ -254,9 +254,23 @@ def process_racs_all(
             stokes_q_cube=pol_result.stokes_cubes["q"],
             stokes_u_cube=pol_result.stokes_cubes["u"],
             stokes_i_cube=pol_result.stokes_cubes.get("i"),
-            stokes_i_weight_cube=pol_result.weight_cubes.get("i"),
-            stokes_q_weight_cube=pol_result.weight_cubes["q"],
-            stokes_u_weight_cube=pol_result.weight_cubes["u"],
+            # The BANE RMS cubes are measured off the co-added planes, so they
+            # describe the cubes rm-synth actually reads. The linmos weights are
+            # an inverse variance carried over from the input images and are the
+            # fallback when the polarisation stage did not run BANE.
+            **(
+                {
+                    "stokes_i_noise_cube": pol_result.rms_cubes.get("i"),
+                    "stokes_q_noise_cube": pol_result.rms_cubes["q"],
+                    "stokes_u_noise_cube": pol_result.rms_cubes["u"],
+                }
+                if pol_result.rms_cubes
+                else {
+                    "stokes_i_weight_cube": pol_result.weight_cubes.get("i"),
+                    "stokes_q_weight_cube": pol_result.weight_cubes["q"],
+                    "stokes_u_weight_cube": pol_result.weight_cubes["u"],
+                }
+            ),
             output_path=rmsynth_field_options.output_path or output_root / "rmsynth",
         )
         assert pipeline_options.rmsynth_cluster_config is not None
@@ -280,7 +294,11 @@ def process_racs_all(
         # covers both. Empty unless rm-synth actually had to convolve.
         resolved_spice_field_options = spice_field_options.with_options(
             cubes=[*pol_result.stokes_cubes.values(), *rmsynth_convolved_cubes],
-            weight_cubes=list(pol_result.weight_cubes.values()),
+            weight_cubes=[
+                *pol_result.weight_cubes.values(),
+                *pol_result.bkg_cubes.values(),
+                *pol_result.rms_cubes.values(),
+            ],
             reference_image=resolved_reference_image,
             output_path=spice_field_options.output_path or output_root / "spice",
         )
@@ -303,6 +321,8 @@ def process_racs_all(
             for cube in (
                 *pol_result.stokes_cubes.values(),
                 *pol_result.weight_cubes.values(),
+                *pol_result.bkg_cubes.values(),
+                *pol_result.rms_cubes.values(),
                 *rmsynth_convolved_cubes,
             )
         )

--- a/flint/prefect/flows/racs_all_pipeline.py
+++ b/flint/prefect/flows/racs_all_pipeline.py
@@ -25,6 +25,10 @@ from flint.options import (
     RACSAllPipelineOptions,
     RMSynthFieldOptions,
     SpiceFieldOptions,
+    StokesCubes,
+    StokesErrorCubes,
+    StokesNoiseCubes,
+    StokesWeightCubes,
     pol_field_options_cli_class,
 )
 from flint.prefect.clusters import get_dask_runner
@@ -42,7 +46,7 @@ STAGE_CLUSTER_CONFIG_ATTRS = (
 
 # Fields on the rm-synth/spice options classes that process_racs_all always recomputes
 # from the polarisation stage's output. Excluded from the combined CLI.
-COMPUTED_FIELDS = {"stokes_q_cube", "stokes_u_cube", "cubes", "weight_cubes"}
+COMPUTED_FIELDS = {"stokes_cubes", "error_cubes", "cubes", "weight_cubes"}
 
 
 def _check_stage_prerequisites(
@@ -251,27 +255,19 @@ def process_racs_all(
     rmsynth_convolved_cubes: list[Path] = []
     rmsynth_noise_cubes: list[Path] = []
     if not pipeline_options.skip_rmsynth:
+        # The BANE RMS cubes are measured off the co-added planes, so they
+        # describe the cubes rm-synth reads. The linmos weights are an inverse
+        # variance carried over from the input images and are the fallback when
+        # the polarisation stage did not run BANE. Either way rm-synth measures
+        # its own once it convolves to a common beam, which supersedes both.
+        error_cubes: StokesErrorCubes = (
+            StokesNoiseCubes.from_mapping(pol_result.rms_cubes)
+            if pol_result.rms_cubes
+            else StokesWeightCubes.from_mapping(pol_result.weight_cubes)
+        )
         resolved_rmsynth_field_options = rmsynth_field_options.with_options(
-            stokes_q_cube=pol_result.stokes_cubes["q"],
-            stokes_u_cube=pol_result.stokes_cubes["u"],
-            stokes_i_cube=pol_result.stokes_cubes.get("i"),
-            # The BANE RMS cubes are measured off the co-added planes, so they
-            # describe the cubes rm-synth actually reads. The linmos weights are
-            # an inverse variance carried over from the input images and are the
-            # fallback when the polarisation stage did not run BANE.
-            **(
-                {
-                    "stokes_i_noise_cube": pol_result.rms_cubes.get("i"),
-                    "stokes_q_noise_cube": pol_result.rms_cubes["q"],
-                    "stokes_u_noise_cube": pol_result.rms_cubes["u"],
-                }
-                if pol_result.rms_cubes
-                else {
-                    "stokes_i_weight_cube": pol_result.weight_cubes.get("i"),
-                    "stokes_q_weight_cube": pol_result.weight_cubes["q"],
-                    "stokes_u_weight_cube": pol_result.weight_cubes["u"],
-                }
-            ),
+            stokes_cubes=StokesCubes.from_mapping(pol_result.stokes_cubes),
+            error_cubes=error_cubes,
             output_path=rmsynth_field_options.output_path or output_root / "rmsynth",
         )
         assert pipeline_options.rmsynth_cluster_config is not None

--- a/flint/prefect/flows/racs_all_pipeline.py
+++ b/flint/prefect/flows/racs_all_pipeline.py
@@ -255,11 +255,8 @@ def process_racs_all(
     rmsynth_convolved_cubes: list[Path] = []
     rmsynth_noise_cubes: list[Path] = []
     if not pipeline_options.skip_rmsynth:
-        # The BANE RMS cubes are measured off the co-added planes, so they
-        # describe the cubes rm-synth reads. The linmos weights are an inverse
-        # variance carried over from the input images and are the fallback when
-        # the polarisation stage did not run BANE. Either way rm-synth measures
-        # its own once it convolves to a common beam, which supersedes both.
+        # BANE RMS if the polarisation stage measured it, else the linmos
+        # weights. rm-synth supersedes both once it convolves to a common beam.
         error_cubes: StokesErrorCubes = (
             StokesNoiseCubes.from_mapping(pol_result.rms_cubes)
             if pol_result.rms_cubes

--- a/flint/prefect/flows/racs_all_pipeline.py
+++ b/flint/prefect/flows/racs_all_pipeline.py
@@ -249,6 +249,7 @@ def process_racs_all(
     output_root = pipeline_options.output_path or continuum_result.output_science_path
 
     rmsynth_convolved_cubes: list[Path] = []
+    rmsynth_noise_cubes: list[Path] = []
     if not pipeline_options.skip_rmsynth:
         resolved_rmsynth_field_options = rmsynth_field_options.with_options(
             stokes_q_cube=pol_result.stokes_cubes["q"],
@@ -282,6 +283,7 @@ def process_racs_all(
         )(rmsynth_field_options=resolved_rmsynth_field_options)
         terminal_results.extend(rmsynth_result.written_paths)
         rmsynth_convolved_cubes = rmsynth_result.convolved_cubes
+        rmsynth_noise_cubes = rmsynth_result.convolved_noise_cubes
 
     if not pipeline_options.skip_spice:
         resolved_reference_image = (
@@ -298,6 +300,7 @@ def process_racs_all(
                 *pol_result.weight_cubes.values(),
                 *pol_result.bkg_cubes.values(),
                 *pol_result.rms_cubes.values(),
+                *rmsynth_noise_cubes,
             ],
             reference_image=resolved_reference_image,
             output_path=spice_field_options.output_path or output_root / "spice",
@@ -324,6 +327,7 @@ def process_racs_all(
                 *pol_result.bkg_cubes.values(),
                 *pol_result.rms_cubes.values(),
                 *rmsynth_convolved_cubes,
+                *rmsynth_noise_cubes,
             )
         )
 

--- a/flint/prefect/flows/rmsynth_pipeline.py
+++ b/flint/prefect/flows/rmsynth_pipeline.py
@@ -149,7 +149,13 @@ def process_rmsynth(
         stokes_cubes=stokes_cube_paths,
         output_path=rmsynth_field_options.output_path,
         beam_cutoff=rmsynth_field_options.beam_cutoff,
-        fft_bane_options=rmsynth_field_options.bane_noise,
+        fft_bane_options=FFTBANEOptions(
+            **get_options_from_strategy(
+                strategy=strategy, operation="rmsynth", mode="fftbane"
+            )
+        )
+        if rmsynth_field_options.bane_noise
+        else None,
     )
     stokes_cubes = CubesForRMSynth.from_mapping(common_resolution.cubes)
 

--- a/flint/prefect/flows/rmsynth_pipeline.py
+++ b/flint/prefect/flows/rmsynth_pipeline.py
@@ -18,12 +18,14 @@ from flint.logging import logger
 from flint.naming import create_name_from_common_fields, get_sbid_from_path
 from flint.options import (
     BaseOptions,
+    FFTBANEOptions,
     RMCleanOptions,
     RMSynthFieldOptions,
     RMSynthOptions,
 )
 from flint.prefect.clusters import get_dask_runner
 from flint.prefect.common.rmsynth import (
+    CommonResolutionCubes,
     convolve_cubes_to_common_resolution,
     task_rmclean,
     task_rmsynth,
@@ -41,13 +43,16 @@ class RMSynthPipelineResult(BaseOptions):
     """The RM-synthesis and RM-CLEAN products written"""
     convolved_cubes: list[Path]
     """Any new Stokes cubes written to bring the inputs to a common resolution. Empty when the inputs already shared one and were used as they are, so a caller may concatenate these with the input cubes without ever repeating a path"""
+    convolved_noise_cubes: list[Path] = []
+    """The BANE background and RMS cubes measured on those convolved cubes. Frequency cubes like the rest, so they are trimmed and compressed alongside them. Empty whenever ``convolved_cubes`` is, or when BANE was not asked for"""
 
 
 def _resolve_common_resolution_cubes(
     stokes_cubes: dict[str, Path],
     output_path: Path | None = None,
     beam_cutoff: float | None = None,
-) -> tuple[dict[str, Path], list[Path]]:
+    fft_bane_options: FFTBANEOptions | None = None,
+) -> CommonResolutionCubes:
     """RM-synthesis is only meaningful when every channel of every Stokes shares
     one resolution, the 'total' mode of racs_tools. Cubes that already do are
     used as they are; otherwise they are convolved to a common beam and written
@@ -65,9 +70,10 @@ def _resolve_common_resolution_cubes(
         stokes_cubes (dict[str, Path]): The input cube of each Stokes to run against
         output_path (Path | None, optional): Directory any new cubes are written into. Defaults to alongside the inputs.
         beam_cutoff (float | None, optional): Channels coarser than this, in arcsec, are blanked rather than dragging the common beam out to their resolution. Defaults to no cutoff.
+        fft_bane_options (FFTBANEOptions | None, optional): When given, the convolved planes also get BANE background and RMS cubes, measured at the resolution the FDF is built at. Defaults to None.
 
     Returns:
-        tuple[dict[str, Path], list[Path]]: The cube to use for each Stokes, and the new cubes written (empty when the inputs were used as they are)
+        CommonResolutionCubes: The cube to use for each Stokes, and any BANE cubes. ``cubes`` is the input dict unchanged when no convolution was needed.
     """
     cube_paths = list(stokes_cubes.values())
     common_beam = common_beam_from_cubes(cube_paths=cube_paths, cutoff=beam_cutoff)
@@ -76,22 +82,21 @@ def _resolve_common_resolution_cubes(
             "No usable restoring beam among the Stokes cubes, so there is no "
             "resolution to make common. Using them as they are."
         )
-        return stokes_cubes, []
+        return CommonResolutionCubes(cubes=stokes_cubes)
 
     if cubes_share_common_beam(cube_paths=cube_paths, cutoff=beam_cutoff):
         logger.info("Stokes cubes already share a common resolution")
-        return stokes_cubes, []
+        return CommonResolutionCubes(cubes=stokes_cubes)
 
     beam_shape = BeamShape.from_radio_beam(radio_beam=common_beam)
     logger.info(f"Bringing the Stokes cubes to {beam_shape=}")
-    convolved_cubes = convolve_cubes_to_common_resolution(
+    return convolve_cubes_to_common_resolution(
         cubes=stokes_cubes,
         beam_shape=beam_shape,
         output_path=output_path,
         beam_cutoff=beam_cutoff,
+        fft_bane_options=fft_bane_options,
     )
-
-    return convolved_cubes, list(convolved_cubes.values())
 
 
 @flow(name="Flint RM-Synthesis Pipeline")
@@ -137,23 +142,48 @@ def process_rmsynth(
         )
     )
 
-    stokes_cubes, convolved_cubes = _resolve_common_resolution_cubes(
+    common_resolution = _resolve_common_resolution_cubes(
         stokes_cubes=stokes_cubes,
         output_path=rmsynth_field_options.output_path,
         beam_cutoff=rmsynth_field_options.beam_cutoff,
+        fft_bane_options=rmsynth_field_options.bane_noise,
     )
+    stokes_cubes = common_resolution.cubes
+
+    # A noise cube only describes the cubes it was measured on. Convolving to a
+    # common beam changes them, so the BANE cubes made just above supersede
+    # whatever the caller passed in; the caller's are right only when no
+    # convolution happened and the cubes are the ones BANE already saw.
+    noise_cubes = common_resolution.rms_cubes or {
+        stokes: cube
+        for stokes, cube in (
+            ("i", rmsynth_field_options.stokes_i_noise_cube),
+            ("q", rmsynth_field_options.stokes_q_noise_cube),
+            ("u", rmsynth_field_options.stokes_u_noise_cube),
+        )
+        if cube is not None
+    }
 
     synth_result = task_rmsynth.submit(
         stokes_q_cube=stokes_cubes["q"],
         stokes_u_cube=stokes_cubes["u"],
         rmsynth_options=rmsynth_options,
         stokes_i_cube=stokes_cubes.get("i"),
-        stokes_i_weight_cube=rmsynth_field_options.stokes_i_weight_cube,
-        stokes_q_weight_cube=rmsynth_field_options.stokes_q_weight_cube,
-        stokes_u_weight_cube=rmsynth_field_options.stokes_u_weight_cube,
-        stokes_i_noise_cube=rmsynth_field_options.stokes_i_noise_cube,
-        stokes_q_noise_cube=rmsynth_field_options.stokes_q_noise_cube,
-        stokes_u_noise_cube=rmsynth_field_options.stokes_u_noise_cube,
+        # The weight cubes are the fallback for a run with no BANE at all, so
+        # they are dropped as soon as a noise cube exists; rm-lite takes one or
+        # the other, never both
+        stokes_i_weight_cube=None
+        if noise_cubes
+        else rmsynth_field_options.stokes_i_weight_cube,
+        stokes_q_weight_cube=None
+        if noise_cubes
+        else rmsynth_field_options.stokes_q_weight_cube,
+        stokes_u_weight_cube=None
+        if noise_cubes
+        else rmsynth_field_options.stokes_u_weight_cube,
+        stokes_i_noise_cube=noise_cubes.get("i"),
+        stokes_q_noise_cube=noise_cubes.get("q"),
+        stokes_u_noise_cube=noise_cubes.get("u"),
     )
 
     run_clean = needs_rmclean(
@@ -197,7 +227,14 @@ def process_rmsynth(
         ).result()
 
     return RMSynthPipelineResult(
-        written_paths=written_paths, convolved_cubes=convolved_cubes
+        written_paths=written_paths,
+        convolved_cubes=list(common_resolution.cubes.values())
+        if common_resolution.convolved
+        else [],
+        convolved_noise_cubes=[
+            *common_resolution.bkg_cubes.values(),
+            *common_resolution.rms_cubes.values(),
+        ],
     )
 
 

--- a/flint/prefect/flows/rmsynth_pipeline.py
+++ b/flint/prefect/flows/rmsynth_pipeline.py
@@ -204,6 +204,8 @@ def process_rmsynth(
         moment_products=rmsynth_field_options.moment_products,
         peak_products=rmsynth_field_options.peak_products,
         output_prefix=output_prefix,
+        moment_threshold_snr=rmsynth_field_options.moment_threshold_snr,
+        peak_threshold_snr=rmsynth_field_options.peak_threshold_snr,
     )
 
     written_paths = output_paths.result()

--- a/flint/prefect/flows/rmsynth_pipeline.py
+++ b/flint/prefect/flows/rmsynth_pipeline.py
@@ -18,13 +18,13 @@ from flint.logging import logger
 from flint.naming import create_name_from_common_fields, get_sbid_from_path
 from flint.options import (
     BaseOptions,
+    CubesForRMSynth,
+    ErrorCubesForRMSynth,
     FFTBANEOptions,
+    NoiseCubesForRMSynth,
     RMCleanOptions,
     RMSynthFieldOptions,
     RMSynthOptions,
-    StokesCubes,
-    StokesErrorCubes,
-    StokesNoiseCubes,
 )
 from flint.prefect.clusters import get_dask_runner
 from flint.prefect.common.rmsynth import (
@@ -151,13 +151,13 @@ def process_rmsynth(
         beam_cutoff=rmsynth_field_options.beam_cutoff,
         fft_bane_options=rmsynth_field_options.bane_noise,
     )
-    stokes_cubes = StokesCubes.from_mapping(common_resolution.cubes)
+    stokes_cubes = CubesForRMSynth.from_mapping(common_resolution.cubes)
 
     # A noise cube only describes the cubes it was measured on, so the BANE
     # cubes made just above supersede the caller's. The caller's are right only
     # when nothing was convolved and they describe these same cubes.
-    error_cubes: StokesErrorCubes | None = (
-        StokesNoiseCubes.from_mapping(common_resolution.rms_cubes)
+    error_cubes: ErrorCubesForRMSynth | None = (
+        NoiseCubesForRMSynth.from_mapping(common_resolution.rms_cubes)
         if common_resolution.rms_cubes
         else rmsynth_field_options.error_cubes
     )

--- a/flint/prefect/flows/rmsynth_pipeline.py
+++ b/flint/prefect/flows/rmsynth_pipeline.py
@@ -122,15 +122,15 @@ def process_rmsynth(
     stokes_cube_paths = {
         stokes: cube
         for stokes, cube in (
-            ("q", rmsynth_field_options.stokes_cubes.q),
-            ("u", rmsynth_field_options.stokes_cubes.u),
-            ("i", rmsynth_field_options.stokes_cubes.i),
+            ("q", rmsynth_field_options.stokes_cubes.q_path),
+            ("u", rmsynth_field_options.stokes_cubes.u_path),
+            ("i", rmsynth_field_options.stokes_cubes.i_path),
         )
         if cube is not None
     }
 
     strategy = load_and_copy_strategy(
-        output_split_science_path=rmsynth_field_options.stokes_cubes.q.parent,
+        output_split_science_path=rmsynth_field_options.stokes_cubes.q_path.parent,
         imaging_strategy=rmsynth_field_options.imaging_strategy,
     )
 
@@ -182,7 +182,7 @@ def process_rmsynth(
     )
 
     output_prefix = create_name_from_common_fields(
-        in_paths=(stokes_cubes.q, stokes_cubes.u)
+        in_paths=(stokes_cubes.q_path, stokes_cubes.u_path)
     )
     if rmsynth_field_options.output_path is not None:
         rmsynth_field_options.output_path.mkdir(parents=True, exist_ok=True)
@@ -191,7 +191,7 @@ def process_rmsynth(
     output_paths = task_write_rm_products.submit(
         synth_results=synth_result,
         clean_results=clean_result,
-        stokes_q_cube=stokes_cubes.q,
+        stokes_q_cube=stokes_cubes.q_path,
         rmsynth_options=rmsynth_options,
         rmclean_options=rmclean_options,
         cube_products=rmsynth_field_options.cube_products,
@@ -227,7 +227,9 @@ def setup_run_rmsynth(
         rmsynth_field_options.sbid_copy_path
         and rmsynth_field_options.stokes_cubes is not None
     ):
-        science_sbid = get_sbid_from_path(path=rmsynth_field_options.stokes_cubes.q)
+        science_sbid = get_sbid_from_path(
+            path=rmsynth_field_options.stokes_cubes.q_path
+        )
         rmsynth_field_options = rmsynth_field_options.with_options(
             sbid_copy_path=rmsynth_field_options.sbid_copy_path / f"{science_sbid}"
         )

--- a/flint/prefect/flows/rmsynth_pipeline.py
+++ b/flint/prefect/flows/rmsynth_pipeline.py
@@ -153,10 +153,9 @@ def process_rmsynth(
     )
     stokes_cubes = StokesCubes.from_mapping(common_resolution.cubes)
 
-    # A noise cube only describes the cubes it was measured on. Convolving to a
-    # common beam changes them, so the BANE cubes made just above supersede
-    # whatever the caller passed in; the caller's are right only when no
-    # convolution happened and the cubes are the ones BANE already saw.
+    # A noise cube only describes the cubes it was measured on, so the BANE
+    # cubes made just above supersede the caller's. The caller's are right only
+    # when nothing was convolved and they describe these same cubes.
     error_cubes: StokesErrorCubes | None = (
         StokesNoiseCubes.from_mapping(common_resolution.rms_cubes)
         if common_resolution.rms_cubes

--- a/flint/prefect/flows/rmsynth_pipeline.py
+++ b/flint/prefect/flows/rmsynth_pipeline.py
@@ -22,6 +22,9 @@ from flint.options import (
     RMCleanOptions,
     RMSynthFieldOptions,
     RMSynthOptions,
+    StokesCubes,
+    StokesErrorCubes,
+    StokesNoiseCubes,
 )
 from flint.prefect.clusters import get_dask_runner
 from flint.prefect.common.rmsynth import (
@@ -103,13 +106,10 @@ def _resolve_common_resolution_cubes(
 def process_rmsynth(
     rmsynth_field_options: RMSynthFieldOptions,
 ) -> RMSynthPipelineResult:
-    if (
-        rmsynth_field_options.stokes_q_cube is None
-        or rmsynth_field_options.stokes_u_cube is None
-    ):
+    if rmsynth_field_options.stokes_cubes is None:
         raise ValueError(
-            "stokes_q_cube and stokes_u_cube are required. The racs-all flow sets "
-            "them from the polarisation stage."
+            "stokes_cubes is required. The racs-all flow sets it from the "
+            "polarisation stage."
         )
     if (
         not rmsynth_field_options.cube_products
@@ -119,15 +119,18 @@ def process_rmsynth(
         logger.info("No RM-synthesis products requested, skipping.")
         return RMSynthPipelineResult(written_paths=[], convolved_cubes=[])
 
-    stokes_cubes = {
-        "q": rmsynth_field_options.stokes_q_cube,
-        "u": rmsynth_field_options.stokes_u_cube,
+    stokes_cube_paths = {
+        stokes: cube
+        for stokes, cube in (
+            ("q", rmsynth_field_options.stokes_cubes.q),
+            ("u", rmsynth_field_options.stokes_cubes.u),
+            ("i", rmsynth_field_options.stokes_cubes.i),
+        )
+        if cube is not None
     }
-    if rmsynth_field_options.stokes_i_cube is not None:
-        stokes_cubes["i"] = rmsynth_field_options.stokes_i_cube
 
     strategy = load_and_copy_strategy(
-        output_split_science_path=rmsynth_field_options.stokes_q_cube.parent,
+        output_split_science_path=rmsynth_field_options.stokes_cubes.q.parent,
         imaging_strategy=rmsynth_field_options.imaging_strategy,
     )
 
@@ -143,47 +146,27 @@ def process_rmsynth(
     )
 
     common_resolution = _resolve_common_resolution_cubes(
-        stokes_cubes=stokes_cubes,
+        stokes_cubes=stokes_cube_paths,
         output_path=rmsynth_field_options.output_path,
         beam_cutoff=rmsynth_field_options.beam_cutoff,
         fft_bane_options=rmsynth_field_options.bane_noise,
     )
-    stokes_cubes = common_resolution.cubes
+    stokes_cubes = StokesCubes.from_mapping(common_resolution.cubes)
 
     # A noise cube only describes the cubes it was measured on. Convolving to a
     # common beam changes them, so the BANE cubes made just above supersede
     # whatever the caller passed in; the caller's are right only when no
     # convolution happened and the cubes are the ones BANE already saw.
-    noise_cubes = common_resolution.rms_cubes or {
-        stokes: cube
-        for stokes, cube in (
-            ("i", rmsynth_field_options.stokes_i_noise_cube),
-            ("q", rmsynth_field_options.stokes_q_noise_cube),
-            ("u", rmsynth_field_options.stokes_u_noise_cube),
-        )
-        if cube is not None
-    }
+    error_cubes: StokesErrorCubes | None = (
+        StokesNoiseCubes.from_mapping(common_resolution.rms_cubes)
+        if common_resolution.rms_cubes
+        else rmsynth_field_options.error_cubes
+    )
 
     synth_result = task_rmsynth.submit(
-        stokes_q_cube=stokes_cubes["q"],
-        stokes_u_cube=stokes_cubes["u"],
+        stokes_cubes=stokes_cubes,
         rmsynth_options=rmsynth_options,
-        stokes_i_cube=stokes_cubes.get("i"),
-        # The weight cubes are the fallback for a run with no BANE at all, so
-        # they are dropped as soon as a noise cube exists; rm-lite takes one or
-        # the other, never both
-        stokes_i_weight_cube=None
-        if noise_cubes
-        else rmsynth_field_options.stokes_i_weight_cube,
-        stokes_q_weight_cube=None
-        if noise_cubes
-        else rmsynth_field_options.stokes_q_weight_cube,
-        stokes_u_weight_cube=None
-        if noise_cubes
-        else rmsynth_field_options.stokes_u_weight_cube,
-        stokes_i_noise_cube=noise_cubes.get("i"),
-        stokes_q_noise_cube=noise_cubes.get("q"),
-        stokes_u_noise_cube=noise_cubes.get("u"),
+        error_cubes=error_cubes,
     )
 
     run_clean = needs_rmclean(
@@ -200,7 +183,7 @@ def process_rmsynth(
     )
 
     output_prefix = create_name_from_common_fields(
-        in_paths=(stokes_cubes["q"], stokes_cubes["u"])
+        in_paths=(stokes_cubes.q, stokes_cubes.u)
     )
     if rmsynth_field_options.output_path is not None:
         rmsynth_field_options.output_path.mkdir(parents=True, exist_ok=True)
@@ -209,7 +192,7 @@ def process_rmsynth(
     output_paths = task_write_rm_products.submit(
         synth_results=synth_result,
         clean_results=clean_result,
-        stokes_q_cube=stokes_cubes["q"],
+        stokes_q_cube=stokes_cubes.q,
         rmsynth_options=rmsynth_options,
         rmclean_options=rmclean_options,
         cube_products=rmsynth_field_options.cube_products,
@@ -243,9 +226,9 @@ def setup_run_rmsynth(
 ) -> None:
     if (
         rmsynth_field_options.sbid_copy_path
-        and rmsynth_field_options.stokes_q_cube is not None
+        and rmsynth_field_options.stokes_cubes is not None
     ):
-        science_sbid = get_sbid_from_path(path=rmsynth_field_options.stokes_q_cube)
+        science_sbid = get_sbid_from_path(path=rmsynth_field_options.stokes_cubes.q)
         rmsynth_field_options = rmsynth_field_options.with_options(
             sbid_copy_path=rmsynth_field_options.sbid_copy_path / f"{science_sbid}"
         )

--- a/flint/prefect/flows/rmsynth_pipeline.py
+++ b/flint/prefect/flows/rmsynth_pipeline.py
@@ -151,6 +151,9 @@ def process_rmsynth(
         stokes_i_weight_cube=rmsynth_field_options.stokes_i_weight_cube,
         stokes_q_weight_cube=rmsynth_field_options.stokes_q_weight_cube,
         stokes_u_weight_cube=rmsynth_field_options.stokes_u_weight_cube,
+        stokes_i_noise_cube=rmsynth_field_options.stokes_i_noise_cube,
+        stokes_q_noise_cube=rmsynth_field_options.stokes_q_noise_cube,
+        stokes_u_noise_cube=rmsynth_field_options.stokes_u_noise_cube,
     )
 
     run_clean = needs_rmclean(

--- a/flint/rmsynth.py
+++ b/flint/rmsynth.py
@@ -132,8 +132,8 @@ def run_rmsynth_3d(
     )
     stokes_i_kwargs = (
         {
-            "stokes_i_file": stokes_cubes.i,
-            "stokes_i_error_file": error_cubes.i if error_cubes else None,
+            "stokes_i_file": stokes_cubes.i_path,
+            "stokes_i_error_file": error_cubes.i_path if error_cubes else None,
             "fit_order": rmsynth_options.fit_order,
             "fit_function": rmsynth_options.fit_function,
             "stokes_i_snr_cut": rmsynth_options.stokes_i_snr_cut,
@@ -143,14 +143,14 @@ def run_rmsynth_3d(
             "compute_model_error": rmsynth_options.compute_model_error,
             "n_error_samples": rmsynth_options.n_error_samples,
         }
-        if stokes_cubes.i is not None
+        if stokes_cubes.i_path is not None
         else {}
     )
     return rmsynth_3d_from_fits(
-        stokes_q_file=stokes_cubes.q,
-        stokes_u_file=stokes_cubes.u,
-        stokes_q_error_file=error_cubes.q if error_cubes else None,
-        stokes_u_error_file=error_cubes.u if error_cubes else None,
+        stokes_q_file=stokes_cubes.q_path,
+        stokes_u_file=stokes_cubes.u_path,
+        stokes_q_error_file=error_cubes.q_path if error_cubes else None,
+        stokes_u_error_file=error_cubes.u_path if error_cubes else None,
         # linmos writes 1/sigma**2 directly, so rm-lite must not invert and
         # square those. A noise cube is a sigma and must be inverted. Applies to
         # the Stokes I error cube as well

--- a/flint/rmsynth.py
+++ b/flint/rmsynth.py
@@ -46,11 +46,11 @@ from rm_lite.utils.synthesis import (  # noqa: E402
 from flint.exceptions import NotSupportedError
 from flint.logging import logger
 from flint.options import (
+    CubesForRMSynth,
+    ErrorCubesForRMSynth,
     RMCleanOptions,
     RMSynthOptions,
-    StokesCubes,
-    StokesErrorCubes,
-    StokesWeightCubes,
+    WeightCubesForRMSynth,
 )
 
 FDFLabel: TypeAlias = Literal["dirty", "clean", "model"]
@@ -110,16 +110,16 @@ def _check_cubes_memmappable(*cubes: Path | None) -> None:
 
 
 def run_rmsynth_3d(
-    stokes_cubes: StokesCubes,
+    stokes_cubes: CubesForRMSynth,
     rmsynth_options: RMSynthOptions,
-    error_cubes: StokesErrorCubes | None = None,
+    error_cubes: ErrorCubesForRMSynth | None = None,
 ) -> RMSynth3DResults:
     """Run 3D RM-synthesis on Stokes Q/U FITS cubes.
 
     Args:
-        stokes_cubes (StokesCubes): The Stokes Q/U cubes, and optionally I to fit a per-pixel fractional-polarisation correction against
+        stokes_cubes (CubesForRMSynth): The Stokes Q/U cubes, and optionally I to fit a per-pixel fractional-polarisation correction against
         rmsynth_options (RMSynthOptions): Options controlling the synthesis
-        error_cubes (StokesErrorCubes | None, optional): Either the linmos weight cubes (an inverse variance) or a set of noise cubes (a sigma), which the type says which of. None leaves rm-lite to estimate a per-channel noise from Q/U itself. Defaults to None.
+        error_cubes (ErrorCubesForRMSynth | None, optional): Either the linmos weight cubes (an inverse variance) or a set of noise cubes (a sigma), which the type says which of. None leaves rm-lite to estimate a per-channel noise from Q/U itself. Defaults to None.
 
     Returns:
         RMSynth3DResults: Lazy dirty FDF cube, the RMSF, and associated
@@ -154,7 +154,7 @@ def run_rmsynth_3d(
         # linmos writes 1/sigma**2 directly, so rm-lite must not invert and
         # square those. A noise cube is a sigma and must be inverted. Applies to
         # the Stokes I error cube as well
-        noise_files_are_weight=isinstance(error_cubes, StokesWeightCubes),
+        noise_files_are_weight=isinstance(error_cubes, WeightCubesForRMSynth),
         phi_max_radm2=rmsynth_options.phi_max_radm2,
         d_phi_radm2=rmsynth_options.d_phi_radm2,
         n_samples=rmsynth_options.n_samples,

--- a/flint/rmsynth.py
+++ b/flint/rmsynth.py
@@ -187,7 +187,8 @@ def run_rmclean_3d(
         auto_threshold=rmclean_options.auto_threshold,
         max_iter=rmclean_options.max_iter,
         gain=rmclean_options.gain,
-        moment_threshold_snr=rmclean_options.moment_threshold_snr,
+        # rm-lite's own moment and peak maps go unused, so its cut is left at
+        # whatever it defaults to; flint derives its own in write_rm_products
         log_level=logging.INFO,
     )
 
@@ -744,7 +745,7 @@ def write_rm_products(
     # applies this same cut inside RM-CLEAN to its own moment maps, which flint
     # does not use, so it is rederived here from the shared theoretical noise.
     moment_threshold = _snr_threshold(
-        rmclean_options.moment_threshold_snr,
+        rmsynth_options.moment_threshold_snr,
         synth_results.theoretical_noise.fdf_error_noise,
     )
     for label in moment_products:
@@ -777,7 +778,7 @@ def write_rm_products(
     # integrates the whole Faraday depth axis, a peak is one sample with no such
     # floor, and peak_pi_error is written beside it to judge significance.
     peak_threshold = _snr_threshold(
-        rmclean_options.peak_threshold_snr,
+        rmsynth_options.peak_threshold_snr,
         synth_results.theoretical_noise.fdf_error_noise,
     )
     for label in peak_products:

--- a/flint/rmsynth.py
+++ b/flint/rmsynth.py
@@ -651,6 +651,8 @@ def write_rm_products(
     moment_products: list[FDFLabel],
     peak_products: list[FDFLabel],
     output_prefix: Path,
+    moment_threshold_snr: float = 5.0,
+    peak_threshold_snr: float = 0.0,
     dask_client: Client | None = None,
 ) -> list[Path]:
     """Batch-compute and write the requested RM-synthesis/RM-CLEAN output products.
@@ -664,6 +666,8 @@ def write_rm_products(
         cube_products (list[FDFLabel]): Which FDF cube(s) to write ('dirty', 'clean', 'model')
         moment_products (list[FDFLabel]): Which FDF(s) to compute Faraday moment maps from
         peak_products (list[FDFLabel]): Which FDF(s) to write peak-statistic maps from, nine per entry
+        moment_threshold_snr (float, optional): SNR cut applied before the moment maps. Defaults to 5.0.
+        peak_threshold_snr (float, optional): SNR cut below which peaks are blanked. Zero applies no cut. Defaults to 0.0.
         output_prefix (Path): Common prefix for the output files
         dask_client (Client | None, optional): A distributed Client (e.g. the one backing a Prefect ``DaskTaskRunner``) to compute across, rather than just the local worker. Defaults to None.
 
@@ -745,7 +749,7 @@ def write_rm_products(
     # applies this same cut inside RM-CLEAN to its own moment maps, which flint
     # does not use, so it is rederived here from the shared theoretical noise.
     moment_threshold = _snr_threshold(
-        rmsynth_options.moment_threshold_snr,
+        moment_threshold_snr,
         synth_results.theoretical_noise.fdf_error_noise,
     )
     for label in moment_products:
@@ -778,7 +782,7 @@ def write_rm_products(
     # integrates the whole Faraday depth axis, a peak is one sample with no such
     # floor, and peak_pi_error is written beside it to judge significance.
     peak_threshold = _snr_threshold(
-        rmsynth_options.peak_threshold_snr,
+        peak_threshold_snr,
         synth_results.theoretical_noise.fdf_error_noise,
     )
     for label in peak_products:

--- a/flint/rmsynth.py
+++ b/flint/rmsynth.py
@@ -45,7 +45,13 @@ from rm_lite.utils.synthesis import (  # noqa: E402
 
 from flint.exceptions import NotSupportedError
 from flint.logging import logger
-from flint.options import RMCleanOptions, RMSynthOptions
+from flint.options import (
+    RMCleanOptions,
+    RMSynthOptions,
+    StokesCubes,
+    StokesErrorCubes,
+    StokesWeightCubes,
+)
 
 FDFLabel: TypeAlias = Literal["dirty", "clean", "model"]
 FDFThreshold: TypeAlias = float | np.ndarray | da.Array | None
@@ -104,30 +110,16 @@ def _check_cubes_memmappable(*cubes: Path | None) -> None:
 
 
 def run_rmsynth_3d(
-    stokes_q_cube: Path,
-    stokes_u_cube: Path,
+    stokes_cubes: StokesCubes,
     rmsynth_options: RMSynthOptions,
-    stokes_i_cube: Path | None = None,
-    stokes_q_weight_cube: Path | None = None,
-    stokes_u_weight_cube: Path | None = None,
-    stokes_i_weight_cube: Path | None = None,
-    stokes_q_noise_cube: Path | None = None,
-    stokes_u_noise_cube: Path | None = None,
-    stokes_i_noise_cube: Path | None = None,
+    error_cubes: StokesErrorCubes | None = None,
 ) -> RMSynth3DResults:
     """Run 3D RM-synthesis on Stokes Q/U FITS cubes.
 
     Args:
-        stokes_q_cube (Path): Path to the Stokes Q FITS cube
-        stokes_u_cube (Path): Path to the Stokes U FITS cube
+        stokes_cubes (StokesCubes): The Stokes Q/U cubes, and optionally I to fit a per-pixel fractional-polarisation correction against
         rmsynth_options (RMSynthOptions): Options controlling the synthesis
-        stokes_i_cube (Path | None, optional): Path to a Stokes I FITS cube, used to fit a per-pixel fractional-polarisation correction. FDF stays in Q/U flux if not given. Defaults to None.
-        stokes_q_weight_cube (Path | None, optional): Path to the linmos Stokes Q weight cube, giving each pixel its own channel weights rather than one spectrum estimated from the Q/U cubes. rm-lite requires both Q and U, or neither. Defaults to None.
-        stokes_u_weight_cube (Path | None, optional): Path to the linmos Stokes U weight cube. See ``stokes_q_weight_cube``. Defaults to None.
-        stokes_i_weight_cube (Path | None, optional): Path to the linmos Stokes I weight cube, used to weight the per-pixel Stokes I fit and to score it against ``stokes_i_snr_cut``. Falls back to ``RMSynthOptions.estimate_stokes_i_noise`` if not given. Defaults to None.
-        stokes_q_noise_cube (Path | None, optional): Path to a Stokes Q noise (sigma) cube, e.g. the BANE RMS cube. Takes precedence over ``stokes_q_weight_cube``: it is a noise rather than an inverse variance, so rm-lite inverts and squares it. Defaults to None.
-        stokes_u_noise_cube (Path | None, optional): Path to a Stokes U noise cube. See ``stokes_q_noise_cube``. Defaults to None.
-        stokes_i_noise_cube (Path | None, optional): Path to a Stokes I noise cube. See ``stokes_q_noise_cube``. Defaults to None.
+        error_cubes (StokesErrorCubes | None, optional): Either the linmos weight cubes (an inverse variance) or a set of noise cubes (a sigma), which the type says which of. None leaves rm-lite to estimate a per-channel noise from Q/U itself. Defaults to None.
 
     Returns:
         RMSynth3DResults: Lazy dirty FDF cube, the RMSF, and associated
@@ -136,57 +128,33 @@ def run_rmsynth_3d(
         itself; see ``RMSynthOptions.per_pixel_rmsf`` for what that costs
     """
     _check_cubes_memmappable(
-        stokes_q_cube,
-        stokes_u_cube,
-        stokes_i_cube,
-        stokes_q_weight_cube,
-        stokes_u_weight_cube,
-        stokes_i_weight_cube,
-        stokes_q_noise_cube,
-        stokes_u_noise_cube,
-        stokes_i_noise_cube,
+        *stokes_cubes.paths, *(error_cubes.paths if error_cubes else ())
     )
-    # A noise cube is sigma, a linmos weight cube is 1/sigma**2. rm-lite takes
-    # either through the same argument and is told which by
-    # `noise_files_are_weight`, so the two cannot be mixed.
-    use_noise_cubes = any(
-        cube is not None
-        for cube in (stokes_q_noise_cube, stokes_u_noise_cube, stokes_i_noise_cube)
-    )
-    if use_noise_cubes and any(
-        cube is not None
-        for cube in (stokes_q_weight_cube, stokes_u_weight_cube, stokes_i_weight_cube)
-    ):
-        msg = "Pass either the noise cubes or the linmos weight cubes, not both."
-        raise ValueError(msg)
-    q_error_cube = stokes_q_noise_cube if use_noise_cubes else stokes_q_weight_cube
-    u_error_cube = stokes_u_noise_cube if use_noise_cubes else stokes_u_weight_cube
-    i_error_cube = stokes_i_noise_cube if use_noise_cubes else stokes_i_weight_cube
     stokes_i_kwargs = (
         {
-            "stokes_i_file": stokes_i_cube,
-            "stokes_i_error_file": i_error_cube,
+            "stokes_i_file": stokes_cubes.i,
+            "stokes_i_error_file": error_cubes.i if error_cubes else None,
             "fit_order": rmsynth_options.fit_order,
             "fit_function": rmsynth_options.fit_function,
             "stokes_i_snr_cut": rmsynth_options.stokes_i_snr_cut,
-            # Only consulted when no Stokes I weight cube is given: rm-lite
+            # Only consulted when no Stokes I error cube is given: rm-lite
             # refuses a stokes_i_snr_cut it has no error to measure against.
             "estimate_stokes_i_noise": rmsynth_options.estimate_stokes_i_noise,
             "compute_model_error": rmsynth_options.compute_model_error,
             "n_error_samples": rmsynth_options.n_error_samples,
         }
-        if stokes_i_cube is not None
+        if stokes_cubes.i is not None
         else {}
     )
     return rmsynth_3d_from_fits(
-        stokes_q_file=stokes_q_cube,
-        stokes_u_file=stokes_u_cube,
-        stokes_q_error_file=q_error_cube,
-        stokes_u_error_file=u_error_cube,
+        stokes_q_file=stokes_cubes.q,
+        stokes_u_file=stokes_cubes.u,
+        stokes_q_error_file=error_cubes.q if error_cubes else None,
+        stokes_u_error_file=error_cubes.u if error_cubes else None,
         # linmos writes 1/sigma**2 directly, so rm-lite must not invert and
-        # square those. A BANE RMS cube is a noise and must be inverted. Applies
-        # to the Stokes I error cube as well
-        noise_files_are_weight=not use_noise_cubes,
+        # square those. A noise cube is a sigma and must be inverted. Applies to
+        # the Stokes I error cube as well
+        noise_files_are_weight=isinstance(error_cubes, StokesWeightCubes),
         phi_max_radm2=rmsynth_options.phi_max_radm2,
         d_phi_radm2=rmsynth_options.d_phi_radm2,
         n_samples=rmsynth_options.n_samples,

--- a/flint/rmsynth.py
+++ b/flint/rmsynth.py
@@ -410,14 +410,9 @@ def write_stokes_i_coeff_maps_to_fits(
 def _snr_threshold(snr: float, fdf_error_noise: FDFThreshold) -> FDFThreshold:
     """An FDF amplitude cut ``snr`` times the theoretical noise, or None for no cut.
 
-    Zero means no cut, and has to short-circuit rather than multiply through:
-    the theoretical noise is ``inf`` wherever a pixel carries no weight at all
-    (linmos blanks the mosaic edge), and ``0 * inf`` is NaN, which blanks every
-    comparison against it instead of passing everything.
-
-    The noise is a scalar for per-channel weights and a lazy (ny, nx) map for
-    the per-pixel ones the linmos cubes give, so the cut comes back in whichever
-    form it arrived in.
+    Zero short-circuits rather than multiplying through: the noise is ``inf``
+    where a pixel carries no weight, and ``0 * inf`` is NaN, which would blank
+    every comparison instead of passing everything.
     """
     if snr == 0 or fdf_error_noise is None:
         return None
@@ -776,15 +771,11 @@ def write_rm_products(
         assert clean_results is not None  # run_clean is `clean_results is not None`
         compute_targets["rmclean_niter"] = clean_results.iter_count_map
 
-    # rm-lite returns peaks of its own on RMClean3DResults, but only for the
-    # clean FDF and only under its own threshold. Deriving them here is what
-    # lets any requested FDF have them -- the dirty one included, which needs no
-    # RM-CLEAN at all -- under a cut flint chooses.
-    #
-    # A separate cut from the moments, and off by default. The moment cut exists
-    # because mom0 integrates the whole Faraday depth axis; a peak is one sample
-    # and has no such floor, so blanking it discards a real measurement whose
-    # error (peak_pi_error) is written beside it.
+    # rm-lite's own peaks cover only the clean FDF under its own threshold;
+    # deriving them here lets any requested FDF have them, the dirty one
+    # included. Cut separately from the moments and off by default: mom0
+    # integrates the whole Faraday depth axis, a peak is one sample with no such
+    # floor, and peak_pi_error is written beside it to judge significance.
     peak_threshold = _snr_threshold(
         rmclean_options.peak_threshold_snr,
         synth_results.theoretical_noise.fdf_error_noise,

--- a/flint/rmsynth.py
+++ b/flint/rmsynth.py
@@ -111,6 +111,9 @@ def run_rmsynth_3d(
     stokes_q_weight_cube: Path | None = None,
     stokes_u_weight_cube: Path | None = None,
     stokes_i_weight_cube: Path | None = None,
+    stokes_q_noise_cube: Path | None = None,
+    stokes_u_noise_cube: Path | None = None,
+    stokes_i_noise_cube: Path | None = None,
 ) -> RMSynth3DResults:
     """Run 3D RM-synthesis on Stokes Q/U FITS cubes.
 
@@ -122,6 +125,9 @@ def run_rmsynth_3d(
         stokes_q_weight_cube (Path | None, optional): Path to the linmos Stokes Q weight cube, giving each pixel its own channel weights rather than one spectrum estimated from the Q/U cubes. rm-lite requires both Q and U, or neither. Defaults to None.
         stokes_u_weight_cube (Path | None, optional): Path to the linmos Stokes U weight cube. See ``stokes_q_weight_cube``. Defaults to None.
         stokes_i_weight_cube (Path | None, optional): Path to the linmos Stokes I weight cube, used to weight the per-pixel Stokes I fit and to score it against ``stokes_i_snr_cut``. Falls back to ``RMSynthOptions.estimate_stokes_i_noise`` if not given. Defaults to None.
+        stokes_q_noise_cube (Path | None, optional): Path to a Stokes Q noise (sigma) cube, e.g. the BANE RMS cube. Takes precedence over ``stokes_q_weight_cube``: it is a noise rather than an inverse variance, so rm-lite inverts and squares it. Defaults to None.
+        stokes_u_noise_cube (Path | None, optional): Path to a Stokes U noise cube. See ``stokes_q_noise_cube``. Defaults to None.
+        stokes_i_noise_cube (Path | None, optional): Path to a Stokes I noise cube. See ``stokes_q_noise_cube``. Defaults to None.
 
     Returns:
         RMSynth3DResults: Lazy dirty FDF cube, the RMSF, and associated
@@ -136,11 +142,30 @@ def run_rmsynth_3d(
         stokes_q_weight_cube,
         stokes_u_weight_cube,
         stokes_i_weight_cube,
+        stokes_q_noise_cube,
+        stokes_u_noise_cube,
+        stokes_i_noise_cube,
     )
+    # A noise cube is sigma, a linmos weight cube is 1/sigma**2. rm-lite takes
+    # either through the same argument and is told which by
+    # `noise_files_are_weight`, so the two cannot be mixed.
+    use_noise_cubes = any(
+        cube is not None
+        for cube in (stokes_q_noise_cube, stokes_u_noise_cube, stokes_i_noise_cube)
+    )
+    if use_noise_cubes and any(
+        cube is not None
+        for cube in (stokes_q_weight_cube, stokes_u_weight_cube, stokes_i_weight_cube)
+    ):
+        msg = "Pass either the noise cubes or the linmos weight cubes, not both."
+        raise ValueError(msg)
+    q_error_cube = stokes_q_noise_cube if use_noise_cubes else stokes_q_weight_cube
+    u_error_cube = stokes_u_noise_cube if use_noise_cubes else stokes_u_weight_cube
+    i_error_cube = stokes_i_noise_cube if use_noise_cubes else stokes_i_weight_cube
     stokes_i_kwargs = (
         {
             "stokes_i_file": stokes_i_cube,
-            "stokes_i_error_file": stokes_i_weight_cube,
+            "stokes_i_error_file": i_error_cube,
             "fit_order": rmsynth_options.fit_order,
             "fit_function": rmsynth_options.fit_function,
             "stokes_i_snr_cut": rmsynth_options.stokes_i_snr_cut,
@@ -156,11 +181,12 @@ def run_rmsynth_3d(
     return rmsynth_3d_from_fits(
         stokes_q_file=stokes_q_cube,
         stokes_u_file=stokes_u_cube,
-        stokes_q_error_file=stokes_q_weight_cube,
-        stokes_u_error_file=stokes_u_weight_cube,
+        stokes_q_error_file=q_error_cube,
+        stokes_u_error_file=u_error_cube,
         # linmos writes 1/sigma**2 directly, so rm-lite must not invert and
-        # square these again. Applies to the Stokes I error cube as well
-        noise_files_are_weight=True,
+        # square those. A BANE RMS cube is a noise and must be inverted. Applies
+        # to the Stokes I error cube as well
+        noise_files_are_weight=not use_noise_cubes,
         phi_max_radm2=rmsynth_options.phi_max_radm2,
         d_phi_radm2=rmsynth_options.d_phi_radm2,
         n_samples=rmsynth_options.n_samples,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,8 @@ dynamic = ["version"]
 dependencies = [
     "astropy>=6.1.3", # fixing until units change in 6.1.4 addressed in radio-beam
     "numpy>=2.0.0",
+    "numba",
+    "rocket-fft",
     "pydantic>=2",
     "scipy",
     "spython>=0.3.1",

--- a/tests/test_bane.py
+++ b/tests/test_bane.py
@@ -1,0 +1,207 @@
+"""Tests for the FFT BANE port in ``flint.bane``"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+from astropy.io import fits
+from astropy.wcs import WCS
+
+from flint.bane import (
+    FFTBANEOptions,
+    bane_fits_image,
+    fft_average,
+    gaussian_kernel,
+    get_kernel,
+    pad_reflect,
+    robust_bane,
+    tophat_kernel,
+)
+
+NY = NX = 1024
+PIX_PER_BEAM = 10
+
+
+def _header(shape: tuple[int, int] = (NY, NX)) -> fits.Header:
+    """A minimal header carrying the beam and pixel scale ``get_kernel`` needs"""
+    wcs = WCS(naxis=2)
+    wcs.wcs.ctype = ["RA---SIN", "DEC--SIN"]
+    wcs.wcs.crval = [180.0, -30.0]
+    wcs.wcs.crpix = [shape[1] / 2, shape[0] / 2]
+    wcs.wcs.cdelt = [-1 / 3600, 1 / 3600]
+    wcs.wcs.cunit = ["deg", "deg"]
+    header = wcs.to_header()
+    header["BMAJ"] = PIX_PER_BEAM / 3600
+    header["BMIN"] = PIX_PER_BEAM / 3600
+    header["BPA"] = 0.0
+    return header
+
+
+def _sky(background: float = 0.0, rms: float = 1e-3, seed: int = 0) -> np.ndarray:
+    """Noise on a flat background, with three point sources"""
+    rng = np.random.default_rng(seed)
+    image = rng.normal(background, rms, (NY, NX)).astype(np.float32)
+    for y, x in ((200, 300), (700, 800), (500, 120)):
+        image[y, x] += 0.5
+    return image
+
+
+def test_pad_reflect_matches_numpy() -> None:
+    """It is a numba-compatible np.pad(mode='reflect'), so it has to agree with
+    the thing it replaces."""
+    rng = np.random.default_rng(0)
+    array = rng.normal(size=(17, 23)).astype(np.float32)
+
+    for pad_y, pad_x in ((1, 1), (5, 3), (8, 11)):
+        assert np.allclose(
+            pad_reflect(array, (pad_y, pad_x)),
+            np.pad(array, ((pad_y, pad_y), (pad_x, pad_x)), mode="reflect"),
+        ), (pad_y, pad_x)
+
+
+def test_fft_average_preserves_a_flat_image() -> None:
+    """The kernel is normalised by its own sum, so smoothing a constant image
+    returns that constant rather than scaling it."""
+    image = np.full((128, 128), 3.0, dtype=np.float32)
+
+    for kernel in (gaussian_kernel(5), tophat_kernel(8)):
+        assert np.allclose(fft_average(image, kernel), 3.0, atol=1e-4)
+
+
+def test_bane_recovers_a_varying_background_and_rms() -> None:
+    """The point of BANE: both the background and the noise vary across the
+    image, and a single number for either would be wrong. Neither is uniform
+    here, and the sources must not drag the noise up."""
+    rng = np.random.default_rng(0)
+    yy, xx = np.mgrid[0:NY, 0:NX]
+    truth_bkg = 2e-3 * (yy / NY)
+    truth_rms = 1e-3 * (1 + xx / NX)
+    image = (rng.normal(0, 1, (NY, NX)) * truth_rms + truth_bkg).astype(np.float32)
+    image[200, 300] += 0.5
+
+    background, rms = robust_bane(image=image, header=_header())
+
+    assert background.shape == image.shape
+    assert rms.shape == image.shape
+    assert np.isfinite(background).all()
+    assert np.isfinite(rms).all()
+
+    # Downsampling and smoothing bias both low, so this is a loose check that
+    # the maps track the truth rather than a tight one on their values
+    assert np.nanmedian(background) == pytest.approx(np.median(truth_bkg), rel=0.3)
+    assert np.nanmedian(rms) == pytest.approx(np.median(truth_rms), rel=0.3)
+
+    # The gradient is the part a scalar noise estimate cannot express
+    assert np.nanmedian(rms[:, -100:]) > 1.5 * np.nanmedian(rms[:, :100])
+    assert np.nanmedian(background[-100:, :]) > np.nanmedian(background[:100, :])
+
+
+def test_blanked_pixels_stay_blank() -> None:
+    """A linmos mosaic blanks beyond its cutoff. Those pixels have no data to
+    measure, so they come back NaN rather than as an extrapolated background."""
+    image = _sky()
+    blank = np.zeros_like(image, dtype=bool)
+    blank[:50, :] = True
+    image[blank] = np.nan
+
+    background, rms = robust_bane(image=image, header=_header())
+
+    assert np.isnan(background[blank]).all()
+    assert np.isnan(rms[blank]).all()
+    assert np.isfinite(background[~blank]).all()
+    assert np.isfinite(rms[~blank]).all()
+
+
+def test_the_seed_makes_a_rerun_reproducible() -> None:
+    """Clipped source pixels are refilled with random noise, so without a fixed
+    seed the same image gives different maps run to run."""
+    image = _sky()
+    # A cut low enough that the refilled pixels survive the downsampling; at the
+    # default 5 sigma only a handful of pixels are touched and the maps agree
+    # whatever the seed
+    options = FFTBANEOptions(clip_sigma=1.0)
+
+    first, _ = robust_bane(image=image, header=_header(), fft_bane_options=options)
+    again, _ = robust_bane(image=image, header=_header(), fft_bane_options=options)
+    assert np.array_equal(first, again)
+
+    other, _ = robust_bane(
+        image=image,
+        header=_header(),
+        fft_bane_options=options.with_options(seed=99),
+    )
+    assert not np.array_equal(first, other)
+
+
+def test_get_kernel_sizes_itself_from_the_beam() -> None:
+    """Unset sizes come from the restoring beam, at 3 and 10 beams. A negative
+    value keeps that behaviour but sets the beam count."""
+    kernel, step = get_kernel(header=_header())
+    assert step == 3 * PIX_PER_BEAM
+    assert kernel.max() == pytest.approx(1.0)
+
+    _, step = get_kernel(header=_header(), step_size=-5)
+    assert step == 5 * PIX_PER_BEAM
+
+    kernel, step = get_kernel(header=_header(), step_size=7, box_size=4)
+    assert step == 7
+    assert kernel.shape == gaussian_kernel(4).shape
+
+
+def test_get_kernel_needs_a_beam_it_can_read() -> None:
+    """Without a beam there is nothing to size the kernel against, so it says so
+    rather than picking a number."""
+    header = _header()
+    for key in ("BMAJ", "BMIN", "BPA"):
+        del header[key]
+
+    with pytest.raises(ValueError, match="Could not parse beam"):
+        get_kernel(header=header)
+
+
+def test_a_kernel_too_big_for_the_image_is_refused() -> None:
+    """``pad_reflect`` is njit-ed without bounds checking, so a kernel wider than
+    the image it pads reads off the end and returns quietly wrong maps. A small
+    image with a big step downsamples into exactly that."""
+    with pytest.raises(ValueError, match="does not fit"):
+        robust_bane(
+            image=np.zeros((64, 64), dtype=np.float32),
+            header=_header(),
+            fft_bane_options=FFTBANEOptions(step_size=16, box_size=32),
+        )
+
+
+def test_bane_fits_image_writes_maps_on_the_input_grid(tmp_path: Path) -> None:
+    """The maps are stacked into cubes beside the image they came from, so they
+    have to keep its shape, including the degenerate axes a linmos plane carries.
+    """
+    image = _sky(background=0.0, rms=1e-3)
+    header = _header()
+    # A linmos plane is (stokes, freq, ny, nx)
+    fits_path = tmp_path / "field.image.fits"
+    fits.writeto(fits_path, image[np.newaxis, np.newaxis], header, overwrite=True)
+
+    bkg_path, rms_path = bane_fits_image(image=fits_path)
+
+    assert bkg_path == tmp_path / "field.image_bkg.fits"
+    assert rms_path == tmp_path / "field.image_rms.fits"
+
+    for path in (bkg_path, rms_path):
+        assert path.exists()
+        assert fits.getdata(path).shape == (1, 1, NY, NX)
+
+    assert np.nanmedian(fits.getdata(rms_path)) == pytest.approx(1e-3, rel=0.3)
+
+
+def test_bane_fits_image_refuses_a_cube(tmp_path: Path) -> None:
+    """Only single planes are ported, so a real cube is an error rather than a
+    silently measured first channel."""
+    fits_path = tmp_path / "cube.fits"
+    fits.writeto(
+        fits_path, np.zeros((4, 32, 32), dtype=np.float32), _header(), overwrite=True
+    )
+
+    with pytest.raises(ValueError, match="expected a single plane"):
+        bane_fits_image(image=fits_path)

--- a/tests/test_prefect_rmsynth_flow.py
+++ b/tests/test_prefect_rmsynth_flow.py
@@ -24,7 +24,8 @@ from flint.convol import (
     cubes_share_common_beam,
     usable_beam_mask,
 )
-from flint.options import RMSynthFieldOptions
+from flint.options import FFTBANEOptions, RMSynthFieldOptions
+from flint.prefect.common.rmsynth import CommonResolutionCubes
 from flint.prefect.flows.rmsynth_pipeline import (
     _resolve_common_resolution_cubes,
     process_rmsynth,
@@ -226,17 +227,34 @@ def test_process_rmsynth_with_stokes_i_on_dask_cluster(
     )
 
 
-def _resolved_cubes(
-    cubes: dict[str, Path], output_path: Path, beam_cutoff: float | None = None
-) -> tuple[dict[str, Path], list[Path]]:
+def _resolve_cubes(
+    cubes: dict[str, Path],
+    output_path: Path,
+    beam_cutoff: float | None = None,
+    fft_bane_options: FFTBANEOptions | None = None,
+) -> CommonResolutionCubes:
     @flow
-    def _resolve() -> tuple[dict[str, Path], list[Path]]:
+    def _resolve() -> CommonResolutionCubes:
         return _resolve_common_resolution_cubes(
-            stokes_cubes=cubes, output_path=output_path, beam_cutoff=beam_cutoff
+            stokes_cubes=cubes,
+            output_path=output_path,
+            beam_cutoff=beam_cutoff,
+            fft_bane_options=fft_bane_options,
         )
 
     with prefect_test_harness(), disable_run_logger():
         return _resolve()
+
+
+def _resolved_cubes(
+    cubes: dict[str, Path], output_path: Path, beam_cutoff: float | None = None
+) -> tuple[dict[str, Path], list[Path]]:
+    """The cubes to use, and the new ones written, as the callers of
+    ``_resolve_common_resolution_cubes`` see them"""
+    resolved = _resolve_cubes(
+        cubes=cubes, output_path=output_path, beam_cutoff=beam_cutoff
+    )
+    return resolved.cubes, (list(resolved.cubes.values()) if resolved.convolved else [])
 
 
 def _cubes_with_beams(tmp_path: Path, offsets: dict[str, float]) -> dict[str, Path]:
@@ -366,3 +384,54 @@ def test_resolve_common_resolution_cubes_without_usable_beams(tmp_path: Path) ->
 
     assert resolved == cubes
     assert convolved_cubes == []
+
+
+def test_bane_cubes_are_measured_on_the_convolved_planes(tmp_path: Path) -> None:
+    """The noise has to describe the cubes the FDF is built from. Convolving to a
+    common beam changes them, so measuring on the polarisation stage's natural
+    resolution cubes would describe a resolution rm-synthesis never reads. These
+    are measured after the convolution instead, and land on the convolved grid.
+    """
+    cubes = _cubes_with_beams(tmp_path, {"q": 0.0, "u": 0.5})
+    output_path = tmp_path / "rmsynth"
+
+    resolved = _resolve_cubes(
+        cubes=cubes,
+        output_path=output_path,
+        fft_bane_options=FFTBANEOptions(step_size=2, box_size=2),
+    )
+
+    assert resolved.convolved
+    assert set(resolved.bkg_cubes) == set(resolved.rms_cubes) == {"q", "u"}
+    for stokes, rms_cube in resolved.rms_cubes.items():
+        assert rms_cube.exists()
+        # Same grid as the convolved cube it was measured on, so rm-lite can read
+        # the two together
+        assert (
+            fits.getdata(rms_cube).shape == fits.getdata(resolved.cubes[stokes]).shape
+        )
+    assert all(cube.exists() for cube in resolved.bkg_cubes.values())
+    # Everything written is a frequency cube the racs-all flow has to spice
+    assert set(resolved.all_cubes) == {
+        *resolved.cubes.values(),
+        *resolved.bkg_cubes.values(),
+        *resolved.rms_cubes.values(),
+    }
+
+
+def test_no_bane_cubes_without_a_convolution(tmp_path: Path) -> None:
+    """Cubes already at one resolution are used as they are, so this stage writes
+    nothing and has nothing to measure. The caller's own noise cubes, measured on
+    those same cubes by the polarisation stage, are already right."""
+    cubes = _cubes_with_beams(tmp_path, {"q": 0.0, "u": 0.0})
+
+    resolved = _resolve_cubes(
+        cubes=cubes,
+        output_path=tmp_path / "rmsynth",
+        fft_bane_options=FFTBANEOptions(step_size=2, box_size=2),
+    )
+
+    assert not resolved.convolved
+    assert resolved.cubes == cubes
+    assert resolved.rms_cubes == {}
+    assert resolved.all_cubes == []

--- a/tests/test_prefect_rmsynth_flow.py
+++ b/tests/test_prefect_rmsynth_flow.py
@@ -24,7 +24,7 @@ from flint.convol import (
     cubes_share_common_beam,
     usable_beam_mask,
 )
-from flint.options import FFTBANEOptions, RMSynthFieldOptions, StokesCubes
+from flint.options import CubesForRMSynth, FFTBANEOptions, RMSynthFieldOptions
 from flint.prefect.common.rmsynth import CommonResolutionCubes
 from flint.prefect.flows.rmsynth_pipeline import (
     _resolve_common_resolution_cubes,
@@ -81,7 +81,7 @@ def test_process_rmsynth_on_dask_cluster(
     monkeypatch.setenv("OMP_NUM_THREADS", "1")
 
     rmsynth_field_options = RMSynthFieldOptions(
-        stokes_cubes=StokesCubes(q=stokes_q_cube, u=stokes_u_cube),
+        stokes_cubes=CubesForRMSynth(q=stokes_q_cube, u=stokes_u_cube),
         cube_products=["dirty"],
         moment_products=["clean"],
     )
@@ -153,7 +153,7 @@ def test_process_rmsynth_no_products_submits_nothing(
     with prefect_test_harness(), disable_run_logger():
         rmsynth_result = process_rmsynth(
             rmsynth_field_options=RMSynthFieldOptions(
-                stokes_cubes=StokesCubes(q=stokes_q_cube, u=stokes_u_cube),
+                stokes_cubes=CubesForRMSynth(q=stokes_q_cube, u=stokes_u_cube),
                 cube_products=[],
                 moment_products=[],
             )
@@ -179,7 +179,7 @@ def test_process_rmsynth_with_stokes_i_on_dask_cluster(
     monkeypatch.setenv("OMP_NUM_THREADS", "1")
 
     rmsynth_field_options = RMSynthFieldOptions(
-        stokes_cubes=StokesCubes(q=stokes_q_cube, u=stokes_u_cube, i=stokes_i_cube),
+        stokes_cubes=CubesForRMSynth(q=stokes_q_cube, u=stokes_u_cube, i=stokes_i_cube),
         cube_products=[],
         moment_products=["clean"],
     )

--- a/tests/test_prefect_rmsynth_flow.py
+++ b/tests/test_prefect_rmsynth_flow.py
@@ -81,7 +81,7 @@ def test_process_rmsynth_on_dask_cluster(
     monkeypatch.setenv("OMP_NUM_THREADS", "1")
 
     rmsynth_field_options = RMSynthFieldOptions(
-        stokes_cubes=CubesForRMSynth(q=stokes_q_cube, u=stokes_u_cube),
+        stokes_cubes=CubesForRMSynth(q_path=stokes_q_cube, u_path=stokes_u_cube),
         cube_products=["dirty"],
         moment_products=["clean"],
     )
@@ -153,7 +153,9 @@ def test_process_rmsynth_no_products_submits_nothing(
     with prefect_test_harness(), disable_run_logger():
         rmsynth_result = process_rmsynth(
             rmsynth_field_options=RMSynthFieldOptions(
-                stokes_cubes=CubesForRMSynth(q=stokes_q_cube, u=stokes_u_cube),
+                stokes_cubes=CubesForRMSynth(
+                    q_path=stokes_q_cube, u_path=stokes_u_cube
+                ),
                 cube_products=[],
                 moment_products=[],
             )
@@ -179,7 +181,9 @@ def test_process_rmsynth_with_stokes_i_on_dask_cluster(
     monkeypatch.setenv("OMP_NUM_THREADS", "1")
 
     rmsynth_field_options = RMSynthFieldOptions(
-        stokes_cubes=CubesForRMSynth(q=stokes_q_cube, u=stokes_u_cube, i=stokes_i_cube),
+        stokes_cubes=CubesForRMSynth(
+            q_path=stokes_q_cube, u_path=stokes_u_cube, i_path=stokes_i_cube
+        ),
         cube_products=[],
         moment_products=["clean"],
     )

--- a/tests/test_prefect_rmsynth_flow.py
+++ b/tests/test_prefect_rmsynth_flow.py
@@ -24,7 +24,7 @@ from flint.convol import (
     cubes_share_common_beam,
     usable_beam_mask,
 )
-from flint.options import FFTBANEOptions, RMSynthFieldOptions
+from flint.options import FFTBANEOptions, RMSynthFieldOptions, StokesCubes
 from flint.prefect.common.rmsynth import CommonResolutionCubes
 from flint.prefect.flows.rmsynth_pipeline import (
     _resolve_common_resolution_cubes,
@@ -81,8 +81,7 @@ def test_process_rmsynth_on_dask_cluster(
     monkeypatch.setenv("OMP_NUM_THREADS", "1")
 
     rmsynth_field_options = RMSynthFieldOptions(
-        stokes_q_cube=stokes_q_cube,
-        stokes_u_cube=stokes_u_cube,
+        stokes_cubes=StokesCubes(q=stokes_q_cube, u=stokes_u_cube),
         cube_products=["dirty"],
         moment_products=["clean"],
     )
@@ -154,8 +153,7 @@ def test_process_rmsynth_no_products_submits_nothing(
     with prefect_test_harness(), disable_run_logger():
         rmsynth_result = process_rmsynth(
             rmsynth_field_options=RMSynthFieldOptions(
-                stokes_q_cube=stokes_q_cube,
-                stokes_u_cube=stokes_u_cube,
+                stokes_cubes=StokesCubes(q=stokes_q_cube, u=stokes_u_cube),
                 cube_products=[],
                 moment_products=[],
             )
@@ -181,9 +179,7 @@ def test_process_rmsynth_with_stokes_i_on_dask_cluster(
     monkeypatch.setenv("OMP_NUM_THREADS", "1")
 
     rmsynth_field_options = RMSynthFieldOptions(
-        stokes_q_cube=stokes_q_cube,
-        stokes_u_cube=stokes_u_cube,
-        stokes_i_cube=stokes_i_cube,
+        stokes_cubes=StokesCubes(q=stokes_q_cube, u=stokes_u_cube, i=stokes_i_cube),
         cube_products=[],
         moment_products=["clean"],
     )

--- a/tests/test_racs_all_pipeline.py
+++ b/tests/test_racs_all_pipeline.py
@@ -163,7 +163,7 @@ def test_process_racs_all_everything_disabled_returns_immediately(
     )
     pol_field_options = PolFieldOptions()
     rmsynth_field_options = RMSynthFieldOptions(
-        stokes_cubes=CubesForRMSynth(q=Path("/tmp/q.fits"), u=Path("/tmp/u.fits"))
+        stokes_cubes=CubesForRMSynth(q_path=Path("/tmp/q.fits"), u=Path("/tmp/u.fits"))
     )
     spice_field_options = SpiceFieldOptions(cubes=[Path("/tmp/i.fits")])
 
@@ -489,8 +489,8 @@ def test_bane_rms_cubes_are_preferred_over_the_linmos_weights(
 
     options = _rmsynth_options(rmsynth_stage)
     assert isinstance(options.error_cubes, NoiseCubesForRMSynth)
-    assert options.error_cubes.q == tmp_path / "q_rms.fits"
-    assert options.error_cubes.u == tmp_path / "u_rms.fits"
+    assert options.error_cubes.q_path == tmp_path / "q_rms.fits"
+    assert options.error_cubes.u_path == tmp_path / "u_rms.fits"
 
 
 def test_the_linmos_weights_are_used_when_bane_did_not_run(
@@ -506,7 +506,7 @@ def test_the_linmos_weights_are_used_when_bane_did_not_run(
 
     options = _rmsynth_options(rmsynth_stage)
     assert isinstance(options.error_cubes, WeightCubesForRMSynth)
-    assert options.error_cubes.q == tmp_path / "q.weight.fits"
+    assert options.error_cubes.q_path == tmp_path / "q.weight.fits"
 
 
 def test_the_bane_cubes_are_spiced(

--- a/tests/test_racs_all_pipeline.py
+++ b/tests/test_racs_all_pipeline.py
@@ -16,6 +16,9 @@ from flint.options import (
     RACSAllPipelineOptions,
     RMSynthFieldOptions,
     SpiceFieldOptions,
+    StokesCubes,
+    StokesNoiseCubes,
+    StokesWeightCubes,
 )
 from flint.prefect.flows.racs_all_pipeline import (
     _check_racs_all_pipeline_options,
@@ -60,7 +63,7 @@ def test_get_parser_excludes_computed_stage_outputs() -> None:
     spice_field_options = create_options_from_parser(
         parser_namespace=args, options_class=SpiceFieldOptions
     )
-    assert rmsynth_field_options.stokes_q_cube is None
+    assert rmsynth_field_options.stokes_cubes is None
     assert spice_field_options.cubes == []
     assert spice_field_options.weight_cubes == []
 
@@ -160,7 +163,7 @@ def test_process_racs_all_everything_disabled_returns_immediately(
     )
     pol_field_options = PolFieldOptions()
     rmsynth_field_options = RMSynthFieldOptions(
-        stokes_q_cube=Path("/tmp/q.fits"), stokes_u_cube=Path("/tmp/u.fits")
+        stokes_cubes=StokesCubes(q=Path("/tmp/q.fits"), u=Path("/tmp/u.fits"))
     )
     spice_field_options = SpiceFieldOptions(cubes=[Path("/tmp/i.fits")])
 
@@ -485,10 +488,9 @@ def test_bane_rms_cubes_are_preferred_over_the_linmos_weights(
     _run_racs_all(tmp_path=tmp_path)
 
     options = _rmsynth_options(rmsynth_stage)
-    assert options.stokes_q_noise_cube == tmp_path / "q_rms.fits"
-    assert options.stokes_u_noise_cube == tmp_path / "u_rms.fits"
-    assert options.stokes_q_weight_cube is None
-    assert options.stokes_u_weight_cube is None
+    assert isinstance(options.error_cubes, StokesNoiseCubes)
+    assert options.error_cubes.q == tmp_path / "q_rms.fits"
+    assert options.error_cubes.u == tmp_path / "u_rms.fits"
 
 
 def test_the_linmos_weights_are_used_when_bane_did_not_run(
@@ -503,8 +505,8 @@ def test_the_linmos_weights_are_used_when_bane_did_not_run(
     _run_racs_all(tmp_path=tmp_path)
 
     options = _rmsynth_options(rmsynth_stage)
-    assert options.stokes_q_weight_cube == tmp_path / "q.weight.fits"
-    assert options.stokes_q_noise_cube is None
+    assert isinstance(options.error_cubes, StokesWeightCubes)
+    assert options.error_cubes.q == tmp_path / "q.weight.fits"
 
 
 def test_the_bane_cubes_are_spiced(

--- a/tests/test_racs_all_pipeline.py
+++ b/tests/test_racs_all_pipeline.py
@@ -334,7 +334,10 @@ def test_stage_prerequisites_requires_polarisation_containers(
 
 
 def _stage_mocks(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, convolved_cubes: list[Path]
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    convolved_cubes: list[Path],
+    bane_cubes: bool = False,
 ):
     """Replace every stage subflow of ``process_racs_all`` with a mock, so the
     wiring between them can be checked without imaging anything."""
@@ -356,10 +359,21 @@ def _stage_mocks(
     pol_result = PolPipelineResult(
         stokes_cubes={"q": tmp_path / "q.fits", "u": tmp_path / "u.fits"},
         weight_cubes={"q": tmp_path / "q.weight.fits", "u": tmp_path / "u.weight.fits"},
+        bkg_cubes={"q": tmp_path / "q_bkg.fits", "u": tmp_path / "u_bkg.fits"}
+        if bane_cubes
+        else {},
+        rms_cubes={"q": tmp_path / "q_rms.fits", "u": tmp_path / "u_rms.fits"}
+        if bane_cubes
+        else {},
         mfs_products={},
         terminal_futures=[],
     )
     spice_stage = _stage([])
+    rmsynth_stage = _stage(
+        RMSynthPipelineResult(
+            written_paths=[tmp_path / "fdf.fits"], convolved_cubes=convolved_cubes
+        )
+    )
 
     monkeypatch.setattr(
         "flint.prefect.flows.racs_all_pipeline.get_dask_runner", lambda cluster: None
@@ -373,18 +387,13 @@ def _stage_mocks(
         _stage(pol_result),
     )
     monkeypatch.setattr(
-        "flint.prefect.flows.racs_all_pipeline.process_rmsynth",
-        _stage(
-            RMSynthPipelineResult(
-                written_paths=[tmp_path / "fdf.fits"], convolved_cubes=convolved_cubes
-            )
-        ),
+        "flint.prefect.flows.racs_all_pipeline.process_rmsynth", rmsynth_stage
     )
     monkeypatch.setattr(
         "flint.prefect.flows.racs_all_pipeline.process_spice_compression", spice_stage
     )
 
-    return pol_result, spice_stage
+    return pol_result, spice_stage, rmsynth_stage
 
 
 def _run_racs_all(tmp_path: Path) -> None:
@@ -419,7 +428,7 @@ def test_rmsynth_convolved_cubes_are_spiced(
     polarisation cubes, so leaving them out of the spice stage would strand an
     untrimmed, uncompressed set on disk once the originals have been trimmed."""
     convolved_cubes = [tmp_path / "q.conv.fits", tmp_path / "u.conv.fits"]
-    pol_result, spice_stage = _stage_mocks(
+    pol_result, spice_stage, _ = _stage_mocks(
         monkeypatch=monkeypatch, tmp_path=tmp_path, convolved_cubes=convolved_cubes
     )
 
@@ -441,7 +450,7 @@ def test_spiced_cubes_are_not_repeated_without_convolution(
 ) -> None:
     """rm-synth reports no convolved cubes when the inputs already shared a
     resolution, so the spice stage never sees the same cube twice."""
-    pol_result, spice_stage = _stage_mocks(
+    pol_result, spice_stage, _ = _stage_mocks(
         monkeypatch=monkeypatch, tmp_path=tmp_path, convolved_cubes=[]
     )
 
@@ -452,3 +461,69 @@ def test_spiced_cubes_are_not_repeated_without_convolution(
     ]
     assert spiced_options.cubes == list(pol_result.stokes_cubes.values())
     assert len(set(spiced_options.cubes)) == len(spiced_options.cubes)
+
+
+def _rmsynth_options(rmsynth_stage):
+    """The options the racs-all flow handed the rm-synth stage"""
+    return rmsynth_stage.with_options.return_value.call_args.kwargs[
+        "rmsynth_field_options"
+    ]
+
+
+def test_bane_rms_cubes_are_preferred_over_the_linmos_weights(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A BANE RMS cube is measured off the co-added planes, so it describes the
+    cubes rm-synth reads; the linmos weights are an inverse variance carried
+    over from the input images. When both exist the RMS cubes win, and the two
+    must not be sent together -- rm-lite is told which it has by a single flag.
+    """
+    _, _, rmsynth_stage = _stage_mocks(
+        monkeypatch=monkeypatch, tmp_path=tmp_path, convolved_cubes=[], bane_cubes=True
+    )
+
+    _run_racs_all(tmp_path=tmp_path)
+
+    options = _rmsynth_options(rmsynth_stage)
+    assert options.stokes_q_noise_cube == tmp_path / "q_rms.fits"
+    assert options.stokes_u_noise_cube == tmp_path / "u_rms.fits"
+    assert options.stokes_q_weight_cube is None
+    assert options.stokes_u_weight_cube is None
+
+
+def test_the_linmos_weights_are_used_when_bane_did_not_run(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """BANE is opt-in, so a polarisation stage that skipped it still has to feed
+    rm-synth something."""
+    _, _, rmsynth_stage = _stage_mocks(
+        monkeypatch=monkeypatch, tmp_path=tmp_path, convolved_cubes=[]
+    )
+
+    _run_racs_all(tmp_path=tmp_path)
+
+    options = _rmsynth_options(rmsynth_stage)
+    assert options.stokes_q_weight_cube == tmp_path / "q.weight.fits"
+    assert options.stokes_q_noise_cube is None
+
+
+def test_the_bane_cubes_are_spiced(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The background and RMS cubes are full-size copies on the polarisation
+    cubes' pixel grid. Left out of the spice stage they would stay untrimmed and
+    uncompressed on disk after everything beside them had been trimmed."""
+    pol_result, spice_stage, _ = _stage_mocks(
+        monkeypatch=monkeypatch, tmp_path=tmp_path, convolved_cubes=[], bane_cubes=True
+    )
+
+    _run_racs_all(tmp_path=tmp_path)
+
+    spiced = spice_stage.with_options.return_value.call_args.kwargs[
+        "spice_field_options"
+    ]
+    assert spiced.weight_cubes == [
+        *pol_result.weight_cubes.values(),
+        *pol_result.bkg_cubes.values(),
+        *pol_result.rms_cubes.values(),
+    ]

--- a/tests/test_racs_all_pipeline.py
+++ b/tests/test_racs_all_pipeline.py
@@ -36,21 +36,21 @@ def test_get_parser() -> None:
 
 
 def test_get_parser_excludes_computed_stage_outputs() -> None:
-    """stokes_q_cube/stokes_u_cube (rm-synth) and cubes/weight_cubes (spice) are
+    """stokes_cubes/error_cubes (rm-synth) and cubes/weight_cubes (spice) are
     computed from the polarisation stage's output inside process_racs_all, so the
     combined CLI must not force the user to supply dummy positional values
     for them -- only low_data/mid_data/high_data should be positional."""
     args = get_parser().parse_args(["/low", "/mid", "/high"])
 
-    assert not hasattr(args, "stokes_q_cube")
-    assert not hasattr(args, "stokes_u_cube")
+    assert not hasattr(args, "stokes_cubes")
+    assert not hasattr(args, "error_cubes")
     assert not hasattr(args, "cubes")
     assert not hasattr(args, "weight_cubes")
 
     # create_options_from_parser reads every field off the namespace, so cli()
     # sets the computed ones to their empty defaults first, as done here.
-    args.stokes_q_cube = None
-    args.stokes_u_cube = None
+    args.stokes_cubes = None
+    args.error_cubes = None
     args.cubes = []
     args.weight_cubes = []
 

--- a/tests/test_racs_all_pipeline.py
+++ b/tests/test_racs_all_pipeline.py
@@ -11,14 +11,14 @@ from prefect.logging import disable_run_logger
 from prefect.testing.utilities import prefect_test_harness
 
 from flint.options import (
+    CubesForRMSynth,
+    NoiseCubesForRMSynth,
     PolFieldOptions,
     RACSAllOptions,
     RACSAllPipelineOptions,
     RMSynthFieldOptions,
     SpiceFieldOptions,
-    StokesCubes,
-    StokesNoiseCubes,
-    StokesWeightCubes,
+    WeightCubesForRMSynth,
 )
 from flint.prefect.flows.racs_all_pipeline import (
     _check_racs_all_pipeline_options,
@@ -163,7 +163,7 @@ def test_process_racs_all_everything_disabled_returns_immediately(
     )
     pol_field_options = PolFieldOptions()
     rmsynth_field_options = RMSynthFieldOptions(
-        stokes_cubes=StokesCubes(q=Path("/tmp/q.fits"), u=Path("/tmp/u.fits"))
+        stokes_cubes=CubesForRMSynth(q=Path("/tmp/q.fits"), u=Path("/tmp/u.fits"))
     )
     spice_field_options = SpiceFieldOptions(cubes=[Path("/tmp/i.fits")])
 
@@ -488,7 +488,7 @@ def test_bane_rms_cubes_are_preferred_over_the_linmos_weights(
     _run_racs_all(tmp_path=tmp_path)
 
     options = _rmsynth_options(rmsynth_stage)
-    assert isinstance(options.error_cubes, StokesNoiseCubes)
+    assert isinstance(options.error_cubes, NoiseCubesForRMSynth)
     assert options.error_cubes.q == tmp_path / "q_rms.fits"
     assert options.error_cubes.u == tmp_path / "u_rms.fits"
 
@@ -505,7 +505,7 @@ def test_the_linmos_weights_are_used_when_bane_did_not_run(
     _run_racs_all(tmp_path=tmp_path)
 
     options = _rmsynth_options(rmsynth_stage)
-    assert isinstance(options.error_cubes, StokesWeightCubes)
+    assert isinstance(options.error_cubes, WeightCubesForRMSynth)
     assert options.error_cubes.q == tmp_path / "q.weight.fits"
 
 
@@ -529,3 +529,48 @@ def test_the_bane_cubes_are_spiced(
         *pol_result.bkg_cubes.values(),
         *pol_result.rms_cubes.values(),
     ]
+
+
+def test_rmsynth_refuses_a_polarisation_strategy_without_the_linear_stokes(
+    tmp_path: Path,
+) -> None:
+    """The FDF is built from Q+iU, so a circular-only strategy has nothing to
+    give rm-synthesis. Caught up front rather than after imaging has run."""
+    from flint.prefect.flows.racs_all_pipeline import _check_rmsynth_has_linear_stokes
+
+    strategy = tmp_path / "circular_only.yaml"
+    strategy.write_text(
+        "version: 0.2\ndefaults: {}\npolarisation:\n  circular:\n    wsclean: {}\n"
+    )
+
+    with pytest.raises(ValueError, match="rm-synthesis needs Stokes"):
+        _check_rmsynth_has_linear_stokes(
+            pipeline_options=RACSAllPipelineOptions(),
+            racs_all_options=RACSAllOptions(
+                low_data=tmp_path,
+                mid_data=tmp_path,
+                high_data=tmp_path,
+                imaging_strategy=strategy,
+            ),
+        )
+
+    # A strategy that does image the linear Stokes passes, and so does a run
+    # with rm-synthesis switched off
+    strategy.write_text(
+        "version: 0.2\ndefaults: {}\npolarisation:\n  linear:\n    wsclean: {}\n"
+    )
+    _check_rmsynth_has_linear_stokes(
+        pipeline_options=RACSAllPipelineOptions(),
+        racs_all_options=RACSAllOptions(
+            low_data=tmp_path,
+            mid_data=tmp_path,
+            high_data=tmp_path,
+            imaging_strategy=strategy,
+        ),
+    )
+    _check_rmsynth_has_linear_stokes(
+        pipeline_options=RACSAllPipelineOptions(skip_rmsynth=True),
+        racs_all_options=RACSAllOptions(
+            low_data=tmp_path, mid_data=tmp_path, high_data=tmp_path
+        ),
+    )

--- a/tests/test_racs_all_pipeline.py
+++ b/tests/test_racs_all_pipeline.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from argparse import ArgumentParser
 from pathlib import Path
+from typing import Any
 
 import pytest
 from capn_crunch import create_options_from_parser
@@ -163,7 +164,9 @@ def test_process_racs_all_everything_disabled_returns_immediately(
     )
     pol_field_options = PolFieldOptions()
     rmsynth_field_options = RMSynthFieldOptions(
-        stokes_cubes=CubesForRMSynth(q_path=Path("/tmp/q.fits"), u=Path("/tmp/u.fits"))
+        stokes_cubes=CubesForRMSynth(
+            q_path=Path("/tmp/q.fits"), u_path=Path("/tmp/u.fits")
+        )
     )
     spice_field_options = SpiceFieldOptions(cubes=[Path("/tmp/i.fits")])
 
@@ -538,39 +541,29 @@ def test_rmsynth_refuses_a_polarisation_strategy_without_the_linear_stokes(
     give rm-synthesis. Caught up front rather than after imaging has run."""
     from flint.prefect.flows.racs_all_pipeline import _check_rmsynth_has_linear_stokes
 
-    strategy = tmp_path / "circular_only.yaml"
+    strategy = tmp_path / "polarisation.yaml"
+
+    def _check(**pol_options: Any) -> None:
+        _check_rmsynth_has_linear_stokes(
+            pipeline_options=RACSAllPipelineOptions(),
+            pol_field_options=PolFieldOptions(**pol_options),
+        )
+
     strategy.write_text(
         "version: 0.2\ndefaults: {}\npolarisation:\n  circular:\n    wsclean: {}\n"
     )
-
     with pytest.raises(ValueError, match="rm-synthesis needs Stokes"):
-        _check_rmsynth_has_linear_stokes(
-            pipeline_options=RACSAllPipelineOptions(),
-            racs_all_options=RACSAllOptions(
-                low_data=tmp_path,
-                mid_data=tmp_path,
-                high_data=tmp_path,
-                imaging_strategy=strategy,
-            ),
-        )
+        _check(imaging_strategy=strategy)
 
-    # A strategy that does image the linear Stokes passes, and so does a run
-    # with rm-synthesis switched off
     strategy.write_text(
         "version: 0.2\ndefaults: {}\npolarisation:\n  linear:\n    wsclean: {}\n"
     )
-    _check_rmsynth_has_linear_stokes(
-        pipeline_options=RACSAllPipelineOptions(),
-        racs_all_options=RACSAllOptions(
-            low_data=tmp_path,
-            mid_data=tmp_path,
-            high_data=tmp_path,
-            imaging_strategy=strategy,
-        ),
-    )
+    _check(imaging_strategy=strategy)
+
+    # No strategy is the polarisation stage's business, not this check's
+    _check()
+
     _check_rmsynth_has_linear_stokes(
         pipeline_options=RACSAllPipelineOptions(skip_rmsynth=True),
-        racs_all_options=RACSAllOptions(
-            low_data=tmp_path, mid_data=tmp_path, high_data=tmp_path
-        ),
+        pol_field_options=PolFieldOptions(imaging_strategy=strategy),
     )

--- a/tests/test_rmsynth.py
+++ b/tests/test_rmsynth.py
@@ -1048,7 +1048,11 @@ def test_the_peak_and_moment_snr_cuts_are_independent(
     """
     stokes_q_cube, stokes_u_cube = qu_cubes
 
-    def peak_pi_and_mom0(prefix: str, **snrs: float) -> tuple[np.ndarray, np.ndarray]:
+    def peak_pi_and_mom0(
+        prefix: str,
+        moment_threshold_snr: float = 5.0,
+        peak_threshold_snr: float = 0.0,
+    ) -> tuple[np.ndarray, np.ndarray]:
         output_prefix = tmp_path / prefix
         _synth_and_write(
             stokes_q_cube=stokes_q_cube,
@@ -1059,7 +1063,8 @@ def test_the_peak_and_moment_snr_cuts_are_independent(
             moment_products=["dirty"],
             peak_products=["dirty"],
             output_prefix=output_prefix,
-            **snrs,
+            moment_threshold_snr=moment_threshold_snr,
+            peak_threshold_snr=peak_threshold_snr,
         )
         return (
             fits.getdata(Path(f"{output_prefix}.fdf.dirty.peak_pi.fits")),

--- a/tests/test_rmsynth.py
+++ b/tests/test_rmsynth.py
@@ -14,13 +14,13 @@ from pydantic import ValidationError
 
 from flint.exceptions import NotSupportedError
 from flint.options import (
+    CubesForRMSynth,
+    ErrorCubesForRMSynth,
+    NoiseCubesForRMSynth,
     RMCleanOptions,
     RMSynthFieldOptions,
     RMSynthOptions,
-    StokesCubes,
-    StokesErrorCubes,
-    StokesNoiseCubes,
-    StokesWeightCubes,
+    WeightCubesForRMSynth,
 )
 from flint.rmsynth import (
     FDFLabel,
@@ -144,19 +144,19 @@ def _run_rmsynth_3d(
 
     These tests are about what rm-synthesis does, not how its arguments are
     grouped, so the containers are built here rather than at ninety call sites.
-    ``StokesErrorCubes`` itself is covered by its own tests below.
+    ``ErrorCubesForRMSynth`` itself is covered by its own tests below.
     """
-    error_cubes: StokesErrorCubes | None = None
+    error_cubes: ErrorCubesForRMSynth | None = None
     if stokes_q_noise_cube is not None:
-        error_cubes = StokesNoiseCubes(
+        error_cubes = NoiseCubesForRMSynth(
             q=stokes_q_noise_cube, u=stokes_u_noise_cube, i=stokes_i_noise_cube
         )
     elif stokes_q_weight_cube is not None:
-        error_cubes = StokesWeightCubes(
+        error_cubes = WeightCubesForRMSynth(
             q=stokes_q_weight_cube, u=stokes_u_weight_cube, i=stokes_i_weight_cube
         )
     return run_rmsynth_3d(
-        stokes_cubes=StokesCubes(q=stokes_q_cube, u=stokes_u_cube, i=stokes_i_cube),
+        stokes_cubes=CubesForRMSynth(q=stokes_q_cube, u=stokes_u_cube, i=stokes_i_cube),
         rmsynth_options=rmsynth_options,
         error_cubes=error_cubes,
     )
@@ -789,7 +789,7 @@ def test_one_linmos_weight_cube_is_refused(tmp_path: Path) -> None:
 
     # ValidationError from the constructor, a plain ValueError from
     # from_mapping; the former subclasses the latter, so one assertion covers both
-    for kind in (StokesWeightCubes, StokesNoiseCubes):
+    for kind in (WeightCubesForRMSynth, NoiseCubesForRMSynth):
         with pytest.raises(ValueError):
             kind(q=weights)
         with pytest.raises(ValueError, match="missing"):
@@ -1560,27 +1560,27 @@ def test_error_cubes_cannot_be_a_weight_and_a_noise_at_once() -> None:
     """
     paths = {"q": Path("q.fits"), "u": Path("u.fits")}
 
-    assert StokesWeightCubes(**paths).kind == "weight"
-    assert StokesNoiseCubes(**paths).kind == "noise"
+    assert WeightCubesForRMSynth(**paths).kind == "weight"
+    assert NoiseCubesForRMSynth(**paths).kind == "noise"
 
     # The tag is what survives the serialisation prefect does to task inputs.
     # Without it pydantic rebuilds a union by first match, and a noise cube
     # coming back as a weight would invert the noise by 1/sigma**2.
     options = RMSynthFieldOptions(
-        stokes_cubes=StokesCubes(**paths), error_cubes=StokesNoiseCubes(**paths)
+        stokes_cubes=CubesForRMSynth(**paths), error_cubes=NoiseCubesForRMSynth(**paths)
     )
     rebuilt = RMSynthFieldOptions.model_validate(options.model_dump())
-    assert isinstance(rebuilt.error_cubes, StokesNoiseCubes)
+    assert isinstance(rebuilt.error_cubes, NoiseCubesForRMSynth)
     assert isinstance(
         RMSynthFieldOptions.model_validate(
-            RMSynthFieldOptions(error_cubes=StokesWeightCubes(**paths)).model_dump()
+            RMSynthFieldOptions(error_cubes=WeightCubesForRMSynth(**paths)).model_dump()
         ).error_cubes,
-        StokesWeightCubes,
+        WeightCubesForRMSynth,
     )
 
     # An untagged trio says nothing about which it is, so it is refused
     with pytest.raises(ValidationError):
-        RMSynthFieldOptions(error_cubes=StokesCubes(**paths))
+        RMSynthFieldOptions(error_cubes=CubesForRMSynth(**paths))
 
 
 def test_a_weight_cube_is_not_inverted_but_a_noise_cube_is(
@@ -1599,13 +1599,13 @@ def test_a_weight_cube_is_not_inverted_but_a_noise_cube_is(
 
     weights = _make_weight_cube(tmp_path, (N_CHAN, NY, NX), freq_hz, sigma, "as_weight")
     for error_cubes, expected in (
-        (StokesWeightCubes(q=weights, u=weights), True),
-        (StokesNoiseCubes(q=weights, u=weights), False),
+        (WeightCubesForRMSynth(q=weights, u=weights), True),
+        (NoiseCubesForRMSynth(q=weights, u=weights), False),
     ):
         with patch("flint.rmsynth.rmsynth_3d_from_fits", side_effect=_capture):
             with pytest.raises(RuntimeError, match="stop here"):
                 run_rmsynth_3d(
-                    stokes_cubes=StokesCubes(q=stokes_q_cube, u=stokes_u_cube),
+                    stokes_cubes=CubesForRMSynth(q=stokes_q_cube, u=stokes_u_cube),
                     rmsynth_options=RMSynthOptions(),
                     error_cubes=error_cubes,
                 )

--- a/tests/test_rmsynth.py
+++ b/tests/test_rmsynth.py
@@ -1049,8 +1049,8 @@ def test_the_peak_and_moment_snr_cuts_are_independent(
         _synth_and_write(
             stokes_q_cube=stokes_q_cube,
             stokes_u_cube=stokes_u_cube,
-            rmsynth_options=RMSynthOptions(),
-            rmclean_options=RMCleanOptions(**snrs),
+            rmsynth_options=RMSynthOptions(**snrs),
+            rmclean_options=RMCleanOptions(),
             cube_products=[],
             moment_products=["dirty"],
             peak_products=["dirty"],
@@ -1079,7 +1079,7 @@ def test_no_peak_cut_by_default_even_where_a_pixel_has_no_weight(
     applied as ``0 * noise``: the theoretical noise is inf for a pixel linmos
     blanked, ``0 * inf`` is NaN, and every comparison against NaN is False -- so
     the cut meant to pass everything would instead blank the whole map."""
-    assert RMCleanOptions().peak_threshold_snr == 0.0
+    assert RMSynthOptions().peak_threshold_snr == 0.0
     assert _snr_threshold(0.0, np.float64(np.inf)) is None
     assert _snr_threshold(0.0, np.array([1e-5, np.inf])) is None
     assert _snr_threshold(5.0, np.float64(2.0)) == 10.0

--- a/tests/test_rmsynth.py
+++ b/tests/test_rmsynth.py
@@ -149,14 +149,20 @@ def _run_rmsynth_3d(
     error_cubes: ErrorCubesForRMSynth | None = None
     if stokes_q_noise_cube is not None:
         error_cubes = NoiseCubesForRMSynth(
-            q=stokes_q_noise_cube, u=stokes_u_noise_cube, i=stokes_i_noise_cube
+            q_path=stokes_q_noise_cube,
+            u_path=stokes_u_noise_cube,
+            i_path=stokes_i_noise_cube,
         )
     elif stokes_q_weight_cube is not None:
         error_cubes = WeightCubesForRMSynth(
-            q=stokes_q_weight_cube, u=stokes_u_weight_cube, i=stokes_i_weight_cube
+            q_path=stokes_q_weight_cube,
+            u_path=stokes_u_weight_cube,
+            i_path=stokes_i_weight_cube,
         )
     return run_rmsynth_3d(
-        stokes_cubes=CubesForRMSynth(q=stokes_q_cube, u=stokes_u_cube, i=stokes_i_cube),
+        stokes_cubes=CubesForRMSynth(
+            q_path=stokes_q_cube, u_path=stokes_u_cube, i_path=stokes_i_cube
+        ),
         rmsynth_options=rmsynth_options,
         error_cubes=error_cubes,
     )
@@ -791,7 +797,7 @@ def test_one_linmos_weight_cube_is_refused(tmp_path: Path) -> None:
     # from_mapping; the former subclasses the latter, so one assertion covers both
     for kind in (WeightCubesForRMSynth, NoiseCubesForRMSynth):
         with pytest.raises(ValueError):
-            kind(q=weights)
+            kind(q_path=weights)
         with pytest.raises(ValueError, match="missing"):
             kind.from_mapping({"q": weights})
 
@@ -1558,7 +1564,7 @@ def test_error_cubes_cannot_be_a_weight_and_a_noise_at_once() -> None:
     "neither, but something cube-shaped" a validation error rather than a silent
     guess at which was meant.
     """
-    paths = {"q": Path("q.fits"), "u": Path("u.fits")}
+    paths = {"q_path": Path("q.fits"), "u_path": Path("u.fits")}
 
     assert WeightCubesForRMSynth(**paths).kind == "weight"
     assert NoiseCubesForRMSynth(**paths).kind == "noise"
@@ -1599,13 +1605,15 @@ def test_a_weight_cube_is_not_inverted_but_a_noise_cube_is(
 
     weights = _make_weight_cube(tmp_path, (N_CHAN, NY, NX), freq_hz, sigma, "as_weight")
     for error_cubes, expected in (
-        (WeightCubesForRMSynth(q=weights, u=weights), True),
-        (NoiseCubesForRMSynth(q=weights, u=weights), False),
+        (WeightCubesForRMSynth(q_path=weights, u_path=weights), True),
+        (NoiseCubesForRMSynth(q_path=weights, u_path=weights), False),
     ):
         with patch("flint.rmsynth.rmsynth_3d_from_fits", side_effect=_capture):
             with pytest.raises(RuntimeError, match="stop here"):
                 run_rmsynth_3d(
-                    stokes_cubes=CubesForRMSynth(q=stokes_q_cube, u=stokes_u_cube),
+                    stokes_cubes=CubesForRMSynth(
+                        q_path=stokes_q_cube, u_path=stokes_u_cube
+                    ),
                     rmsynth_options=RMSynthOptions(),
                     error_cubes=error_cubes,
                 )

--- a/tests/test_rmsynth.py
+++ b/tests/test_rmsynth.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
+from unittest.mock import patch
 
 import numpy as np
 import pytest
@@ -12,9 +13,18 @@ from astropy.wcs import WCS
 from pydantic import ValidationError
 
 from flint.exceptions import NotSupportedError
-from flint.options import RMCleanOptions, RMSynthOptions
+from flint.options import (
+    RMCleanOptions,
+    RMSynthFieldOptions,
+    RMSynthOptions,
+    StokesCubes,
+    StokesErrorCubes,
+    StokesNoiseCubes,
+    StokesWeightCubes,
+)
 from flint.rmsynth import (
     FDFLabel,
+    RMSynth3DResults,
     _snr_threshold,
     needs_rmclean,
     run_rmclean_3d,
@@ -118,6 +128,40 @@ def qu_cubes(tmp_path: Path) -> tuple[Path, Path]:
     return _make_qu_cubes(tmp_path)
 
 
+def _run_rmsynth_3d(
+    stokes_q_cube: Path,
+    stokes_u_cube: Path,
+    rmsynth_options: RMSynthOptions,
+    stokes_i_cube: Path | None = None,
+    stokes_q_weight_cube: Path | None = None,
+    stokes_u_weight_cube: Path | None = None,
+    stokes_i_weight_cube: Path | None = None,
+    stokes_q_noise_cube: Path | None = None,
+    stokes_u_noise_cube: Path | None = None,
+    stokes_i_noise_cube: Path | None = None,
+) -> RMSynth3DResults:
+    """``run_rmsynth_3d`` from a flat set of paths.
+
+    These tests are about what rm-synthesis does, not how its arguments are
+    grouped, so the containers are built here rather than at ninety call sites.
+    ``StokesErrorCubes`` itself is covered by its own tests below.
+    """
+    error_cubes: StokesErrorCubes | None = None
+    if stokes_q_noise_cube is not None:
+        error_cubes = StokesNoiseCubes(
+            q=stokes_q_noise_cube, u=stokes_u_noise_cube, i=stokes_i_noise_cube
+        )
+    elif stokes_q_weight_cube is not None:
+        error_cubes = StokesWeightCubes(
+            q=stokes_q_weight_cube, u=stokes_u_weight_cube, i=stokes_i_weight_cube
+        )
+    return run_rmsynth_3d(
+        stokes_cubes=StokesCubes(q=stokes_q_cube, u=stokes_u_cube, i=stokes_i_cube),
+        rmsynth_options=rmsynth_options,
+        error_cubes=error_cubes,
+    )
+
+
 def _synth_and_write(
     stokes_q_cube: Path,
     stokes_u_cube: Path,
@@ -135,7 +179,7 @@ def _synth_and_write(
     if not cube_products and not moment_products and not peak_products:
         return []
 
-    synth_results = run_rmsynth_3d(
+    synth_results = _run_rmsynth_3d(
         stokes_q_cube=stokes_q_cube,
         stokes_u_cube=stokes_u_cube,
         rmsynth_options=rmsynth_options,
@@ -365,7 +409,7 @@ def test_unnamed_stokes_i_model_terms_are_skipped_with_a_warning(
     """
     stokes_q_cube, stokes_u_cube = qu_cubes
     rmsynth_options = RMSynthOptions()
-    synth_results = run_rmsynth_3d(
+    synth_results = _run_rmsynth_3d(
         stokes_q_cube=stokes_q_cube,
         stokes_u_cube=stokes_u_cube,
         rmsynth_options=rmsynth_options,
@@ -410,7 +454,7 @@ def test_stokes_i_model_rebuilds_from_the_written_term_maps(
     output_prefix = tmp_path / "test_field"
     rmsynth_options = RMSynthOptions(fit_order=-3)
 
-    synth_results = run_rmsynth_3d(
+    synth_results = _run_rmsynth_3d(
         stokes_q_cube=stokes_q_cube,
         stokes_u_cube=stokes_u_cube,
         rmsynth_options=rmsynth_options,
@@ -577,7 +621,7 @@ def test_rmsynth_rejects_compressed_cubes(tmp_path: Path) -> None:
     """A gzipped cube cannot be memmapped, so rm-lite's per-block reopens would
     each inflate the whole cube into memory."""
     with pytest.raises(NotSupportedError):
-        run_rmsynth_3d(
+        _run_rmsynth_3d(
             stokes_q_cube=tmp_path / "q.fits.gz",
             stokes_u_cube=tmp_path / "u.fits.gz",
             rmsynth_options=RMSynthOptions(),
@@ -594,7 +638,7 @@ def test_rmsynth_rejects_a_compressed_weight_cube(tmp_path: Path) -> None:
         {"stokes_i_weight_cube": tmp_path / "i.weight.fits.gz"},
     ):
         with pytest.raises(NotSupportedError):
-            run_rmsynth_3d(
+            _run_rmsynth_3d(
                 stokes_q_cube=stokes_q_cube,
                 stokes_u_cube=stokes_u_cube,
                 stokes_i_cube=_make_i_cube(tmp_path),
@@ -652,7 +696,7 @@ def test_rmsynth_options_reach_rm_lite(
     stokes_q_cube, stokes_u_cube = qu_cubes
     rmsynth_options = RMSynthOptions(per_pixel_rmsf=True, estimate_stokes_i_noise=False)
     with pytest.raises(NotSupportedError, match="stop before synthesising"):
-        run_rmsynth_3d(
+        _run_rmsynth_3d(
             stokes_q_cube=stokes_q_cube,
             stokes_u_cube=stokes_u_cube,
             stokes_i_cube=_make_i_cube(tmp_path),
@@ -727,7 +771,7 @@ def test_one_linmos_weight_cube_is_refused(
     stokes_q_cube, stokes_u_cube = qu_cubes
 
     with pytest.raises(ValueError, match="[Mm]ust pass both"):
-        run_rmsynth_3d(
+        _run_rmsynth_3d(
             stokes_q_cube=stokes_q_cube,
             stokes_u_cube=stokes_u_cube,
             rmsynth_options=RMSynthOptions(),
@@ -750,7 +794,7 @@ def test_rmsynth_with_linmos_weights_stays_cleanable(
     """
     stokes_q_cube, stokes_u_cube = qu_cubes
 
-    synth_results = run_rmsynth_3d(
+    synth_results = _run_rmsynth_3d(
         stokes_q_cube=stokes_q_cube,
         stokes_u_cube=stokes_u_cube,
         rmsynth_options=RMSynthOptions(),
@@ -793,7 +837,7 @@ def test_linmos_weights_give_each_pixel_its_own_rmsf(
     primary beam does -- and the linmos cubes are exactly that case."""
     stokes_q_cube, stokes_u_cube = qu_cubes
 
-    synth_results = run_rmsynth_3d(
+    synth_results = _run_rmsynth_3d(
         stokes_q_cube=stokes_q_cube,
         stokes_u_cube=stokes_u_cube,
         rmsynth_options=RMSynthOptions(),
@@ -828,7 +872,7 @@ def test_channels_linmos_blanked_everywhere_drop_out(
     stokes_q_cube, stokes_u_cube = qu_cubes
     blanked_channels = (0, 5, N_CHAN - 1)
 
-    synth_results = run_rmsynth_3d(
+    synth_results = _run_rmsynth_3d(
         stokes_q_cube=stokes_q_cube,
         stokes_u_cube=stokes_u_cube,
         rmsynth_options=RMSynthOptions(),
@@ -1218,7 +1262,7 @@ def test_rmclean_runs_once_per_chunk_whatever_is_requested(
         lambda *a, **k: real_compute(*a, **{**k, "scheduler": "threads"}),
     )
 
-    synth_results = run_rmsynth_3d(
+    synth_results = _run_rmsynth_3d(
         stokes_q_cube=stokes_q_cube,
         stokes_u_cube=stokes_u_cube,
         rmsynth_options=RMSynthOptions(),
@@ -1299,7 +1343,7 @@ def test_rmclean_runs_once_per_chunk_on_a_distributed_client(
     )
     try:
         with Client(cluster) as client:
-            synth_results = run_rmsynth_3d(
+            synth_results = _run_rmsynth_3d(
                 stokes_q_cube=stokes_q_cube,
                 stokes_u_cube=stokes_u_cube,
                 rmsynth_options=RMSynthOptions(),
@@ -1454,7 +1498,7 @@ def test_stokes_i_fit_does_not_multiply_with_requested_products(
     stokes_i_weight_cube = _make_i_weight_cube(tmp_path)
 
     # Built once, and never computed, only to read the chunking off it
-    n_chunks = run_rmsynth_3d(
+    n_chunks = _run_rmsynth_3d(
         stokes_q_cube=stokes_q_cube,
         stokes_u_cube=stokes_u_cube,
         rmsynth_options=RMSynthOptions(),
@@ -1490,3 +1534,64 @@ def test_stokes_i_fit_does_not_multiply_with_requested_products(
     assert len(set(counts.values())) == 1, (
         f"the Stokes I fit count moves with the requested products: {counts}"
     )
+
+
+def test_error_cubes_cannot_be_a_weight_and_a_noise_at_once() -> None:
+    """A weight cube is 1/sigma**2 and a noise cube is sigma. rm-lite takes
+    either through one argument and is told which by a flag, so confusing them
+    inverts the noise. One argument of a tagged type makes "both" unsayable and
+    "neither, but something cube-shaped" a validation error rather than a silent
+    guess at which was meant.
+    """
+    paths = {"q": Path("q.fits"), "u": Path("u.fits")}
+
+    assert StokesWeightCubes(**paths).kind == "weight"
+    assert StokesNoiseCubes(**paths).kind == "noise"
+
+    # The tag is what survives the serialisation prefect does to task inputs.
+    # Without it pydantic rebuilds a union by first match, and a noise cube
+    # coming back as a weight would invert the noise by 1/sigma**2.
+    options = RMSynthFieldOptions(
+        stokes_cubes=StokesCubes(**paths), error_cubes=StokesNoiseCubes(**paths)
+    )
+    rebuilt = RMSynthFieldOptions.model_validate(options.model_dump())
+    assert isinstance(rebuilt.error_cubes, StokesNoiseCubes)
+    assert isinstance(
+        RMSynthFieldOptions.model_validate(
+            RMSynthFieldOptions(error_cubes=StokesWeightCubes(**paths)).model_dump()
+        ).error_cubes,
+        StokesWeightCubes,
+    )
+
+    # An untagged trio says nothing about which it is, so it is refused
+    with pytest.raises(ValidationError):
+        RMSynthFieldOptions(error_cubes=StokesCubes(**paths))
+
+
+def test_a_weight_cube_is_not_inverted_but_a_noise_cube_is(
+    tmp_path: Path, qu_cubes: tuple[Path, Path]
+) -> None:
+    """The one thing the tag decides once it reaches rm-lite."""
+    stokes_q_cube, stokes_u_cube = qu_cubes
+    sigma = 1e-3
+    freq_hz = np.linspace(700e6, 1300e6, N_CHAN)
+
+    captured: dict[str, object] = {}
+
+    def _capture(**kwargs: object) -> None:
+        captured.update(kwargs)
+        raise RuntimeError("stop here")
+
+    weights = _make_weight_cube(tmp_path, (N_CHAN, NY, NX), freq_hz, sigma, "as_weight")
+    for error_cubes, expected in (
+        (StokesWeightCubes(q=weights, u=weights), True),
+        (StokesNoiseCubes(q=weights, u=weights), False),
+    ):
+        with patch("flint.rmsynth.rmsynth_3d_from_fits", side_effect=_capture):
+            with pytest.raises(RuntimeError, match="stop here"):
+                run_rmsynth_3d(
+                    stokes_cubes=StokesCubes(q=stokes_q_cube, u=stokes_u_cube),
+                    rmsynth_options=RMSynthOptions(),
+                    error_cubes=error_cubes,
+                )
+        assert captured["noise_files_are_weight"] is expected, error_cubes

--- a/tests/test_rmsynth.py
+++ b/tests/test_rmsynth.py
@@ -181,6 +181,8 @@ def _synth_and_write(
     stokes_q_weight_cube: Path | None = None,
     stokes_u_weight_cube: Path | None = None,
     peak_products: list[FDFLabel] = [],
+    moment_threshold_snr: float = 5.0,
+    peak_threshold_snr: float = 0.0,
 ) -> list[Path]:
     if not cube_products and not moment_products and not peak_products:
         return []
@@ -213,6 +215,8 @@ def _synth_and_write(
         moment_products=moment_products,
         peak_products=peak_products,
         output_prefix=output_prefix,
+        moment_threshold_snr=moment_threshold_snr,
+        peak_threshold_snr=peak_threshold_snr,
     )
 
 
@@ -1049,12 +1053,13 @@ def test_the_peak_and_moment_snr_cuts_are_independent(
         _synth_and_write(
             stokes_q_cube=stokes_q_cube,
             stokes_u_cube=stokes_u_cube,
-            rmsynth_options=RMSynthOptions(**snrs),
+            rmsynth_options=RMSynthOptions(),
             rmclean_options=RMCleanOptions(),
             cube_products=[],
             moment_products=["dirty"],
             peak_products=["dirty"],
             output_prefix=output_prefix,
+            **snrs,
         )
         return (
             fits.getdata(Path(f"{output_prefix}.fdf.dirty.peak_pi.fits")),
@@ -1079,7 +1084,7 @@ def test_no_peak_cut_by_default_even_where_a_pixel_has_no_weight(
     applied as ``0 * noise``: the theoretical noise is inf for a pixel linmos
     blanked, ``0 * inf`` is NaN, and every comparison against NaN is False -- so
     the cut meant to pass everything would instead blank the whole map."""
-    assert RMSynthOptions().peak_threshold_snr == 0.0
+    assert RMSynthFieldOptions().peak_threshold_snr == 0.0
     assert _snr_threshold(0.0, np.float64(np.inf)) is None
     assert _snr_threshold(0.0, np.array([1e-5, np.inf])) is None
     assert _snr_threshold(5.0, np.float64(2.0)) == 10.0

--- a/tests/test_rmsynth.py
+++ b/tests/test_rmsynth.py
@@ -632,10 +632,29 @@ def test_rmsynth_rejects_a_compressed_weight_cube(tmp_path: Path) -> None:
     """The weight cubes are read block-by-block just like the Stokes cubes, so a
     gzipped one inflates the whole cube per read in exactly the same way."""
     stokes_q_cube, stokes_u_cube = _make_qu_cubes(tmp_path)
+    uncompressed = _make_weight_cube(
+        tmp_path,
+        (N_CHAN, NY, NX),
+        np.linspace(700e6, 1300e6, N_CHAN),
+        1e-3,
+        "plain",
+    )
+    # One compressed cube at a time, the rest readable, so the check is on the
+    # gzipped one rather than on a half-filled set
     for weights in (
-        {"stokes_q_weight_cube": tmp_path / "q.weight.fits.gz"},
-        {"stokes_u_weight_cube": tmp_path / "u.weight.fits.gz"},
-        {"stokes_i_weight_cube": tmp_path / "i.weight.fits.gz"},
+        {
+            "stokes_q_weight_cube": tmp_path / "q.weight.fits.gz",
+            "stokes_u_weight_cube": uncompressed,
+        },
+        {
+            "stokes_q_weight_cube": uncompressed,
+            "stokes_u_weight_cube": tmp_path / "u.weight.fits.gz",
+        },
+        {
+            "stokes_q_weight_cube": uncompressed,
+            "stokes_u_weight_cube": uncompressed,
+            "stokes_i_weight_cube": tmp_path / "i.weight.fits.gz",
+        },
     ):
         with pytest.raises(NotSupportedError):
             _run_rmsynth_3d(
@@ -761,24 +780,20 @@ def _make_linmos_weight_cube(
     return path
 
 
-def test_one_linmos_weight_cube_is_refused(
-    tmp_path: Path, qu_cubes: tuple[Path, Path]
-) -> None:
+def test_one_linmos_weight_cube_is_refused(tmp_path: Path) -> None:
     """rm-lite builds the weights from Q and U together, so a lone cube is a
-    wiring mistake it refuses rather than half-applies. Pinned here because the
-    racs-all flow passes the pair positionally and a silent drop would look like
-    a linmos-weighted run that never was."""
-    stokes_q_cube, stokes_u_cube = qu_cubes
+    wiring mistake rather than something to half-apply. The container now
+    refuses it at construction, before any cube is opened, so a half-filled set
+    cannot reach rm-lite at all."""
+    weights = _make_linmos_weight_cube(tmp_path, "q", blank_outside=1.5)
 
-    with pytest.raises(ValueError, match="[Mm]ust pass both"):
-        _run_rmsynth_3d(
-            stokes_q_cube=stokes_q_cube,
-            stokes_u_cube=stokes_u_cube,
-            rmsynth_options=RMSynthOptions(),
-            stokes_q_weight_cube=_make_linmos_weight_cube(
-                tmp_path, "q", blank_outside=1.5
-            ),
-        )
+    # ValidationError from the constructor, a plain ValueError from
+    # from_mapping; the former subclasses the latter, so one assertion covers both
+    for kind in (StokesWeightCubes, StokesNoiseCubes):
+        with pytest.raises(ValueError):
+            kind(q=weights)
+        with pytest.raises(ValueError, match="missing"):
+            kind.from_mapping({"q": weights})
 
 
 def test_rmsynth_with_linmos_weights_stays_cleanable(

--- a/uv.lock
+++ b/uv.lock
@@ -169,6 +169,7 @@ dependencies = [
     { name = "fitscube", extra = ["pgzip"] },
     { name = "jolly-roger" },
     { name = "matplotlib" },
+    { name = "numba" },
     { name = "numpy" },
     { name = "pandas" },
     { name = "prefect" },
@@ -177,6 +178,7 @@ dependencies = [
     { name = "racs-tools" },
     { name = "radio-beam" },
     { name = "reproject" },
+    { name = "rocket-fft" },
     { name = "scikit-image" },
     { name = "scipy" },
     { name = "spython" },
@@ -255,6 +257,7 @@ requires-dist = [
     { name = "mypy", marker = "extra == 'dev'" },
     { name = "myst-parser", marker = "extra == 'all'" },
     { name = "myst-parser", marker = "extra == 'dev'" },
+    { name = "numba" },
     { name = "numpy", specifier = ">=2.0.0" },
     { name = "pandas" },
     { name = "pre-commit", marker = "extra == 'all'" },
@@ -277,6 +280,7 @@ requires-dist = [
     { name = "reproject" },
     { name = "rm-lite", marker = "extra == 'all'", specifier = "==2026.8.7" },
     { name = "rm-lite", marker = "extra == 'rmsynth'", specifier = "==2026.8.7" },
+    { name = "rocket-fft" },
     { name = "ruff", marker = "extra == 'all'" },
     { name = "ruff", marker = "extra == 'dev'" },
     { name = "scikit-image" },
@@ -3505,6 +3509,32 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/6d/9f/c3d7d0260ae064d4e810b476aa4b7ce56298d0457617dc3b544a2a9611ab/rm_lite-2026.8.7.tar.gz", hash = "sha256:155519c3e4063bfa733c7da7f383001c9e47f6cdc5a51d9f33a6b8a06e60f68f", size = 447821, upload-time = "2026-08-31T02:52:55.402Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/44/1d/92c36880b4b3deb64710951fd2232a586010f872c9b80363e4d994fe88fe/rm_lite-2026.8.7-py3-none-any.whl", hash = "sha256:bf1760d5ebaeead154fb5b24cd600e18fe5c742a7044411469b15d8316002e75", size = 117925, upload-time = "2026-08-31T02:52:54.139Z" },
+]
+
+[[package]]
+name = "rocket-fft"
+version = "0.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numba" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/44/b0/09cbec3177ecf56e5ceb789a69fbcdcbabe758cbb682e5d36b14aa8c05fb/rocket_fft-0.3.1.tar.gz", hash = "sha256:ddc902a361099aff9fc02fe9ea3b0d036c2f67f93df356c2b754f7627d7fa4f4", size = 74276, upload-time = "2025-12-26T00:30:54.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/81/4b1c9a3c336dfee613d23bb0a8f0819abdcb87634dde79e4e6d74f839f5e/rocket_fft-0.3.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:43145d0ff69c88fec886af069b6f9886fe834fc17566c731de8ade3d8dfcfaf4", size = 362992, upload-time = "2025-12-26T00:30:20.116Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/00/30b3713e43c5966cdc9a2003019f224099cb53109d79068e46c56cd7b073/rocket_fft-0.3.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7f50f967a4ebdc88184d259c242474837d6c38c41b1e2fd09bffa08639d9b7a3", size = 322683, upload-time = "2025-12-26T00:30:21.585Z" },
+    { url = "https://files.pythonhosted.org/packages/be/82/993f210253fbf4275844b66e159281f37d6f84270ee9f6e4010d81347216/rocket_fft-0.3.1-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b94ff9502f63515bebfa2bce319db6dd00d02031e1cef8441a4dded728d7c4d", size = 2164173, upload-time = "2025-12-26T00:30:23.332Z" },
+    { url = "https://files.pythonhosted.org/packages/09/52/f454823728d5775ec314985d2611afc0d7f8001adefaf719261df776a6c4/rocket_fft-0.3.1-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d0e9f0f03416d276f023f50744f5cef9f750b3b830d6e1edd340db623ff5ca6d", size = 2163734, upload-time = "2025-12-26T00:30:25.173Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/d4/3944b2513382e7e7fd08300ab1b0d0864e675e7a5fd6451d78ca338ae6e1/rocket_fft-0.3.1-cp311-cp311-win_amd64.whl", hash = "sha256:8173cd4ed9d464b2e789d2303a5f7953980bde8237c60af2fc6204b82addeec5", size = 215164, upload-time = "2025-12-26T00:30:26.627Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/78/8edd1349af038a8ab0fa3aee97ff2b91b4227e2561f0f721e78f3cd24635/rocket_fft-0.3.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:89be2e23812678ef7afdc793682e9aef4afbd7a0a30041cb292f02c73d62a0a9", size = 359246, upload-time = "2025-12-26T00:30:27.668Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/3a/41b7a3355e6d44139f2a891d4763ff0a1eeb634fc0faa43cefdb1cdda702/rocket_fft-0.3.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0de1a8841638e3091ef774d9304a6427801fd06dd29e6d2baacd17bac65eb9f3", size = 322703, upload-time = "2025-12-26T00:30:29.169Z" },
+    { url = "https://files.pythonhosted.org/packages/08/18/12d001c33cd7c4e012da59d25086879aec303e0e157d9ec737ecab8e8f58/rocket_fft-0.3.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:46970c0dcc70bd9c365d6a9f4a235edec2e8eaad628097c0e21d920669e25abe", size = 2151682, upload-time = "2025-12-26T00:30:30.315Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/92/98bd01cad9e5ceeb383722d744597d066e37cdd0e54742906341aa369c28/rocket_fft-0.3.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7d64c9fc81206f2c77f74f68761f54ac6f1ebe4c8840f0ef9795c28ab229463f", size = 2160197, upload-time = "2025-12-26T00:30:31.945Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/c7/d273a880278c1a0946e4bec5ca54e79595b50003b5eb4400c1d60e5e41e0/rocket_fft-0.3.1-cp312-cp312-win_amd64.whl", hash = "sha256:05afc9805cfb97b330417b4bfcd435aace98dff2fc479bfbcb4ac4568f56ec51", size = 215185, upload-time = "2025-12-26T00:30:33.412Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/33/1b1025d47226031616bf1ac02e63f240d02b89fe2b8462b35d1766519968/rocket_fft-0.3.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:3fa706995cebcc7bff41894e23323d2a221906454d21cb12fed97833b0f7433e", size = 359250, upload-time = "2025-12-26T00:30:34.456Z" },
+    { url = "https://files.pythonhosted.org/packages/af/3c/371012b4ffa4697574ecfa148e8068a74e6ad57a182ec78f9b221bd4270c/rocket_fft-0.3.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4a50609003f944aea1b8000a19f9b9cf9cbaaa5e4726e5aefaccccd1cfd81a99", size = 322700, upload-time = "2025-12-26T00:30:35.982Z" },
+    { url = "https://files.pythonhosted.org/packages/48/2c/5bbe8d6b0c4e009f7bc6f9f4eee802a9b556ec2c3b02b9d5e5ccfa8edff1/rocket_fft-0.3.1-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5906c6517fc87295a1d142c7e6ebd1c55e057f6ee4c605549bbcecacab83774f", size = 2151627, upload-time = "2025-12-26T00:30:37.177Z" },
+    { url = "https://files.pythonhosted.org/packages/55/0d/ac67fb0b2fac382ab5585719bbd1f4927c19ba0ee3bbc28dc8a1ef83e81d/rocket_fft-0.3.1-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d830aacc34d65b28daab715aa4a90d98489e89a48c2836039982f18ba1e2db3", size = 2160355, upload-time = "2025-12-26T00:30:38.81Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/af/0ab2b29548925c6f84607010d3bf5a928331232d1ef54f273ab9989c64c0/rocket_fft-0.3.1-cp313-cp313-win_amd64.whl", hash = "sha256:97452673ea99b907c75c99c4046d5297ea01778a6e74cb51ba515c01e3e5e5d7", size = 215172, upload-time = "2025-12-26T00:30:39.885Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Two commits: the BANE port, then the wiring. Worth reviewing separately.

## Why

The racs-all smoke test produced all-zero moment maps and all-NaN peak maps, and the linmos weight cubes are the prime suspect for the noise estimate behind them. This replaces that inferred noise with one measured off the co-added planes themselves.

## 1. `flint/bane.py`, the port

Ported from `AegeanTools.BANE_fft` (AlecThomson/Aegean, `dask` branch). Only the 2D single-plane routines: the cube handling, chunking, `estimate_rms` (which needs `AegeanTools.numba_polyfit`) and the CLI all drop out.

`numba` and `rocket-fft` are new dependencies. The latter is not optional: numba's nopython mode has no `np.fft`, so without it every `njit` here fails to compile, eagerly at import for the three carrying explicit signatures. I verified that directly before adding it.

### Upstream bugs fixed, each measured on a synthetic sky

| | before | after |
|---|---|---|
| DC background of 0.01 on 1e-3 noise | 100% of pixels flagged as sources, background destroyed | recovers 9.99e-3 of 1e-2 |
| background at a 150 px blanked border | 3.59e-4, 18% of truth | 1.91e-3, 96% of truth |
| rms at that border | 9.39e-4, 94% of truth | 9.65e-4, 96% of truth |

1. **`get_kernel`'s beam guard never fired.** It caught `ValueError`; `radio_beam` raises `NoBeamException`, which inherits straight from `Exception`. A header with no beam escaped the friendly error entirely.
2. **A kernel wider than the image read out of bounds.** `pad_reflect` pads by the kernel shape and is `njit`-ed without bounds checking, so it returned quietly wrong maps rather than raising. A 256 px image with a 10 px beam downsamples to 6x6 against a 9x9 kernel and gave an RMS of exactly zero. Now refused with a message naming the fix.
3. **Sources were clipped on `|image| / rms`, not `|image - background| / rms`.** Any DC offset made every pixel a source.
4. **The clip threshold was one `mad_std` for the whole plane** while the noise it clips against is not uniform. Now two passes, the second clipping against the first pass's maps, so the cut follows the noise. This is the case the polarisation mosaics are bought for.
5. **Blanked pixels entered the convolution as measured zeros** while the normalisation still divided by the whole kernel, collapsing the background toward zero within a kernel width of any blank. Now normalised by the smoothed validity mask.

### Not fixed

The offset upstream records as a TODO. I tried sampling half a cell in, measured it, and it made the background *worse* (mean abs error 3.06e-4 against 2.68e-4), so the grid is left as upstream has it. My current read of the cause is in a comment on `_downsample_slices`: the sampled region spans `step` to `length - step` while the zoom back up stretches it across the full image, so it is misregistered by construction. Not attempted here.

## 2. The wiring

- `linmos_channel_groups_to_cubes` optionally runs BANE on each co-added channel as it lands, in parallel with the other channels, and stacks the background and RMS planes into cubes the same way image and weight planes are stacked.
- It now returns a `LinmosCubes` NamedTuple instead of a list. `create_convolve_linmos_cubes` calls `.futures` on it, so the continuum flows are untouched.
- The racs-all flow hands the RMS cubes to rm-synthesis in place of the weight cubes, and spices the background and RMS cubes alongside the rest.
- A weight cube is `1/sigma**2`, an RMS cube is `sigma`. rm-lite takes either through the same argument and is told which by `noise_files_are_weight`, so `run_rmsynth_3d` gains explicit noise-cube arguments, refuses both sets at once, and sets the flag accordingly.
- BANE is opt-in via `PolFieldOptions.bane_noise`; the flow falls back to the linmos weights when it was not run.
- `FFTBANEOptions` lives in `flint/options.py`, not `flint/bane.py`, so strategy validation does not import numba. Same reason `RMSynthOptions` lives there rather than in `flint/rmsynth.py`.

## Known limitation, worth deciding before merge

BANE runs on the linmos planes **before** cube assembly, while rm-synthesis convolves the cubes to a common beam before building the FDF. The RMS cubes therefore describe the pre-convolution resolution, which is the same mismatch the weight cubes have. Swapping weights for RMS fixes the scale and the spatial variation of the noise, but not this. Options discussed: measure after the convolution inside the rm-synth stage, accept the mismatch, or convolve before co-adding.

There is also an open question about whether the weight-cube path should be dropped from the flow entirely rather than kept as a fallback.

## Tests

`tests/test_bane.py` is new: `pad_reflect` against `np.pad`, a flat image through `fft_average`, recovery of a varying background and RMS, blanked pixels staying blank, seed reproducibility, beam-derived kernel sizing, and one test per fixed bug. `tests/test_racs_all_pipeline.py` gains three covering RMS cubes preferred over weights, the weight fallback, and the BANE cubes reaching SPICE.

Full suite was still running when this was opened; `test_bane.py`, `test_rmsynth.py` and `test_racs_all_pipeline.py` all pass, and ruff is clean. I will report the full result on the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MKV4YVPViaNXK1H6euKLhA

---
_Generated by [Claude Code](https://claude.ai/code/session_01MKV4YVPViaNXK1H6euKLhA)_