### PR TITLE
Blank the BANE maps of a plane with no usable beam

### DIFF
--- a/flint/bane.py
+++ b/flint/bane.py
@@ -28,6 +28,7 @@ from radio_beam import Beam
 from radio_beam.beam import NoBeamException
 from scipy import ndimage
 
+from flint.convol import header_beam_is_usable
 from flint.logging import logger
 from flint.naming import create_aegean_names
 from flint.options import FFTBANEOptions
@@ -292,6 +293,12 @@ def _bane_round(
     return background, rms
 
 
+def _needs_a_beam(fft_bane_options: FFTBANEOptions) -> bool:
+    """Whether ``get_kernel`` will read the beam, rather than take both sizes as given"""
+    step_size, box_size = fft_bane_options.step_size, fft_bane_options.box_size
+    return step_size is None or step_size < 0 or box_size is None or box_size < 0
+
+
 def robust_bane(
     image: NDArray[np.float32],
     header: fits.Header | dict[str, Any],
@@ -304,6 +311,9 @@ def robust_bane(
     Two passes: the first clips sources against one background and noise for the
     plane, the second against the maps the first produced.
 
+    A plane with no usable beam gets blank maps, unless both sizes are given
+    outright and so no beam is needed to size the kernel.
+
     Args:
         image (NDArray[np.float32]): The image plane to measure
         header (fits.Header | dict[str, Any]): Its header, for the beam and pixel scale
@@ -315,6 +325,16 @@ def robust_bane(
         tuple[NDArray[np.float32], NDArray[np.float32]]: Background and RMS, shaped like `image`
     """
     fft_bane_options = fft_bane_options or FFTBANEOptions()
+
+    if _needs_a_beam(fft_bane_options) and not header_beam_is_usable(header=header):
+        # A blank channel is marked with a zero beam, or loses its beam keywords
+        # altogether once linmos has co-added it. There is no resolution to size
+        # a kernel against and no signal to measure, so the maps are blank too.
+        # Blank rather than absent so the plane still stacks into a cube
+        logger.warning("No usable beam to size the BANE kernel, returning blank maps")
+        blank = np.full_like(image, np.nan, dtype=np.float32)
+        return blank, blank.copy()
+
     kernel, step_size_pix = get_kernel(
         header=header,
         step_size=fft_bane_options.step_size,

--- a/flint/convol.py
+++ b/flint/convol.py
@@ -9,7 +9,7 @@ from argparse import ArgumentParser
 from collections.abc import Collection
 from pathlib import Path
 from shutil import copyfile
-from typing import Literal, NamedTuple
+from typing import Any, Literal, NamedTuple
 
 import astropy.units as u
 import numpy as np
@@ -133,7 +133,7 @@ def usable_beam_mask(beams: Beams, cutoff: float | None = None) -> np.ndarray:
     return usable
 
 
-def beam_from_header(header: fits.Header) -> Beam | None:
+def beam_from_header(header: fits.Header | dict[str, Any]) -> Beam | None:
     """The restoring beam recorded in a FITS header, or None when there is none"""
     try:
         return Beam.from_fits_header(header)
@@ -141,7 +141,9 @@ def beam_from_header(header: fits.Header) -> Beam | None:
         return None
 
 
-def header_beam_is_usable(header: fits.Header, cutoff: float | None = None) -> bool:
+def header_beam_is_usable(
+    header: fits.Header | dict[str, Any], cutoff: float | None = None
+) -> bool:
     """Whether the beam a FITS header records is a real PSF. See ``usable_beam_mask``"""
     beam = beam_from_header(header=header)
     if beam is None:

--- a/tests/test_bane.py
+++ b/tests/test_bane.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
 import numpy as np
@@ -205,3 +206,48 @@ def test_bane_fits_image_refuses_a_cube(tmp_path: Path) -> None:
 
     with pytest.raises(ValueError, match="expected a single plane"):
         bane_fits_image(image=fits_path)
+
+
+@pytest.mark.parametrize("beamless", ["missing", "zero"])
+def test_bane_fits_image_blanks_a_plane_with_no_beam(
+    tmp_path: Path, beamless: str, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A blank channel loses its beam keywords through linmos, or carries the
+    zero beam that marks it as holding no PSF. Neither can size a kernel, and
+    neither holds signal, so the maps come out blank rather than raising and
+    taking the whole cube with them."""
+    header = _header()
+    for key in ("BMAJ", "BMIN", "BPA"):
+        if beamless == "missing":
+            del header[key]
+        else:
+            header[key] = 0.0
+
+    fits_path = tmp_path / "field.image.fits"
+    fits.writeto(fits_path, _sky()[np.newaxis, np.newaxis], header, overwrite=True)
+
+    with caplog.at_level(logging.WARNING, logger="flint"):
+        bkg_path, rms_path = bane_fits_image(image=fits_path)
+
+    # A zero beam sizes a 1x1 all-NaN kernel rather than raising, so the maps
+    # coming out blank does not on its own say the beam was checked
+    assert "No usable beam" in caplog.text
+
+    for path in (bkg_path, rms_path):
+        assert fits.getdata(path).shape == (1, 1, NY, NX)
+        assert np.all(np.isnan(fits.getdata(path)))
+
+
+def test_robust_bane_without_a_beam_runs_on_given_sizes() -> None:
+    """The beam only sizes the kernel, so sizes given outright need no beam"""
+    header = _header()
+    for key in ("BMAJ", "BMIN", "BPA"):
+        del header[key]
+
+    background, rms = robust_bane(
+        image=_sky(background=0.0, rms=1e-3),
+        header=header,
+        fft_bane_options=FFTBANEOptions(step_size=10, box_size=10),
+    )
+    assert np.isfinite(background).all()
+    assert np.nanmedian(rms) == pytest.approx(1e-3, rel=0.3)


### PR DESCRIPTION
Fixes the `bane_fits_image` failure seen in the polarisation flow:

```
ValueError: Could not parse beam from header - try specifying step size
radio_beam.beam.NoBeamException: No BMAJ found and does not appear to be a CASA/AIPS header.
```

## Where the beamless planes come from

`get_kernel` reads the restoring beam to size the step and box whenever
`FFTBANEOptions.step_size`/`box_size` are unset, which is the default.

Blank channels have no beam to read. `convolve_plane_to_beam` deliberately
stamps `BMAJ=BMIN=BPA=0.0` on a plane beyond the cutoff, and a channel that
never had a fitted PSF keeps its zero beam. Those go through
`linmos_channel_groups_to_cubes`, and the co-added plane for such a channel
comes out with no beam keywords at all, then straight into
`task_bane_fits_image`. Only that one channel's task failed, which is why the
rest of the map ran fine.

`BMAJ=0.0` was broken too, just silently: it parses, gives `pix_per_beam=0`,
`box_size_pix=0`, and `gaussian_kernel(0)` is a 1x1 all-NaN kernel. So the
check has to cover a missing beam and a placeholder zero beam alike.

## The change

`robust_bane` now tests the header with `flint.convol.header_beam_is_usable`
(the same definition of usable the convolution and common-beam code already
uses: present, non-zero, finite) before sizing the kernel. With no usable
beam it logs a warning and returns all-NaN background and RMS maps shaped
like the input, which `bane_fits_image` then writes out as normal.

Blank rather than absent: the bkg/rms planes are stacked into cubes
channel-by-channel alongside the image planes, so dropping one would
misalign the frequency axis. A blank channel holds no signal, its data is
already NaN, and a NaN noise is what rm-lite reads as a flagged channel.

Skipped when both sizes are given outright, since no beam is needed then.
`get_kernel`'s `ValueError` is left alone, still the right answer for a
direct caller.

`beam_from_header` and `header_beam_is_usable` take
`fits.Header | dict[str, Any]` now, matching what `robust_bane` already
accepts.

## Tests

- A plane with the beam keywords deleted, and one with them zeroed, both get
  blank maps on the input pixel grid. Asserts the warning too: a zero beam
  produced all-NaN maps before this change as well, so the NaN alone does not
  say the beam was checked. Both fail without the fix.
- `robust_bane` with no beam but explicit `step_size`/`box_size` still
  measures the plane.

No CHANGELOG entry: the top heading is the released v0.3.0, and the last two
PRs on this branch did not add one either.

## Verification

`uv run pytest tests/test_bane.py` passes (13 tests). `uv run ruff check`
and `ruff format --check` are clean. The full suite did not finish in this
environment (killed for resources both times), so it is worth a run in CI
before merging. `mypy` on the changed modules reports one error, on
`_ft_kernel` at `flint/bane.py:49`, which is pre-existing and untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LWfbjm7f9FrUXuEiMmZQab

---
_Generated by [Claude Code](https://claude.ai/code/session_01LWfbjm7f9FrUXuEiMmZQab)_