### PR TITLE
Take the rm-synth cubes as a list, so the standalone pipeline can run

### DIFF
--- a/docs/quickstart/polarisation.md
+++ b/docs/quickstart/polarisation.md
@@ -61,44 +61,6 @@ cubes alone, so both are available: the natural cubes to archive, the total cube
 to synthesise from. See `RMSynthFieldOptions.beam_cutoff` to drop the coarsest
 channels from that solve rather than smoothing the whole band to reach them.
 
-## Running RM-synthesis on its own
-
-`flint_flow_rmsynth_pipeline` runs the rm-synth stage against cubes that have
-already been imaged, without the rest of the `racs-all` flow. The Stokes cubes
-are given as a flat list, and which Stokes each one is comes from its filename,
-so they have to follow the `flint` or CASDA naming scheme:
-
-```bash
-flint_flow_rmsynth_pipeline \
-  --stokes-cubes SB56289.RACS_1041+18.round1.q.pol.image.cube.fits \
-                 SB56289.RACS_1041+18.round1.u.pol.image.cube.fits \
-                 SB56289.RACS_1041+18.round1.i.pol.image.cube.fits \
-  --imaging-strategy strategy.yaml
-```
-
-Stokes Q and U are required; Stokes I is optional and is used to fit the
-fractional-polarisation correction. `--error-cubes` takes a matching list, and
-needs `--error-cube-kind` to say whether those are `linmos` weights (an inverse
-variance) or a noise (a sigma) -- reading one as the other inverts the error by
-1/sigma**2. Every option can equally be set in a `--cli-config` file:
-
-```
-stokes-cubes = [SB56289.RACS_1041+18.round1.q.pol.image.cube.fits, SB56289.RACS_1041+18.round1.u.pol.image.cube.fits]
-error-cubes = [SB56289.RACS_1041+18.round1.q.pol.weight.cube.fits, SB56289.RACS_1041+18.round1.u.pol.weight.cube.fits]
-error-cube-kind = weight
-```
-
-```{argparse}
-:ref: flint.prefect.flows.rmsynth_pipeline.get_parser
-:prog: flint_flow_rmsynth_pipeline
-```
-
-## The `RMSynthFieldOptions` class
-
-```{literalinclude}  ../../flint/options.py
-:pyobject: RMSynthFieldOptions
-```
-
 ## Spectro-polarimetric imaging in WSClean
 
 We encourage users to carefully read the [WSclean documentation](https://wsclean.readthedocs.io/en/latest/). In practice, we have encountered a few common 'gotchas' when producing polarisation cube. As always, a user should pay attention to the output logs to see e.g. how many iterations have been performed and what the stopping criterion was. We also encourage the inspection of image, model, and residual products to see how well (or not) deconvolution has performed.

--- a/docs/quickstart/polarisation.md
+++ b/docs/quickstart/polarisation.md
@@ -61,6 +61,44 @@ cubes alone, so both are available: the natural cubes to archive, the total cube
 to synthesise from. See `RMSynthFieldOptions.beam_cutoff` to drop the coarsest
 channels from that solve rather than smoothing the whole band to reach them.
 
+## Running RM-synthesis on its own
+
+`flint_flow_rmsynth_pipeline` runs the rm-synth stage against cubes that have
+already been imaged, without the rest of the `racs-all` flow. The Stokes cubes
+are given as a flat list, and which Stokes each one is comes from its filename,
+so they have to follow the `flint` or CASDA naming scheme:
+
+```bash
+flint_flow_rmsynth_pipeline \
+  --stokes-cubes SB56289.RACS_1041+18.round1.q.pol.image.cube.fits \
+                 SB56289.RACS_1041+18.round1.u.pol.image.cube.fits \
+                 SB56289.RACS_1041+18.round1.i.pol.image.cube.fits \
+  --imaging-strategy strategy.yaml
+```
+
+Stokes Q and U are required; Stokes I is optional and is used to fit the
+fractional-polarisation correction. `--error-cubes` takes a matching list, and
+needs `--error-cube-kind` to say whether those are `linmos` weights (an inverse
+variance) or a noise (a sigma) -- reading one as the other inverts the error by
+1/sigma**2. Every option can equally be set in a `--cli-config` file:
+
+```
+stokes-cubes = [SB56289.RACS_1041+18.round1.q.pol.image.cube.fits, SB56289.RACS_1041+18.round1.u.pol.image.cube.fits]
+error-cubes = [SB56289.RACS_1041+18.round1.q.pol.weight.cube.fits, SB56289.RACS_1041+18.round1.u.pol.weight.cube.fits]
+error-cube-kind = weight
+```
+
+```{argparse}
+:ref: flint.prefect.flows.rmsynth_pipeline.get_parser
+:prog: flint_flow_rmsynth_pipeline
+```
+
+## The `RMSynthFieldOptions` class
+
+```{literalinclude}  ../../flint/options.py
+:pyobject: RMSynthFieldOptions
+```
+
 ## Spectro-polarimetric imaging in WSClean
 
 We encourage users to carefully read the [WSclean documentation](https://wsclean.readthedocs.io/en/latest/). In practice, we have encountered a few common 'gotchas' when producing polarisation cube. As always, a user should pay attention to the output logs to see e.g. how many iterations have been performed and what the stopping criterion was. We also encourage the inspection of image, model, and residual products to see how well (or not) deconvolution has performed.

--- a/flint/options.py
+++ b/flint/options.py
@@ -20,8 +20,9 @@ from astropy.time import Time
 from capn_crunch import BaseOptions
 from pydantic import Field, create_model
 
-from flint.exceptions import MSError
+from flint.exceptions import MSError, NamingException
 from flint.logging import logger
+from flint.naming import split_images
 
 
 class BandpassOptions(BaseOptions):
@@ -276,6 +277,32 @@ class _CubesForRMSynth(BaseOptions):
             msg = f"Need a cube for every one of q and u, missing {sorted(missing)}."
             raise ValueError(msg)
         return cls(q_path=cubes["q"], u_path=cubes["u"], i_path=cubes.get("i"))
+
+    @classmethod
+    def from_paths(cls, paths: list[Path]) -> Self:
+        """From a flat list of cubes, taking the Stokes of each from its filename.
+
+        For the CLI, which has only a list of paths to hand. Prefer
+        ``from_mapping`` wherever the Stokes of each cube is already known.
+
+        Raises:
+            ValueError: A path carries no recognisable Stokes, or two cubes claim the same one
+        """
+        try:
+            split = split_images(images=paths, by="pol")
+        except (NamingException, ValueError) as err:
+            msg = (
+                f"Could not read the Stokes of every cube in {paths}. Names must "
+                "follow the flint or CASDA scheme, as the polarisation stage writes them."
+            )
+            raise ValueError(msg) from err
+
+        duplicated = {pol: found for pol, found in split.items() if len(found) > 1}
+        if duplicated:
+            msg = f"More than one cube for a Stokes, so which to use is ambiguous: {duplicated}"
+            raise ValueError(msg)
+
+        return cls.from_mapping({pol: found[0] for pol, found in split.items()})
 
     @property
     def paths(self) -> list[Path]:
@@ -554,6 +581,30 @@ def pol_field_options_cli_class(
     }
     return create_model(
         "PolFieldOptionsCLI", __base__=PolFieldOptions.__base__, **unique_fields
+    )
+
+
+def exclude_fields_cli_class(
+    options_class: type[BaseOptions], exclude_fields: set[str]
+) -> type[BaseOptions]:
+    """Build a sibling of ``options_class`` exposing only the fields not in
+    ``exclude_fields``, so it can be added to a parser that already exposes
+    those fields via another options class, or sets them up by hand, without a
+    duplicate-flag error.
+
+    The result derives from ``options_class.__base__``, so it is a sibling rather
+    than a subclass. Generalises ``pol_field_options_cli_class`` to an arbitrary,
+    accumulated set of already-registered field names.
+    """
+    unique_fields = {
+        name: (field.annotation, field)
+        for name, field in options_class.model_fields.items()
+        if name not in exclude_fields
+    }
+    return create_model(
+        f"{options_class.__name__}CLI",
+        __base__=options_class.__base__,
+        **unique_fields,
     )
 
 

--- a/flint/prefect/flows/racs_all_pipeline.py
+++ b/flint/prefect/flows/racs_all_pipeline.py
@@ -41,13 +41,6 @@ from flint.prefect.flows.racs_all_continuum_selfcal import process_racs_all_cont
 from flint.prefect.flows.rmsynth_pipeline import process_rmsynth
 from flint.prefect.flows.spice_compression_pipeline import process_spice_compression
 
-STAGE_CLUSTER_CONFIG_ATTRS = (
-    "imaging_cluster_config",
-    "polarisation_cluster_config",
-    "rmsynth_cluster_config",
-    "spice_cluster_config",
-)
-
 # Fields on the rm-synth/spice options classes that process_racs_all always recomputes
 # from the polarisation stage's output. Excluded from the combined CLI.
 COMPUTED_FIELDS = {"stokes_cubes", "error_cubes", "cubes", "weight_cubes"}
@@ -434,7 +427,12 @@ def cli() -> None:
         parser_namespace=args, options_class=SpiceFieldOptions
     )
 
-    for cluster_config_attr in STAGE_CLUSTER_CONFIG_ATTRS:
+    for cluster_config_attr in (
+        "imaging_cluster_config",
+        "polarisation_cluster_config",
+        "rmsynth_cluster_config",
+        "spice_cluster_config",
+    ):
         if getattr(pipeline_options, cluster_config_attr) is None:
             pipeline_options = pipeline_options.with_options(
                 **{cluster_config_attr: args.cluster_config}

--- a/flint/prefect/flows/racs_all_pipeline.py
+++ b/flint/prefect/flows/racs_all_pipeline.py
@@ -9,11 +9,10 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from capn_crunch import BaseOptions, add_options_to_parser, create_options_from_parser
+from capn_crunch import add_options_to_parser, create_options_from_parser
 from configargparse import ArgumentParser
 from fitscube.combine_fits import compress_cube
 from prefect import flow
-from pydantic import create_model
 
 from flint.configuration import (
     POLARISATION_MAPPING,
@@ -33,6 +32,7 @@ from flint.options import (
     RMSynthFieldOptions,
     SpiceFieldOptions,
     WeightCubesForRMSynth,
+    exclude_fields_cli_class,
     pol_field_options_cli_class,
 )
 from flint.prefect.clusters import get_dask_runner
@@ -192,29 +192,6 @@ def _check_spice_mfs_dependency(
             "(needed as the aegean source-finding reference image). Pass "
             "--skip-spice to disable the stage."
         )
-
-
-def _exclude_fields_cli_class(
-    options_class: type[BaseOptions], exclude_fields: set[str]
-) -> type[BaseOptions]:
-    """Build a sibling of ``options_class`` exposing only the fields not in
-    ``exclude_fields``, so it can be added to a parser that already exposes
-    those fields via another options class without a duplicate-flag error.
-
-    The result derives from ``options_class.__base__``, so it is a sibling rather
-    than a subclass. Generalises ``pol_field_options_cli_class`` to an arbitrary,
-    accumulated set of already-registered field names.
-    """
-    unique_fields = {
-        name: (field.annotation, field)
-        for name, field in options_class.model_fields.items()
-        if name not in exclude_fields
-    }
-    return create_model(
-        f"{options_class.__name__}CLI",
-        __base__=options_class.__base__,
-        **unique_fields,
-    )
 
 
 @flow(name="Flint RACS-All Pipeline")
@@ -417,14 +394,14 @@ def get_parser() -> ArgumentParser:
 
     parser = add_options_to_parser(
         parser=parser,
-        options_class=_exclude_fields_cli_class(RMSynthFieldOptions, seen_fields),
+        options_class=exclude_fields_cli_class(RMSynthFieldOptions, seen_fields),
         description="RM-synthesis processing options",
     )
     seen_fields |= set(RMSynthFieldOptions.model_fields)
 
     parser = add_options_to_parser(
         parser=parser,
-        options_class=_exclude_fields_cli_class(SpiceFieldOptions, seen_fields),
+        options_class=exclude_fields_cli_class(SpiceFieldOptions, seen_fields),
         description="SPICE compression processing options",
     )
 

--- a/flint/prefect/flows/rmsynth_pipeline.py
+++ b/flint/prefect/flows/rmsynth_pipeline.py
@@ -25,6 +25,8 @@ from flint.options import (
     RMCleanOptions,
     RMSynthFieldOptions,
     RMSynthOptions,
+    WeightCubesForRMSynth,
+    exclude_fields_cli_class,
 )
 from flint.prefect.clusters import get_dask_runner
 from flint.prefect.common.rmsynth import (
@@ -262,10 +264,46 @@ def get_parser() -> ArgumentParser:
         help="Path to a cluster configuration file, or a known cluster name. ",
     )
 
+    # stokes_cubes/error_cubes are nested Options classes, which
+    # add_options_to_parser can only render as a single-value flag that no CLI or
+    # config string can fill. Set up by hand below and assembled in cli().
     parser = add_options_to_parser(
         parser=parser,
-        options_class=RMSynthFieldOptions,
+        options_class=exclude_fields_cli_class(
+            RMSynthFieldOptions, {"stokes_cubes", "error_cubes"}
+        ),
         description="RM-synthesis processing options",
+    )
+
+    group = parser.add_argument_group(title="Input cubes")
+    group.add_argument(
+        "--stokes-cubes",
+        type=Path,
+        nargs="+",
+        default=None,
+        metavar="CUBE",
+        help="The Stokes cubes to synthesise, one per Stokes. Q and U are required, "
+        "I is optional and fits the fractional-polarisation correction. Which Stokes "
+        "each cube is comes from its filename.",
+    )
+    group.add_argument(
+        "--error-cubes",
+        type=Path,
+        nargs="+",
+        default=None,
+        metavar="CUBE",
+        help="Cubes describing the error on --stokes-cubes, matched to a Stokes the "
+        "same way. Requires --error-cube-kind. Omit to let rm-lite estimate the noise "
+        "from Q/U itself.",
+    )
+    group.add_argument(
+        "--error-cube-kind",
+        type=str,
+        choices=("weight", "noise"),
+        default=None,
+        help="Whether --error-cubes are linmos weights (an inverse variance) or a "
+        "noise (a sigma). Required with --error-cubes: reading one as the other "
+        "inverts the error by 1/sigma**2.",
     )
 
     return parser
@@ -276,8 +314,27 @@ def cli() -> None:
 
     args = parser.parse_args()
 
+    if args.error_cubes and args.error_cube_kind is None:
+        parser.error("--error-cubes requires --error-cube-kind")
+
+    error_cubes_class = {
+        "weight": WeightCubesForRMSynth,
+        "noise": NoiseCubesForRMSynth,
+    }.get(args.error_cube_kind)
+
+    # The cube fields are off the parser, so their values are substituted rather
+    # than read straight off the namespace.
+    namespace = vars(args) | {
+        "stokes_cubes": CubesForRMSynth.from_paths(paths=args.stokes_cubes)
+        if args.stokes_cubes
+        else None,
+        "error_cubes": error_cubes_class.from_paths(paths=args.error_cubes)
+        if args.error_cubes and error_cubes_class is not None
+        else None,
+    }
+
     rmsynth_field_options = create_options_from_parser(
-        parser_namespace=args, options_class=RMSynthFieldOptions
+        parser_namespace=namespace, options_class=RMSynthFieldOptions
     )
 
     setup_run_rmsynth(

--- a/tests/test_prefect_rmsynth_flow.py
+++ b/tests/test_prefect_rmsynth_flow.py
@@ -24,10 +24,17 @@ from flint.convol import (
     cubes_share_common_beam,
     usable_beam_mask,
 )
-from flint.options import CubesForRMSynth, FFTBANEOptions, RMSynthFieldOptions
+from flint.options import (
+    CubesForRMSynth,
+    FFTBANEOptions,
+    RMSynthFieldOptions,
+    WeightCubesForRMSynth,
+)
 from flint.prefect.common.rmsynth import CommonResolutionCubes
+from flint.prefect.flows import rmsynth_pipeline
 from flint.prefect.flows.rmsynth_pipeline import (
     _resolve_common_resolution_cubes,
+    get_parser,
     process_rmsynth,
 )
 
@@ -435,3 +442,145 @@ def test_no_bane_cubes_without_a_convolution(tmp_path: Path) -> None:
     assert resolved.cubes == cubes
     assert resolved.rms_cubes == {}
     assert resolved.all_cubes == []
+
+
+def _cube_names(
+    tmp_path: Path, pols: tuple[str, ...], suffix: str = "image"
+) -> list[Path]:
+    """Cube paths named in the flint scheme, which is what from_paths reads"""
+    # STEM carries a channel range, which the flint scheme puts in place of the
+    # polarisation, so these names need a round instead
+    stem = "SB12345.BENCH_0000+00.round1"
+    return [tmp_path / f"{stem}.{pol}.pol.{suffix}.cube.fits" for pol in pols]
+
+
+def test_get_parser_takes_a_list_of_stokes_cubes(tmp_path: Path) -> None:
+    """The nested cube Options cannot be filled by a single CLI or config value,
+    so the standalone pipeline takes a flat list of cubes instead."""
+    cubes = _cube_names(tmp_path, ("q", "u", "i"))
+
+    args = get_parser().parse_args(["--stokes-cubes", *[str(cube) for cube in cubes]])
+
+    assert args.stokes_cubes == cubes
+    stokes_cubes = CubesForRMSynth.from_paths(paths=args.stokes_cubes)
+    assert (stokes_cubes.q_path, stokes_cubes.u_path, stokes_cubes.i_path) == tuple(
+        cubes
+    )
+
+
+def test_get_parser_takes_stokes_cubes_from_a_config_file(tmp_path: Path) -> None:
+    """The failing case: a list in a --cli-config file, which configargparse
+    rejects outright unless the argument accepts more than one value."""
+    cubes = _cube_names(tmp_path, ("q", "u", "i"))
+    config = tmp_path / "rmsynth.cfg"
+    config.write_text(f"stokes-cubes = [{', '.join(str(cube) for cube in cubes)}]\n")
+
+    args = get_parser().parse_args(["--cli-config", str(config)])
+
+    assert args.stokes_cubes == cubes
+
+
+def test_get_parser_stokes_i_cube_is_optional(tmp_path: Path) -> None:
+    """rm-synthesis runs on Q and U alone"""
+    cubes = _cube_names(tmp_path, ("q", "u"))
+
+    args = get_parser().parse_args(["--stokes-cubes", *[str(cube) for cube in cubes]])
+    stokes_cubes = CubesForRMSynth.from_paths(paths=args.stokes_cubes)
+
+    assert stokes_cubes.i_path is None
+
+
+def test_get_parser_error_cube_kind_picks_the_container(tmp_path: Path) -> None:
+    """Weights and noises are told apart by the kind flag, never guessed: reading
+    one as the other inverts the error by 1/sigma**2."""
+    cubes = _cube_names(tmp_path, ("q", "u"), suffix="weight")
+
+    args = get_parser().parse_args(
+        [
+            "--error-cubes",
+            *[str(cube) for cube in cubes],
+            "--error-cube-kind",
+            "weight",
+        ]
+    )
+
+    assert args.error_cube_kind == "weight"
+    assert args.error_cubes == cubes
+
+
+def test_from_paths_needs_q_and_u(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="missing"):
+        CubesForRMSynth.from_paths(paths=_cube_names(tmp_path, ("q",)))
+
+
+def test_from_paths_rejects_two_cubes_for_one_stokes(tmp_path: Path) -> None:
+    cubes = _cube_names(tmp_path, ("q", "u"))
+    with pytest.raises(ValueError, match="ambiguous"):
+        CubesForRMSynth.from_paths(paths=[*cubes, cubes[0]])
+
+
+def test_from_paths_rejects_unreadable_names(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="flint or CASDA scheme"):
+        CubesForRMSynth.from_paths(paths=[tmp_path / "not-a-flint-name.fits"])
+
+
+def test_cli_assembles_the_cube_options(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """cli() substitutes the cube fields into the namespace, as they are off the
+    parser, so the options class it builds carries the nested containers."""
+    captured: dict[str, RMSynthFieldOptions] = {}
+
+    def _capture(cluster_config: str | Path, **kwargs: RMSynthFieldOptions) -> None:
+        captured.update(kwargs)
+
+    monkeypatch.setattr(rmsynth_pipeline, "setup_run_rmsynth", _capture)
+    stokes = _cube_names(tmp_path, ("q", "u"))
+    errors = _cube_names(tmp_path, ("q", "u"), suffix="weight")
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "flint_flow_rmsynth_pipeline",
+            "--stokes-cubes",
+            *[str(cube) for cube in stokes],
+            "--error-cubes",
+            *[str(cube) for cube in errors],
+            "--error-cube-kind",
+            "weight",
+        ],
+    )
+
+    rmsynth_pipeline.cli()
+
+    options = captured["rmsynth_field_options"]
+    assert isinstance(options.stokes_cubes, CubesForRMSynth)
+    assert options.stokes_cubes.paths == stokes
+    assert isinstance(options.error_cubes, WeightCubesForRMSynth)
+    assert options.error_cubes.paths == errors
+
+
+def test_cli_error_cubes_require_a_kind(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Guessing between a weight and a noise inverts the error by 1/sigma**2"""
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "flint_flow_rmsynth_pipeline",
+            "--error-cubes",
+            *[str(cube) for cube in _cube_names(tmp_path, ("q", "u"))],
+        ],
+    )
+
+    with pytest.raises(SystemExit):
+        rmsynth_pipeline.cli()
+
+
+def test_cli_without_cubes_leaves_them_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The fields stay optional: process_rmsynth raises on a missing stokes_cubes,
+    and the racs-all flow sets them in memory rather than through this CLI."""
+    args = get_parser().parse_args([])
+
+    assert args.stokes_cubes is None
+    assert args.error_cubes is None
+    assert args.error_cube_kind is None


### PR DESCRIPTION
## The problem

`flint_flow_rmsynth_pipeline` could not be run on its own at all. Passing the Stokes cubes in a `--cli-config` file failed with:

```
flint_flow_rmsynth_pipeline: error: --stokes-cubes can't be set to a list '[...q..., ...u..., ...i...]'
unless its action type is changed to 'append' or nargs is set to '*', '+', or > 1
```

`RMSynthFieldOptions.stokes_cubes` is a nested Options class (`CubesForRMSynth`), and `add_options_to_parser` renders anything non-iterable as a single-value `store` argument. So:

- configargparse rejects a list outright, which is the error above.
- Even a single string would fail, as pydantic will not coerce `str` into `CubesForRMSynth`.
- `error_cubes` is worse: a discriminated `WeightCubesForRMSynth | NoiseCubesForRMSynth` union that no one CLI string can express.

The `racs-all` flow never hit this. It already excludes both fields from its combined CLI (`COMPUTED_FIELDS`) and sets them in memory from the polarisation stage.

## The fix

Keep the model-typed fields as the programmatic API, so the `racs-all` handoff keeps its exact per-Stokes mapping, and give the standalone CLI a flat surface:

- Exclude `stokes_cubes`/`error_cubes` from the generated parser and add them by hand as `nargs="+"` lists of paths.
- Which Stokes each cube is comes from its filename, via the existing `split_images(by="pol")`, in a new `_CubesForRMSynth.from_paths` classmethod beside `from_mapping`.
- `--error-cubes` requires a new `--error-cube-kind {weight,noise}`. It is required rather than guessed because reading a weight as a noise inverts the error by 1/sigma**2.
- `_exclude_fields_cli_class` moves from `racs_all_pipeline` to `flint.options` as `exclude_fields_cli_class` so both flows can use it; importing it the other way round would be circular.

The originally failing config now works unchanged:

```
stokes-cubes = [SB56289.RACS_1041+18.round1.q.pol.image.cube.fits, SB56289.RACS_1041+18.round1.u.pol.image.cube.fits]
```

## Notes

Recovering the Stokes from the filename means cube names have to follow the `flint` or CASDA scheme, which the polarisation pipeline already requires of its inputs. Both a name that does not parse and one carrying no polarisation raise a message saying so, rather than failing later inside rm-synthesis.

## Tests

Nine tests in `tests/test_prefect_rmsynth_flow.py`: the failing `--cli-config` case, the equivalent command line, Stokes I being optional, `--error-cube-kind` picking the container, `cli()` assembling the nested options, `--error-cubes` without a kind, and the missing-Stokes / duplicate-Stokes / unparseable-name errors.

`pre-commit run --hook-stage manual --all-files` is clean and the suite is 544 passed. Three failures are environmental in this sandbox and unrelated to the diff: two `test_catalogue` tests cannot reach `vizier.cds.unistra.fr` through the proxy, and `test_copy_directory` needs `rsync`, which is not installed here.

Also adds a short `Running RM-synthesis on its own` section to the polarisation quickstart, which documented no rm-synth CLI before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LWfbjm7f9FrUXuEiMmZQab

---
_Generated by [Claude Code](https://claude.ai/code/session_01LWfbjm7f9FrUXuEiMmZQab)_