### PR TITLE
Only treat polarisation keys as polarisations to image

### DIFF
--- a/flint/prefect/flows/polarisation_pipeline.py
+++ b/flint/prefect/flows/polarisation_pipeline.py
@@ -11,6 +11,7 @@ from prefect.futures import PrefectFuture
 from flint.coadd.linmos import LinmosOptions
 from flint.configuration import (
     POLARISATION_MAPPING,
+    Strategy,
     get_options_from_strategy,
     load_and_copy_strategy,
 )
@@ -106,6 +107,29 @@ def _no_products(
         mfs_products={},
         terminal_futures=terminal_futures or [],
     )
+
+
+def _polarisations_to_image(strategy: Strategy) -> dict[str, Any]:
+    """Pull the polarisations to image out of the strategy's polarisation operation.
+
+    The operation also carries modes that apply across all polarisations (e.g.
+    ``fitscube``, ``fftbane``), which sit alongside the polarisation keys. Only
+    the polarisation keys describe something to image.
+
+    Args:
+        strategy (Strategy): The loaded strategy
+
+    Returns:
+        dict[str, Any]: Polarisation name and its scoped modes. Falls back to Stokes I when the strategy names none.
+    """
+    polarisation_scope = strategy.get("polarisation", {})
+    polarisations = {
+        key: value
+        for key, value in polarisation_scope.items()
+        if key in POLARISATION_MAPPING
+    }
+
+    return polarisations or {"total": {}}
 
 
 @flow(name="Flint Polarisation Pipeline")
@@ -220,7 +244,7 @@ def process_science_fields_pol(
         logger.info("No wsclean container provided. Returning. ")
         return _no_products(terminal_futures=[field_summary])
 
-    polarisations: dict[str, str] = strategy.get("polarisation", {"total": {}})
+    polarisations = _polarisations_to_image(strategy=strategy)
 
     # Solved once for all beams, and before any imaging
     cube_division: ChannelDivision | None = None

--- a/tests/test_polarisation_pipeline.py
+++ b/tests/test_polarisation_pipeline.py
@@ -1,0 +1,45 @@
+"""Tests around the polarisation pipeline helpers"""
+
+from __future__ import annotations
+
+from flint.configuration import Strategy
+from flint.prefect.flows.polarisation_pipeline import _polarisations_to_image
+
+
+def test_polarisations_to_image_defaults_to_total():
+    """No polarisation operation at all means Stokes I"""
+    assert _polarisations_to_image(strategy=Strategy()) == {"total": {}}
+
+
+def test_polarisations_to_image_keeps_polarisations():
+    """Polarisation keys and their scoped modes are carried through"""
+    strategy = Strategy(
+        polarisation={
+            "total": {"wsclean": {"niter": 10}},
+            "linear": {"wsclean": {"niter": 20}},
+        }
+    )
+    assert _polarisations_to_image(strategy=strategy) == {
+        "total": {"wsclean": {"niter": 10}},
+        "linear": {"wsclean": {"niter": 20}},
+    }
+
+
+def test_polarisations_to_image_drops_operation_modes():
+    """Modes applied across all polarisations are not polarisations to image"""
+    strategy = Strategy(
+        polarisation={
+            "fftbane": {"step_size": 16},
+            "fitscube": {"compress": True},
+            "linear": {"wsclean": {"niter": 20}},
+        }
+    )
+    assert _polarisations_to_image(strategy=strategy) == {
+        "linear": {"wsclean": {"niter": 20}}
+    }
+
+
+def test_polarisations_to_image_modes_only_defaults_to_total():
+    """A polarisation operation carrying only modes still images Stokes I"""
+    strategy = Strategy(polarisation={"fftbane": {"step_size": 16}})
+    assert _polarisations_to_image(strategy=strategy) == {"total": {}}


### PR DESCRIPTION
## The failure

A strategy with an `fftbane` block under `polarisation` passes `flint_config verify` but kills the flow:

```
File "flint/prefect/flows/polarisation_pipeline.py", line 244, in process_science_fields_pol
  update_wsclean_options = get_options_from_strategy(
File "flint/configuration.py", line 355, in get_options_from_strategy
  {"pol": POLARISATION_MAPPING[polarisation]}
KeyError: 'fftbane'
```

## Why

The `polarisation` operation holds two kinds of key:

- polarisation scopes (`total`, `linear`, `circular`), each holding modes scoped to that polarisation
- modes that apply across all of them (`fitscube`, `spice`, and now `fftbane`), sitting directly under the operation

`verify_configuration` knows about both, which is why the strategy verifies. The pipeline did not: it took every key under `polarisation` as a polarisation to image, so it reached `POLARISATION_MAPPING["fftbane"]` on the wsclean lookup. The guard further down (`if polarisation not in POLARISATION_MAPPING`) never got a chance to fire.

`fftbane` only started appearing under `polarisation` with #415, so this is new. The strategy itself is correct and needs no change.

## The change

`_polarisations_to_image` filters the operation scope down to the known polarisations, falling back to `total` when the strategy names none. Unit tests cover the four cases: no operation, polarisations only, polarisations mixed with modes, and modes only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LWfbjm7f9FrUXuEiMmZQab

---
_Generated by [Claude Code](https://claude.ai/code/session_01LWfbjm7f9FrUXuEiMmZQab)_