### PR TITLE
Treat the linmos zero fill as blank when BANE measures a plane

### DIFF
--- a/flint/bane.py
+++ b/flint/bane.py
@@ -289,6 +289,12 @@ def _bane_round(
             background, zoom, order=3, grid_mode=True, mode="reflect"
         )
         rms = ndimage.zoom(rms, zoom, order=3, grid_mode=True, mode="reflect")
+        # The cubic spline rings across the step the nan_to_num above puts at
+        # the footprint edge, and undershoots to a negative noise. A negative
+        # error squares to a small positive variance, so an inverse-variance
+        # weight downstream comes out orders of magnitude too large rather than
+        # obviously wrong
+        rms = np.clip(rms, 0.0, None)
 
     return background, rms
 

--- a/flint/bane.py
+++ b/flint/bane.py
@@ -314,10 +314,13 @@ def robust_bane(
     A plane with no usable beam gets blank maps, unless both sizes are given
     outright and so no beam is needed to size the kernel.
 
+    Blank pixels are those that are not finite and, unless
+    ``fft_bane_options.invalidate_zeros`` is unset, those of exactly zero.
+
     Args:
         image (NDArray[np.float32]): The image plane to measure
         header (fits.Header | dict[str, Any]): Its header, for the beam and pixel scale
-        fft_bane_options (FFTBANEOptions | None, optional): Step, box, clip and seed. Defaults to ``FFTBANEOptions()``.
+        fft_bane_options (FFTBANEOptions | None, optional): Step, box, clip, seed and zero blanking. Defaults to ``FFTBANEOptions()``.
         kernel_func (Callable, optional): Kernel shape. Defaults to ``gaussian_kernel``.
         rms_estimator (Callable, optional): First-pass RMS estimator. Defaults to ``mad_std``.
 
@@ -343,6 +346,14 @@ def robust_bane(
     )
 
     nan_mask = ~np.isfinite(image)
+    if fft_bane_options.invalidate_zeros:
+        # linmos fills outside its primary beam cutoff with exact zeros rather
+        # than nans, and a measured zero is not a blank: it drags the seed
+        # median and mad_std below down towards zero, and past half the plane
+        # being blank it takes both to exactly zero, whereupon round one clips
+        # every pixel as a source and refills it with zero-scaled noise. The
+        # maps come back identically zero, which reads downstream as noiseless
+        nan_mask = nan_mask | (image == 0.0)
     valid = (~nan_mask).astype(np.float32)
     filled = np.where(nan_mask, 0.0, image).astype(np.float32)
     finite = image[~nan_mask].ravel()

--- a/flint/bane.py
+++ b/flint/bane.py
@@ -321,7 +321,9 @@ def robust_bane(
     outright and so no beam is needed to size the kernel.
 
     Blank pixels are those that are not finite and, unless
-    ``fft_bane_options.invalidate_zeros`` is unset, those of exactly zero.
+    ``fft_bane_options.invalidate_zeros`` is unset, those of exactly zero. A
+    plane that is blank throughout gets blank maps, there being nothing to
+    measure.
 
     Args:
         image (NDArray[np.float32]): The image plane to measure
@@ -363,6 +365,16 @@ def robust_bane(
     valid = (~nan_mask).astype(np.float32)
     filled = np.where(nan_mask, 0.0, image).astype(np.float32)
     finite = image[~nan_mask].ravel()
+
+    if finite.size == 0:
+        # Nothing was measured, so there are no seeds to take a median and a
+        # mad_std of. Both would come back NaN off an empty slice and propagate
+        # to the same blank maps, but noisily, by way of a pair of numpy
+        # RuntimeWarnings. A plane blanked by linmos rather than by the beam
+        # cutoff reaches this once its zeros count as blank
+        logger.warning("Every pixel of the plane is blank, returning blank maps")
+        blank = np.full_like(image, np.nan, dtype=np.float32)
+        return blank, blank.copy()
 
     # The median matters: testing |image| rather than |image - background| makes
     # every pixel a source as soon as the plane carries a DC offset

--- a/flint/options.py
+++ b/flint/options.py
@@ -253,6 +253,8 @@ class FFTBANEOptions(BaseOptions):
     """Pixels above this SNR are replaced by noise before the background is fitted"""
     seed: int = 1234
     """Seeds the noise clipped pixels are filled with, so a rerun reproduces the maps"""
+    invalidate_zeros: bool = True
+    """Treat pixels of exactly 0.0 as blank, as ``FitsCubeOptions.invalidate_zeros`` does. linmos fills outside its primary beam cutoff with zeros, not nans"""
 
 
 class _CubesForRMSynth(BaseOptions):

--- a/tests/test_bane.py
+++ b/tests/test_bane.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import warnings
 from pathlib import Path
 
 import numpy as np
@@ -186,6 +187,23 @@ def test_the_rms_map_is_never_negative() -> None:
         assert not np.any(rms[np.isfinite(rms)] < 0.0)
 
 
+def test_a_wholly_blank_plane_returns_blank_maps_quietly() -> None:
+    """Nothing measured means no seeds to take a median and a mad_std of. Both
+    come back NaN off an empty slice and reach the same blank maps anyway, but
+    by way of a pair of numpy RuntimeWarnings. linmos hands over such a plane as
+    all zeros rather than all NaNs, so blanking the zeros is what reaches it."""
+    for plane in (
+        np.full((NY, NX), np.nan, dtype=np.float32),
+        np.zeros((NY, NX), dtype=np.float32),
+    ):
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", RuntimeWarning)
+            background, rms = robust_bane(image=plane, header=_header())
+
+        assert np.isnan(background).all()
+        assert np.isnan(rms).all()
+
+
 def test_the_seed_makes_a_rerun_reproducible() -> None:
     """Clipped source pixels are refilled with random noise, so without a fixed
     seed the same image gives different maps run to run."""
@@ -239,7 +257,9 @@ def test_a_kernel_too_big_for_the_image_is_refused() -> None:
     image with a big step downsamples into exactly that."""
     with pytest.raises(ValueError, match="does not fit"):
         robust_bane(
-            image=np.zeros((64, 64), dtype=np.float32),
+            # Not zeros: those are blank now, and a wholly blank plane returns
+            # blank maps before the kernel is ever pressed against the image
+            image=np.ones((64, 64), dtype=np.float32),
             header=_header(),
             fft_bane_options=FFTBANEOptions(step_size=16, box_size=32),
         )

--- a/tests/test_bane.py
+++ b/tests/test_bane.py
@@ -115,6 +115,61 @@ def test_blanked_pixels_stay_blank() -> None:
     assert np.isfinite(rms[~blank]).all()
 
 
+def _footprint(radius: int) -> np.ndarray:
+    """Mask of a circular mosaic footprint, as linmos leaves after its cutoff"""
+    yy, xx = np.mgrid[0:NY, 0:NX]
+    return (yy - NY / 2) ** 2 + (xx - NX / 2) ** 2 < radius**2
+
+
+def test_the_linmos_zero_fill_is_treated_as_blank() -> None:
+    """linmos fills beyond its cutoff with exact zeros, not NaNs. Counted as
+    measured data those zeros take the seed median and mad_std to exactly zero
+    once more than half the plane is blank, and the maps collapse to zero
+    everywhere, which reads downstream as a noiseless image."""
+    inside = _footprint(radius=380)
+    assert (~inside).mean() > 0.5, "the collapse needs over half the plane blank"
+
+    sky = _sky(background=5e-4, rms=1e-3)
+    zero_filled = np.where(inside, sky, 0.0).astype(np.float32)
+    nan_filled = np.where(inside, sky, np.nan).astype(np.float32)
+
+    zero_bkg, zero_rms = robust_bane(image=zero_filled, header=_header())
+    nan_bkg, nan_rms = robust_bane(image=nan_filled, header=_header())
+
+    # The noise inside the footprint was measured, not zeroed
+    assert np.nanmedian(zero_rms[inside]) == pytest.approx(1e-3, rel=0.3)
+    # Blanking either way describes the same plane, so it measures the same
+    assert np.nanmedian(zero_rms[inside]) == pytest.approx(
+        np.nanmedian(nan_rms[inside]), rel=0.05
+    )
+    assert np.nanmedian(zero_bkg[inside]) == pytest.approx(
+        np.nanmedian(nan_bkg[inside]), rel=0.05
+    )
+
+    # And the maps blank where the image is blank, so the noise cube and the
+    # image cube it describes share a footprint
+    assert np.isnan(zero_rms[~inside]).all()
+    assert np.isnan(zero_bkg[~inside]).all()
+
+
+def test_invalidate_zeros_can_be_turned_off() -> None:
+    """Off, zeros count as measured data again, which is what a caller whose
+    zeros are real would want."""
+    inside = _footprint(radius=380)
+    zero_filled = np.where(inside, _sky(rms=1e-3), 0.0).astype(np.float32)
+
+    _, rms = robust_bane(
+        image=zero_filled,
+        header=_header(),
+        fft_bane_options=FFTBANEOptions(invalidate_zeros=False),
+    )
+
+    # Nothing is blank, so nothing is NaN, and the collapse described above is
+    # exactly what the zeros produce
+    assert np.isfinite(rms).all()
+    assert np.all(rms == 0.0)
+
+
 def test_the_seed_makes_a_rerun_reproducible() -> None:
     """Clipped source pixels are refilled with random noise, so without a fixed
     seed the same image gives different maps run to run."""

--- a/tests/test_bane.py
+++ b/tests/test_bane.py
@@ -170,6 +170,22 @@ def test_invalidate_zeros_can_be_turned_off() -> None:
     assert np.all(rms == 0.0)
 
 
+def test_the_rms_map_is_never_negative() -> None:
+    """The maps are zoomed back up with a cubic spline, which rings across the
+    step at a footprint edge and undershoots below zero. A negative noise
+    squares to a small variance, so an inverse-variance weight built from it
+    comes out orders of magnitude too large rather than obviously wrong."""
+    inside = _footprint(radius=480)
+    sky = _sky(rms=1e-3)
+
+    for filled in (
+        np.where(inside, sky, np.nan).astype(np.float32),
+        np.where(inside, sky, 0.0).astype(np.float32),
+    ):
+        _, rms = robust_bane(image=filled, header=_header())
+        assert not np.any(rms[np.isfinite(rms)] < 0.0)
+
+
 def test_the_seed_makes_a_rerun_reproducible() -> None:
     """Clipped source pixels are refilled with random noise, so without a fixed
     seed the same image gives different maps run to run."""


### PR DESCRIPTION
`linmos` fills outside its primary beam cutoff with exact zeros rather than nans, and `robust_bane` keyed its blanking off `~np.isfinite` alone. Those zeros counted as measured data, and the noise maps we hand rm-synthesis were wrong because of it.

## The bug

The seed background and noise are a `median` and a `mad_std` over the whole plane. Zeros drag both down, and once more than half the plane is blank they take both to exactly zero. Round one then evaluates `|filled - 0| / 0 > clip_sigma`, flags every non-zero pixel as a source, and refills it with zero-scaled noise. Both maps come back **identically zero, including inside the footprint**.

Measured on a synthetic mosaic (1024², 10 pix/beam, truth rms 1e-3), sweeping the blank fraction:

| blank % | `mad_std(plane)` | rms core, zero-filled | rms core, nan-filled | rms edge, zero-filled | rms edge, nan-filled |
|--:|--:|--:|--:|--:|--:|
| 0.2 | 9.99e-4 | 1.009e-3 | 1.009e-3 | 9.32e-4 | 9.32e-4 |
| 21.5 | 7.45e-4 | 1.029e-3 | 1.038e-3 | 1.004e-3 | 1.017e-3 |
| 31.0 | 5.92e-4 | 1.007e-3 | 1.051e-3 | 9.44e-4 | 1.008e-3 |
| **52.1** | **0.0** | **0.0** | 1.058e-3 | **0.0** | 1.004e-3 |
| **56.7** | **0.0** | **0.0** | 1.055e-3 | **0.0** | 9.46e-4 |

Below half the plane the two-pass local normalisation mostly rescues the interior, with the edge still biased low by a few percent. At and above half it collapses completely. Blank fraction is per channel, so a channel with most of its beams flagged has a small footprint on the full-union grid and collapses while its neighbours do not.

A noise cube of zeros reads downstream as a noiseless image. rm-lite's `natural_weight` guards only the wholly-zero cube; a partially zero one gives `1/0**2 = inf`, which `zero_nonfinite` then turns into weight `0`, dropping those channels from the synthesis without saying so.

Separately, the maps were finite *outside* the footprint too (225107 of 225107 blank pixels finite at 21.5% blank, median 8.7e-4), so a noise cube and the image cube it describes disagreed about where there is no data.

## Where it bites

The polarisation stage is the broken path. Per-channel linmos in `linmos_channel_groups_to_cubes` runs with `trim_linmos_fits=False` on purpose, so the `0.0 -> nan` inside `trim_fits_image` never runs, and `task_bane_fits_image` measures the raw zero-filled plane. `FitsCubeOptions.invalidate_zeros` does the same job but at cube assembly, after BANE has already read the plane. BANE sat in the gap between the two.

It reaches rm-synthesis two ways: when `cubes_share_common_beam` is true, `_resolve_common_resolution_cubes` returns early with no `rms_cubes` and the pipeline falls back to the polarisation stage's cubes; and a standalone `process_rmsynth` on cubes that were never invalidated hits it directly.

The rm-synthesis stage's own BANE is fine as it stands: its inputs carry nans, `split_cube_into_planes` preserves them, and racs_tools `conv_mode="robust"` masks and restores them. The only leak is a ~2 px annulus where the nan mask erodes during convolution and picks up amplitude-suppressed values (median 5.1e-5 against 1e-3 noise), which a 10-beam box does not notice.

## Changes

Three commits, reviewable separately.

**Treat the zero fill as blank.** `FFTBANEOptions.invalidate_zeros`, defaulting on and named for the `FitsCubeOptions` flag that does the same job later, folds `image == 0.0` into `nan_mask`. Everything after that line already did the right thing. Fixes both callers and the `bane_fits_image` CLI at once, with no extra per-plane I/O, and blanks the maps outside the footprint so the noise cube and the image cube now agree.

**Stop the RMS map going negative.** Independent of the above, and it survives correct nan blanking. Each round smooths on a downsampled grid and zooms back up with an order-3 spline; the `nan_to_num` just before it puts a step at the footprint edge and the spline rings across it into negative noise: 276 pixels at 31% blank (min -6.1e-5), 1998 at 56.7% (min -1.2e-4), all inside the footprint. A negative noise squared into an inverse-variance weight gives a small positive variance, so those edge pixels came out roughly 280x overweighted rather than rejected. Clamped at zero once back on the full grid.

**Return blank maps for a wholly blank plane.** Behaviour unchanged, since the empty-slice `median` and `mad_std` were NaN and propagated to the same blank maps; it just no longer arrives there via two numpy `RuntimeWarning`s. Blanking the zeros is what newly reaches this, for an all-zero plane that still carries a live beam.

## Tests

New in `tests/test_bane.py`: a >50% blank footprint filled with zeros now measures the same interior noise as the same footprint filled with nans and blanks outside it; `invalidate_zeros=False` restores the old behaviour, collapse included; the RMS map is never negative on a sharp-edged footprint; a wholly blank plane returns blank maps without warnings. The kernel-too-big test now builds its image from ones, since zeros describe a blank plane and short-circuit before the kernel is measured against the image.

Confirmed the negative-RMS test fails without its fix and passes with it.

Ran locally: `tests/test_bane.py`, `tests/test_configuration.py`, `tests/test_options.py` (58 passed), and `tests/test_prefect_rmsynth_flow.py`, `tests/test_polarisation_pipeline.py`, `tests/test_racs_all_pipeline.py`, `tests/test_bane.py` (67 passed, `--skip-slow`). `pre-commit run --hook-stage manual` clean on the changed files, mypy included. Leaving the full suite to CI.

## Not in this PR

- rm-lite's `natural_weight` (`rm_lite/utils/synthesis.py:1255`) silently drops channels whose error is zero, via `inf` then `zero_nonfinite`. This change stops flint feeding it zeros, but the silent drop is worth a guard on the rm-lite side.
- `docs/config.md` lists strategy modes but omits `fftbane`, along with `rmsynth` and `spice`, so the options under it are undiscoverable from the docs. Pre-existing, and widening it felt out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LWfbjm7f9FrUXuEiMmZQab

---
_Generated by [Claude Code](https://claude.ai/code/session_01LWfbjm7f9FrUXuEiMmZQab)_