### PR TITLE
Align the FFT BANE maps with the plane they measure, and halve their memory

### DIFF
--- a/flint/bane.py
+++ b/flint/bane.py
@@ -91,13 +91,6 @@ def fft_average(
 
     Reflect-padded by the kernel size so the FFT's periodic wrap does not fold
     the far edge of the image back onto the near one.
-
-    ``_ft_kernel`` zero-pads the kernel out from index zero rather than centring
-    it on the origin, which convolves and displaces in one go: the result comes
-    back half a kernel further along each axis. The window is taken at that
-    displacement, which costs nothing and leaves a smoothed pixel sitting over
-    the pixel it smooths - a flat image hides this, but a noise map laid over
-    the image it describes does not.
     """
     pad_x, pad_y = kernel.shape
     image_padded = pad_reflect(array=image, pad_width=(pad_x, pad_y))
@@ -106,6 +99,8 @@ def fft_average(
     kernel_fft = _ft_kernel(kernel, shape=image_padded.shape)
     smooth = fft.irfft2(image_fft * kernel_fft, s=image_padded.shape) / kernel.sum()
 
+    # `_ft_kernel` pads from index zero, not about the origin, so the result
+    # comes back half a kernel along each axis
     nx, ny = image.shape
     start_x, start_y = pad_x + pad_x // 2, pad_y + pad_y // 2
     return smooth[start_x : start_x + nx, start_y : start_y + ny]
@@ -220,12 +215,8 @@ def _downsample_slices(
 ) -> tuple[slice, slice]:
     """Slices taking every `step_size_pix` pixel, trimmed to an even count.
 
-    The sampled region runs from `step_size_pix` to `length - step_size_pix`,
-    so it does not cover the plane. `_to_full_resolution` puts the maps back
-    where these slices took them from, which is what upstream's TODO about an
-    offset is: scaling them over the whole plane instead moves them bodily.
-    Sampling half a cell in so a plain scaling would be honest was tried and is
-    only exact when the step divides the plane, so this keeps upstream's grid.
+    These do not cover the plane, so `_to_full_resolution` reads them to put
+    the maps back where they were taken from.
     """
     slices = []
     for length in (shape[0], shape[1]):
@@ -243,24 +234,9 @@ def _to_full_resolution(
 ) -> NDArray[np.float32]:
     """Put a map measured on the downsampled grid back onto the plane's own grid.
 
-    ``ndimage.zoom`` takes a scale and nothing else, and the sampled grid is not
-    a pure scaling of the plane's: it starts a step in and stops a step short.
-    Stretching the maps over the whole plane instead of over the region actually
-    sampled moves every pixel of them - up and to the right, by tens of pixels
-    for a typical step, and growing across the field, since the error is a
-    stretch as well as a shift. The affine transform carries the offset too, so
-    a sample lands back on the pixel it was taken from.
-
-    Outside the sampled region the nearest sample is held rather than the grid
-    reflected, so the extrapolated border does not ring.
-
-    Linear rather than a cubic spline. A blank leaves a step in the map, where
-    ``nan_to_num`` has put zero against a measured value, and a cubic overshoots
-    it: a plane blanked to an eighth came back with a background reaching nine
-    thousand times its own noise a single row past the blank edge, in the map
-    that was written out. Linear cannot overshoot, being a weighted mean of the
-    two samples either side, and away from the blanks it differs from the cubic
-    by well under a percent of the noise - for half the time.
+    An affine transform rather than `ndimage.zoom`, which takes a scale alone
+    and so cannot know the sampled grid starts a step in. Linear rather than a
+    spline, which overshoots the step a blank leaves in the map.
 
     Args:
         smoothed (NDArray[np.float32]): A map on the downsampled grid
@@ -282,17 +258,6 @@ def _to_full_resolution(
         order=1,
         mode="nearest",
     )
-
-
-def _where_masked(
-    value: NDArray[np.float32] | np.float32, mask: NDArray[np.bool_]
-) -> NDArray[np.float32] | np.float32:
-    """``value`` at the set pixels of `mask`, taking a scalar to mean everywhere.
-
-    Round one clips against one number for the whole plane, round two against
-    the maps round one made, and the refill below reads both the same way.
-    """
-    return value[mask] if isinstance(value, np.ndarray) else value
 
 
 def _bane_round(
@@ -338,9 +303,17 @@ def _bane_round(
     # round rather than from a zero-filled copy kept across both, which would be
     # a second full-resolution plane held for the whole routine
     clipped = np.where(nan_mask, np.float32(0.0), image)
-    clipped[source_mask] = _where_masked(background, source_mask) + rng.normal(
-        loc=0, scale=1, size=n_source
-    ) * _where_masked(rms, source_mask)
+    # Round one clips against one number for the whole plane, round two against
+    # the maps round one made
+    at_source: NDArray[np.float32] | np.float32
+    rms_at_source: NDArray[np.float32] | np.float32
+    if isinstance(background, np.ndarray) and isinstance(rms, np.ndarray):
+        at_source, rms_at_source = background[source_mask], rms[source_mask]
+    else:
+        at_source, rms_at_source = background, rms
+    clipped[source_mask] = (
+        at_source + rng.normal(loc=0, scale=1, size=n_source) * rms_at_source
+    )
 
     sampled_at: tuple[slice, slice] | None = None
     full_shape = clipped.shape
@@ -382,47 +355,11 @@ def _bane_round(
             smooth_background, sampled_at, full_shape
         )
         smooth_rms = _to_full_resolution(smooth_rms, sampled_at, full_shape)
-        # A guard rather than a fix: the linear interpolation above is a
-        # weighted mean of two non-negative samples and so cannot undershoot.
-        # It is what makes the interpolation order safe to raise again, since a
-        # spline does undershoot across the step `nan_to_num` leaves at the
-        # footprint edge - and a negative error squares to a small positive
-        # variance, so an inverse-variance weight downstream would come out
-        # orders of magnitude too large rather than obviously wrong
+        # A guard: linear interpolation cannot undershoot, but a spline can, and
+        # a negative error squares to a small positive variance downstream
         np.clip(smooth_rms, 0.0, None, out=smooth_rms)
 
     return smooth_background, smooth_rms
-
-
-def _seed_estimates(
-    image: NDArray[np.float32],
-    nan_mask: NDArray[np.bool_],
-    rms_estimator: Callable[[NDArray[np.float32]], float],
-) -> tuple[np.float32, np.float32] | None:
-    """The one background and RMS for the whole plane that round one clips against.
-
-    Returns None when nothing was measured, there being no seeds to take.
-
-    The median matters: testing |image| rather than |image - background| makes
-    every pixel a source as soon as the plane carries a DC offset.
-
-    Compacting the measured pixels costs a copy of most of the plane, and
-    ``rms_estimator`` copies it again; both are made and dropped here rather
-    than held across the rounds that follow, where the maps are the peak.
-
-    Args:
-        image (NDArray[np.float32]): The plane being measured
-        nan_mask (NDArray[np.bool_]): True wherever the plane is blank
-        rms_estimator (Callable): Estimator of the plane's noise, e.g. ``mad_std``
-
-    Returns:
-        tuple[np.float32, np.float32] | None: Seed background and RMS, or None if the plane is wholly blank
-    """
-    finite = image[~nan_mask].ravel()
-    if finite.size == 0:
-        return None
-    # float32, matching the maps they seed and the plane they came from
-    return np.float32(np.median(finite)), np.float32(rms_estimator(finite))
 
 
 def _needs_a_beam(fft_bane_options: FFTBANEOptions) -> bool:
@@ -499,8 +436,8 @@ def robust_bane(
         # maps come back identically zero, which reads downstream as noiseless
         nan_mask |= image == 0.0
 
-    seeds = _seed_estimates(image=image, nan_mask=nan_mask, rms_estimator=rms_estimator)
-    if seeds is None:
+    finite = image[~nan_mask].ravel()
+    if finite.size == 0:
         # Nothing was measured, so there are no seeds to take a median and a
         # mad_std of. Both would come back NaN off an empty slice and propagate
         # to the same blank maps, but noisily, by way of a pair of numpy
@@ -510,14 +447,18 @@ def robust_bane(
         blank = np.full_like(image, np.nan, dtype=np.float32)
         return blank, blank.copy()
 
+    # The median matters: testing |image| rather than |image - background| makes
+    # every pixel a source as soon as the plane carries a DC offset. Scalars,
+    # and dropped before the rounds: `finite` and the copy `rms_estimator` makes
+    # of it are each most of a plane
+    clip_against: tuple[
+        NDArray[np.float32] | np.float32, NDArray[np.float32] | np.float32
+    ] = (np.float32(np.median(finite)), np.float32(rms_estimator(finite)))
+    del finite
+
     # A mosaic's noise rises with the primary beam, so one threshold clips real
     # noise at the edge while missing faint sources in the middle
     rng = np.random.default_rng(fft_bane_options.seed)
-    # Round one clips against the seed pair, round two against the maps round
-    # one made
-    clip_against: tuple[
-        NDArray[np.float32] | np.float32, NDArray[np.float32] | np.float32
-    ] = seeds
     for round_number in (1, 2):
         background, rms = _bane_round(
             image=image,

--- a/flint/bane.py
+++ b/flint/bane.py
@@ -254,6 +254,14 @@ def _to_full_resolution(
     Outside the sampled region the nearest sample is held rather than the grid
     reflected, so the extrapolated border does not ring.
 
+    Linear rather than a cubic spline. A blank leaves a step in the map, where
+    ``nan_to_num`` has put zero against a measured value, and a cubic overshoots
+    it: a plane blanked to an eighth came back with a background reaching nine
+    thousand times its own noise a single row past the blank edge, in the map
+    that was written out. Linear cannot overshoot, being a weighted mean of the
+    two samples either side, and away from the blanks it differs from the cubic
+    by well under a percent of the noise - for half the time.
+
     Args:
         smoothed (NDArray[np.float32]): A map on the downsampled grid
         sampled_at (tuple[slice, slice]): The slices that took that grid off the plane
@@ -271,7 +279,7 @@ def _to_full_resolution(
         matrix=1.0 / steps,
         offset=-starts / steps,
         output_shape=shape,
-        order=3,
+        order=1,
         mode="nearest",
     )
 
@@ -374,11 +382,13 @@ def _bane_round(
             smooth_background, sampled_at, full_shape
         )
         smooth_rms = _to_full_resolution(smooth_rms, sampled_at, full_shape)
-        # The cubic spline rings across the step the nan_to_num above puts at
-        # the footprint edge, and undershoots to a negative noise. A negative
-        # error squares to a small positive variance, so an inverse-variance
-        # weight downstream comes out orders of magnitude too large rather than
-        # obviously wrong
+        # A guard rather than a fix: the linear interpolation above is a
+        # weighted mean of two non-negative samples and so cannot undershoot.
+        # It is what makes the interpolation order safe to raise again, since a
+        # spline does undershoot across the step `nan_to_num` leaves at the
+        # footprint edge - and a negative error squares to a small positive
+        # variance, so an inverse-variance weight downstream would come out
+        # orders of magnitude too large rather than obviously wrong
         np.clip(smooth_rms, 0.0, None, out=smooth_rms)
 
     return smooth_background, smooth_rms

--- a/flint/bane.py
+++ b/flint/bane.py
@@ -225,12 +225,22 @@ def _downsample_slices(
     return slices[0], slices[1]
 
 
+def _where_masked(
+    value: NDArray[np.float32] | np.float32, mask: NDArray[np.bool_]
+) -> NDArray[np.float32] | np.float32:
+    """``value`` at the set pixels of `mask`, taking a scalar to mean everywhere.
+
+    Round one clips against one number for the whole plane, round two against
+    the maps round one made, and the refill below reads both the same way.
+    """
+    return value[mask] if isinstance(value, np.ndarray) else value
+
+
 def _bane_round(
-    filled: NDArray[np.float32],
-    valid: NDArray[np.float32],
+    image: NDArray[np.float32],
     nan_mask: NDArray[np.bool_],
-    background: NDArray[np.float32],
-    rms: NDArray[np.float32],
+    background: NDArray[np.float32] | np.float32,
+    rms: NDArray[np.float32] | np.float32,
     kernel: NDArray[np.float32],
     step_size_pix: int,
     clip_sigma: float,
@@ -241,62 +251,121 @@ def _bane_round(
 
     The refill carries the local background: zero-mean noise would drag the
     background down wherever a source was removed.
+
+    ``background`` and ``rms`` are either maps or, for the first round, the one
+    number each that describes the whole plane.
     """
     with np.errstate(invalid="ignore", divide="ignore"):
-        source_mask = (np.abs(filled - background) / rms > clip_sigma) & ~nan_mask
+        # Built in place: the plain expression holds the difference, its
+        # absolute value and the ratio as three separate full-size temporaries.
+        # A blank compares however its stand-in value happens to fall - a NaN
+        # never exceeds the threshold, a linmos zero may - so the mask is
+        # cleared over them below rather than the plane being zero-filled first
+        deviation = image - background
+        np.abs(deviation, out=deviation)
+        deviation /= rms
+        source_mask = deviation > clip_sigma
+    del deviation
+    source_mask[nan_mask] = False
+
+    n_source = int(source_mask.sum())
     logger.info(
-        f"BANE round {round_number}: refilling {source_mask.sum()} "
-        f"({source_mask.sum() / filled.size * 100:0.1f}%) source pixels with noise"
+        f"BANE round {round_number}: refilling {n_source} "
+        f"({n_source / image.size * 100:0.1f}%) source pixels with noise"
     )
 
-    clipped = filled.copy()
-    clipped[source_mask] = (
-        background[source_mask]
-        + rng.normal(loc=0, scale=1, size=source_mask.sum()) * rms[source_mask]
-    )
-    # Blanked pixels must stay at zero: bane_fft normalises by the smoothed
-    # validity mask and assumes they contribute nothing
-    clipped[nan_mask] = 0.0
+    # Blanked pixels have to hold zero: bane_fft normalises by the smoothed
+    # validity mask and assumes they contribute nothing. Built from `image` each
+    # round rather than from a zero-filled copy kept across both, which would be
+    # a second full-resolution plane held for the whole routine
+    clipped = np.where(nan_mask, np.float32(0.0), image)
+    clipped[source_mask] = _where_masked(background, source_mask) + rng.normal(
+        loc=0, scale=1, size=n_source
+    ) * _where_masked(rms, source_mask)
 
     zoom: tuple[float, float] | None = None
-    round_valid = valid
     if step_size_pix > 0:
+        # Taken as contiguous copies here rather than as views handed to
+        # `bane_fft`, so the full-size `clipped` can be dropped below before the
+        # zoom allocates the full-size maps to replace it
         y_slice, x_slice = _downsample_slices(clipped.shape, step_size_pix)
+        downsampled = np.ascontiguousarray(clipped[y_slice, x_slice])
+        # Built already downsampled: `bane_fft` is the only thing that wants a
+        # float32 validity mask, and at full resolution that is another copy of
+        # the whole plane
+        round_valid = (~nan_mask[y_slice, x_slice]).astype(np.float32)
         zoom = (
-            clipped.shape[0] / clipped[y_slice, x_slice].shape[0],
-            clipped.shape[1] / clipped[y_slice, x_slice].shape[1],
+            clipped.shape[0] / downsampled.shape[0],
+            clipped.shape[1] / downsampled.shape[1],
         )
-        clipped, round_valid = clipped[y_slice, x_slice], valid[y_slice, x_slice]
+    else:
+        downsampled = np.ascontiguousarray(clipped)
+        round_valid = (~nan_mask).astype(np.float32)
 
     # pad_reflect is njit-ed without bounds checking, so a kernel wider than the
     # image reads off the end and returns quietly wrong maps rather than raising
-    if any(pad >= length for pad, length in zip(kernel.shape, clipped.shape)):
+    if any(pad >= length for pad, length in zip(kernel.shape, downsampled.shape)):
         msg = (
-            f"A {kernel.shape} kernel does not fit the {clipped.shape} image it "
+            f"A {kernel.shape} kernel does not fit the {downsampled.shape} image it "
             "smooths. Lower step_size so less is downsampled away, or box_size "
             "for a smaller kernel."
         )
         raise ValueError(msg)
 
-    background, rms = bane_fft(
-        np.ascontiguousarray(clipped), kernel, np.ascontiguousarray(round_valid)
-    )
-    background = np.nan_to_num(background, nan=0.0)
-    rms = np.nan_to_num(rms, nan=0.0)
+    del clipped, source_mask
+
+    smooth_background, smooth_rms = bane_fft(downsampled, kernel, round_valid)
+    # In place throughout: both come straight out of bane_fft, so nothing else
+    # holds a view of them
+    np.nan_to_num(smooth_background, nan=0.0, copy=False)
+    np.nan_to_num(smooth_rms, nan=0.0, copy=False)
 
     if zoom is not None:
-        background = ndimage.zoom(
-            background, zoom, order=3, grid_mode=True, mode="reflect"
+        smooth_background = ndimage.zoom(
+            smooth_background, zoom, order=3, grid_mode=True, mode="reflect"
         )
-        rms = ndimage.zoom(rms, zoom, order=3, grid_mode=True, mode="reflect")
+        smooth_rms = ndimage.zoom(
+            smooth_rms, zoom, order=3, grid_mode=True, mode="reflect"
+        )
         # The cubic spline rings across the step the nan_to_num above puts at
         # the footprint edge, and undershoots to a negative noise. A negative
         # error squares to a small positive variance, so an inverse-variance
         # weight downstream comes out orders of magnitude too large rather than
         # obviously wrong
-        rms = np.clip(rms, 0.0, None)
+        np.clip(smooth_rms, 0.0, None, out=smooth_rms)
 
-    return background, rms
+    return smooth_background, smooth_rms
+
+
+def _seed_estimates(
+    image: NDArray[np.float32],
+    nan_mask: NDArray[np.bool_],
+    rms_estimator: Callable[[NDArray[np.float32]], float],
+) -> tuple[np.float32, np.float32] | None:
+    """The one background and RMS for the whole plane that round one clips against.
+
+    Returns None when nothing was measured, there being no seeds to take.
+
+    The median matters: testing |image| rather than |image - background| makes
+    every pixel a source as soon as the plane carries a DC offset.
+
+    Compacting the measured pixels costs a copy of most of the plane, and
+    ``rms_estimator`` copies it again; both are made and dropped here rather
+    than held across the rounds that follow, where the maps are the peak.
+
+    Args:
+        image (NDArray[np.float32]): The plane being measured
+        nan_mask (NDArray[np.bool_]): True wherever the plane is blank
+        rms_estimator (Callable): Estimator of the plane's noise, e.g. ``mad_std``
+
+    Returns:
+        tuple[np.float32, np.float32] | None: Seed background and RMS, or None if the plane is wholly blank
+    """
+    finite = image[~nan_mask].ravel()
+    if finite.size == 0:
+        return None
+    # float32, matching the maps they seed and the plane they came from
+    return np.float32(np.median(finite)), np.float32(rms_estimator(finite))
 
 
 def _needs_a_beam(fft_bane_options: FFTBANEOptions) -> bool:
@@ -324,6 +393,11 @@ def robust_bane(
     ``fft_bane_options.invalidate_zeros`` is unset, those of exactly zero. A
     plane that is blank throughout gets blank maps, there being nothing to
     measure.
+
+    Peaks at roughly five times the plane, the two maps and the working copies
+    of the plane the rounds need. A worker measuring a channel of its own has to
+    fit that, not just the maps it hands back - a 6000x6000 float32 plane is
+    137 MB and peaks near 600 MB. ``tests/test_bane.py`` holds the multiple.
 
     Args:
         image (NDArray[np.float32]): The image plane to measure
@@ -353,6 +427,11 @@ def robust_bane(
         kernel_func=kernel_func,
     )
 
+    # The rounds below smooth the plane itself rather than a zero-filled copy of
+    # it, and ``bane_fft`` is compiled for float32 alone. A plane read from a
+    # FITS file is float32 already, so this is a view rather than a copy
+    image = np.asarray(image, dtype=np.float32)
+
     nan_mask = ~np.isfinite(image)
     if fft_bane_options.invalidate_zeros:
         # linmos fills outside its primary beam cutoff with exact zeros rather
@@ -361,12 +440,10 @@ def robust_bane(
         # being blank it takes both to exactly zero, whereupon round one clips
         # every pixel as a source and refills it with zero-scaled noise. The
         # maps come back identically zero, which reads downstream as noiseless
-        nan_mask = nan_mask | (image == 0.0)
-    valid = (~nan_mask).astype(np.float32)
-    filled = np.where(nan_mask, 0.0, image).astype(np.float32)
-    finite = image[~nan_mask].ravel()
+        nan_mask |= image == 0.0
 
-    if finite.size == 0:
+    seeds = _seed_estimates(image=image, nan_mask=nan_mask, rms_estimator=rms_estimator)
+    if seeds is None:
         # Nothing was measured, so there are no seeds to take a median and a
         # mad_std of. Both would come back NaN off an empty slice and propagate
         # to the same blank maps, but noisily, by way of a pair of numpy
@@ -376,27 +453,27 @@ def robust_bane(
         blank = np.full_like(image, np.nan, dtype=np.float32)
         return blank, blank.copy()
 
-    # The median matters: testing |image| rather than |image - background| makes
-    # every pixel a source as soon as the plane carries a DC offset
-    background = np.full_like(filled, float(np.median(finite)))
-    rms = np.full_like(filled, float(rms_estimator(finite)))
-
     # A mosaic's noise rises with the primary beam, so one threshold clips real
     # noise at the edge while missing faint sources in the middle
     rng = np.random.default_rng(fft_bane_options.seed)
+    # Round one clips against the seed pair, round two against the maps round
+    # one made
+    clip_against: tuple[
+        NDArray[np.float32] | np.float32, NDArray[np.float32] | np.float32
+    ] = seeds
     for round_number in (1, 2):
         background, rms = _bane_round(
-            filled=filled,
-            valid=valid,
+            image=image,
             nan_mask=nan_mask,
-            background=background,
-            rms=rms,
+            background=clip_against[0],
+            rms=clip_against[1],
             kernel=kernel,
             step_size_pix=step_size_pix,
             clip_sigma=fft_bane_options.clip_sigma,
             rng=rng,
             round_number=round_number,
         )
+        clip_against = (background, rms)
 
     background[nan_mask] = np.nan
     rms[nan_mask] = np.nan
@@ -412,6 +489,9 @@ def bane_fits_image(
 
     Named ``_bkg.fits`` and ``_rms.fits`` beside the input, as the aegean BANE
     names them, so the two are interchangeable downstream.
+
+    Runs as one task per channel, so a worker's memory has to cover the peak
+    ``robust_bane`` reaches - see there for the multiple of the plane it takes.
 
     Args:
         image (Path): Single-plane FITS image to measure

--- a/flint/bane.py
+++ b/flint/bane.py
@@ -91,6 +91,13 @@ def fft_average(
 
     Reflect-padded by the kernel size so the FFT's periodic wrap does not fold
     the far edge of the image back onto the near one.
+
+    ``_ft_kernel`` zero-pads the kernel out from index zero rather than centring
+    it on the origin, which convolves and displaces in one go: the result comes
+    back half a kernel further along each axis. The window is taken at that
+    displacement, which costs nothing and leaves a smoothed pixel sitting over
+    the pixel it smooths - a flat image hides this, but a noise map laid over
+    the image it describes does not.
     """
     pad_x, pad_y = kernel.shape
     image_padded = pad_reflect(array=image, pad_width=(pad_x, pad_y))
@@ -99,7 +106,9 @@ def fft_average(
     kernel_fft = _ft_kernel(kernel, shape=image_padded.shape)
     smooth = fft.irfft2(image_fft * kernel_fft, s=image_padded.shape) / kernel.sum()
 
-    return smooth[pad_x:-pad_x, pad_y:-pad_y]
+    nx, ny = image.shape
+    start_x, start_y = pad_x + pad_x // 2, pad_y + pad_y // 2
+    return smooth[start_x : start_x + nx, start_y : start_y + ny]
 
 
 @nb.njit(
@@ -211,10 +220,12 @@ def _downsample_slices(
 ) -> tuple[slice, slice]:
     """Slices taking every `step_size_pix` pixel, trimmed to an even count.
 
-    The sampled region runs from `step_size_pix` to `length - step_size_pix`
-    while the zoom back up stretches it over the whole image. That is the likely
-    cause of the offset upstream records as a TODO; sampling half a cell in
-    instead measured worse, so this keeps upstream's grid.
+    The sampled region runs from `step_size_pix` to `length - step_size_pix`,
+    so it does not cover the plane. `_to_full_resolution` puts the maps back
+    where these slices took them from, which is what upstream's TODO about an
+    offset is: scaling them over the whole plane instead moves them bodily.
+    Sampling half a cell in so a plain scaling would be honest was tried and is
+    only exact when the step divides the plane, so this keeps upstream's grid.
     """
     slices = []
     for length in (shape[0], shape[1]):
@@ -223,6 +234,46 @@ def _downsample_slices(
             stop -= 1
         slices.append(slice(step_size_pix, stop, step_size_pix))
     return slices[0], slices[1]
+
+
+def _to_full_resolution(
+    smoothed: NDArray[np.float32],
+    sampled_at: tuple[slice, slice],
+    shape: tuple[int, ...],
+) -> NDArray[np.float32]:
+    """Put a map measured on the downsampled grid back onto the plane's own grid.
+
+    ``ndimage.zoom`` takes a scale and nothing else, and the sampled grid is not
+    a pure scaling of the plane's: it starts a step in and stops a step short.
+    Stretching the maps over the whole plane instead of over the region actually
+    sampled moves every pixel of them - up and to the right, by tens of pixels
+    for a typical step, and growing across the field, since the error is a
+    stretch as well as a shift. The affine transform carries the offset too, so
+    a sample lands back on the pixel it was taken from.
+
+    Outside the sampled region the nearest sample is held rather than the grid
+    reflected, so the extrapolated border does not ring.
+
+    Args:
+        smoothed (NDArray[np.float32]): A map on the downsampled grid
+        sampled_at (tuple[slice, slice]): The slices that took that grid off the plane
+        shape (tuple[int, ...]): Shape of the plane to put it back on
+
+    Returns:
+        NDArray[np.float32]: The map on the plane's grid
+    """
+    # affine_transform reads `input[matrix @ output_index + offset]`, so this is
+    # the inverse of `sample k of axis i came from pixel start_i + k * step_i`
+    steps = np.array([axis.step for axis in sampled_at], dtype=np.float64)
+    starts = np.array([axis.start for axis in sampled_at], dtype=np.float64)
+    return ndimage.affine_transform(
+        smoothed,
+        matrix=1.0 / steps,
+        offset=-starts / steps,
+        output_shape=shape,
+        order=3,
+        mode="nearest",
+    )
 
 
 def _where_masked(
@@ -283,21 +334,19 @@ def _bane_round(
         loc=0, scale=1, size=n_source
     ) * _where_masked(rms, source_mask)
 
-    zoom: tuple[float, float] | None = None
+    sampled_at: tuple[slice, slice] | None = None
+    full_shape = clipped.shape
     if step_size_pix > 0:
         # Taken as contiguous copies here rather than as views handed to
         # `bane_fft`, so the full-size `clipped` can be dropped below before the
-        # zoom allocates the full-size maps to replace it
-        y_slice, x_slice = _downsample_slices(clipped.shape, step_size_pix)
+        # maps are put back on the plane's grid to replace it
+        y_slice, x_slice = _downsample_slices(full_shape, step_size_pix)
         downsampled = np.ascontiguousarray(clipped[y_slice, x_slice])
         # Built already downsampled: `bane_fft` is the only thing that wants a
         # float32 validity mask, and at full resolution that is another copy of
         # the whole plane
         round_valid = (~nan_mask[y_slice, x_slice]).astype(np.float32)
-        zoom = (
-            clipped.shape[0] / downsampled.shape[0],
-            clipped.shape[1] / downsampled.shape[1],
-        )
+        sampled_at = (y_slice, x_slice)
     else:
         downsampled = np.ascontiguousarray(clipped)
         round_valid = (~nan_mask).astype(np.float32)
@@ -320,13 +369,11 @@ def _bane_round(
     np.nan_to_num(smooth_background, nan=0.0, copy=False)
     np.nan_to_num(smooth_rms, nan=0.0, copy=False)
 
-    if zoom is not None:
-        smooth_background = ndimage.zoom(
-            smooth_background, zoom, order=3, grid_mode=True, mode="reflect"
+    if sampled_at is not None:
+        smooth_background = _to_full_resolution(
+            smooth_background, sampled_at, full_shape
         )
-        smooth_rms = ndimage.zoom(
-            smooth_rms, zoom, order=3, grid_mode=True, mode="reflect"
-        )
+        smooth_rms = _to_full_resolution(smooth_rms, sampled_at, full_shape)
         # The cubic spline rings across the step the nan_to_num above puts at
         # the footprint edge, and undershoots to a negative noise. A negative
         # error squares to a small positive variance, so an inverse-variance

--- a/tests/test_bane.py
+++ b/tests/test_bane.py
@@ -445,3 +445,29 @@ def test_the_noise_map_lines_up_with_the_noise_it_measures() -> None:
     # an uncentred kernel and a wrongly scaled step back up cost between them
     assert abs(peak_y - centre_y) < 10, f"noise peak {peak_y} rows from {centre_y}"
     assert abs(peak_x - centre_x) < 10, f"noise peak {peak_x} columns from {centre_x}"
+
+
+def test_a_plane_measured_without_downsampling() -> None:
+    """``step_size=0`` smooths the plane at its own resolution, which is the one
+    path that never steps the maps back up. The kernel still has to be centred
+    on the pixel it smooths, so a blob of louder noise stays where it was put."""
+    shape = (512, 512)
+    centre_y, centre_x = 300, 180
+    yy, xx = np.mgrid[0 : shape[0], 0 : shape[1]].astype(np.float32)
+    amplitude = 1.0 + 5.0 * np.exp(
+        -0.5 * (((xx - centre_x) / 50) ** 2 + ((yy - centre_y) / 50) ** 2)
+    )
+    rng = np.random.default_rng(11)
+    image = (rng.normal(0.0, 1e-3, shape) * amplitude).astype(np.float32)
+
+    background, rms = robust_bane(
+        image=image,
+        header=_header(shape),
+        fft_bane_options=FFTBANEOptions(step_size=0, box_size=12),
+    )
+
+    assert np.isfinite(background).all()
+    assert np.isfinite(rms).all()
+    peak_y, peak_x = np.unravel_index(int(np.nanargmax(rms)), rms.shape)
+    assert abs(peak_y - centre_y) < 10, f"noise peak {peak_y} rows from {centre_y}"
+    assert abs(peak_x - centre_x) < 10, f"noise peak {peak_x} columns from {centre_x}"

--- a/tests/test_bane.py
+++ b/tests/test_bane.py
@@ -174,10 +174,11 @@ def test_invalidate_zeros_can_be_turned_off() -> None:
 
 
 def test_the_rms_map_is_never_negative() -> None:
-    """The maps are zoomed back up with a cubic spline, which rings across the
-    step at a footprint edge and undershoots below zero. A negative noise
-    squares to a small variance, so an inverse-variance weight built from it
-    comes out orders of magnitude too large rather than obviously wrong."""
+    """A negative noise squares to a small variance, so an inverse-variance
+    weight built from it comes out orders of magnitude too large rather than
+    obviously wrong. The linear step back up to full resolution cannot
+    undershoot, but a spline rings across the step at a footprint edge and
+    does, so this holds whatever it is interpolated with."""
     inside = _footprint(radius=480)
     sky = _sky(rms=1e-3)
 
@@ -441,6 +442,6 @@ def test_the_noise_map_lines_up_with_the_noise_it_measures() -> None:
 
     peak_y, peak_x = np.unravel_index(int(np.nanargmax(rms)), rms.shape)
     # Comfortable for a blob this broad, and nowhere near the sixty-odd pixels
-    # an uncentred kernel and a mis-scaled step back up cost between them
+    # an uncentred kernel and a wrongly scaled step back up cost between them
     assert abs(peak_y - centre_y) < 10, f"noise peak {peak_y} rows from {centre_y}"
     assert abs(peak_x - centre_x) < 10, f"noise peak {peak_x} columns from {centre_x}"

--- a/tests/test_bane.py
+++ b/tests/test_bane.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import tracemalloc
 import warnings
 from pathlib import Path
 
@@ -342,3 +343,49 @@ def test_robust_bane_without_a_beam_runs_on_given_sizes() -> None:
     )
     assert np.isfinite(background).all()
     assert np.nanmedian(rms) == pytest.approx(1e-3, rel=0.3)
+
+
+def test_the_working_memory_stays_a_small_multiple_of_the_plane() -> None:
+    """A channel is measured as one task on one worker, so the peak the routine
+    reaches - not the size of the maps it returns - is what has to fit. Held at
+    a few times the plane by keeping the seeds as scalars, building the clip
+    mask in place, and taking the validity mask already downsampled. The bound
+    is loose enough for numpy and scipy to allocate differently between
+    versions, and tight enough to catch a full-resolution array coming back."""
+    image = _sky()
+    header = _header()
+
+    # numba compiles on the first call, and the compilation allocates
+    robust_bane(image=image, header=header)
+
+    for options in (
+        FFTBANEOptions(),
+        FFTBANEOptions(step_size=8, box_size=12),
+        # A cut this low makes a source of most of the plane, so the refill
+        # draws its noise in bulk
+        FFTBANEOptions(clip_sigma=1.0),
+    ):
+        tracemalloc.start()
+        robust_bane(image=image, header=header, fft_bane_options=options)
+        _, peak = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+
+        assert peak < 7 * image.nbytes, (
+            f"{options} peaked at {peak / image.nbytes:.1f}x the plane"
+        )
+
+
+def test_a_wider_plane_is_measured_as_float32() -> None:
+    """``bane_fft`` is compiled for float32 alone. A plane read from a FITS file
+    is float32 already, but a caller computing one in double precision should
+    get the maps rather than a numba typing error."""
+    image = _sky()
+    background, rms = robust_bane(image=image, header=_header())
+    wide_background, wide_rms = robust_bane(
+        image=image.astype(np.float64), header=_header()
+    )
+
+    assert wide_background.dtype == background.dtype == np.float32
+    assert wide_rms.dtype == rms.dtype == np.float32
+    assert np.array_equal(wide_background, background, equal_nan=True)
+    assert np.array_equal(wide_rms, rms, equal_nan=True)

--- a/tests/test_bane.py
+++ b/tests/test_bane.py
@@ -11,6 +11,7 @@ import numpy as np
 import pytest
 from astropy.io import fits
 from astropy.wcs import WCS
+from scipy import ndimage
 
 from flint.bane import (
     FFTBANEOptions,
@@ -389,3 +390,57 @@ def test_a_wider_plane_is_measured_as_float32() -> None:
     assert wide_rms.dtype == rms.dtype == np.float32
     assert np.array_equal(wide_background, background, equal_nan=True)
     assert np.array_equal(wide_rms, rms, equal_nan=True)
+
+
+def test_fft_average_puts_the_smoothed_pixel_over_the_pixel_it_smooths() -> None:
+    """The kernel is zero-padded out to the image shape, which centres it on the
+    origin rather than on the pixel it smooths unless the window is taken at the
+    matching displacement. A flat image cannot show this - convolving a delta
+    can, and so can comparing against a convolution that is centred by
+    construction."""
+    image = np.zeros((64, 64), dtype=np.float32)
+    image[32, 20] = 1.0
+
+    for kernel in (gaussian_kernel(6), gaussian_kernel(9), tophat_kernel(8)):
+        kernel = (kernel / kernel.max()).astype(np.float32)
+        smoothed = fft_average(np.ascontiguousarray(image), kernel)
+
+        # Centre of mass rather than the brightest pixel: a tophat answers a
+        # delta with a disc of equal values, whose argmax is its first row
+        centre = ndimage.center_of_mass(smoothed)
+        assert centre == pytest.approx((32.0, 20.0), abs=0.01), (
+            f"a {kernel.shape} kernel moved the delta to {centre}"
+        )
+
+        # `pad_reflect` is np.pad's "reflect", which scipy calls "mirror"
+        centred = ndimage.convolve(image, kernel / kernel.sum(), mode="mirror")
+        assert np.allclose(smoothed, centred, atol=1e-6)
+
+
+def test_the_noise_map_lines_up_with_the_noise_it_measures() -> None:
+    """A background or noise map is read against the image it came from, so
+    where it puts a feature matters as much as the value it puts there. Both the
+    kernel centring and the step back up to full resolution can displace it, by
+    tens of pixels each and both in the same direction."""
+    shape = (512, 512)
+    centre_y, centre_x = 300, 180
+    yy, xx = np.mgrid[0 : shape[0], 0 : shape[1]].astype(np.float32)
+    # A smooth blob of louder noise: no edge, so nothing that could bias a
+    # centre by the way the map averages variance rather than amplitude
+    amplitude = 1.0 + 5.0 * np.exp(
+        -0.5 * (((xx - centre_x) / 50) ** 2 + ((yy - centre_y) / 50) ** 2)
+    )
+    rng = np.random.default_rng(11)
+    image = (rng.normal(0.0, 1e-3, shape) * amplitude).astype(np.float32)
+
+    _, rms = robust_bane(
+        image=image,
+        header=_header(shape),
+        fft_bane_options=FFTBANEOptions(step_size=10, box_size=6),
+    )
+
+    peak_y, peak_x = np.unravel_index(int(np.nanargmax(rms)), rms.shape)
+    # Comfortable for a blob this broad, and nowhere near the sixty-odd pixels
+    # an uncentred kernel and a mis-scaled step back up cost between them
+    assert abs(peak_y - centre_y) < 10, f"noise peak {peak_y} rows from {centre_y}"
+    assert abs(peak_x - centre_x) < 10, f"noise peak {peak_x} columns from {centre_x}"


### PR DESCRIPTION
Started as an investigation into `bane-fft` tasks appearing to hold memory in the Dask dashboard. That turned out to be a misreading, but looking closely at the routine turned up a real alignment bug, which is now the important half of this.

**The background and noise maps came out displaced up and to the right of the plane they describe.** Anything already made with the current code carries that shift, and anything derived from those maps — source-finding thresholds, the inverse-variance weights rm-synthesis takes from the RMS cube — inherits it. Those products want regenerating.

## Three substantive changes, separable

### 1. `efb9b1e` — working memory, 9.5x the plane to 4.3x

`bane_fits_image` runs as one task per channel, so what a worker has to fit is the peak `robust_bane` reaches, not the two paths it hands back. Six full-resolution arrays that did not need to exist:

- the seed background and noise were two whole arrays holding a single number each — now scalars
- the compacted copy for `median`/`mad_std` was held for the whole routine — now dropped before the rounds it seeds
- the clip mask built three full-size temporaries — now in place
- the validity mask was full resolution but only ever consumed downsampled — now built downsampled
- the zero-filled copy of the plane was held across both rounds — each round now builds its clipped plane from the image directly
- `nan_to_num` and the negative-noise clip copied rather than working in place, and the source count was summed three times

Measured by RSS: 588 MB to 287 MB at 4000x4000, 1287 MB to 588 MB at 6000x6000.

**Output is bit-identical** across fourteen cases — NaN and linmos-zero blanking, a wholly blank plane, a plane with no beam, DC offsets, gradients, fixed and beam-derived kernel sizes, no downsampling, and both clip and seed settings. 28/28 arrays, worst difference 0.

### 2. `939a1ad` — the alignment bug

Two causes, both displacing the maps the same way, so they added.

**The kernel was never centred.** `_ft_kernel` zero-pads out from index zero rather than centring on the origin, so every `fft_average` convolves and translates in one go, by half the kernel. Convolving a delta shows it exactly: a (13, 13) kernel moved it 6 pixels along each axis, a (19, 19) kernel 9. Because the kernel lives on the downsampled grid, half a kernel is `step * box//2` in plane pixels — tens of pixels at the default sizes. Taking the output window at that displacement costs nothing and now matches `ndimage.convolve` to 1e-6.

`test_fft_average_preserves_a_flat_image` could never have caught this: a flat image is invariant under translation.

**The step back up scaled the maps over the whole plane**, while the samples that made them start a step in and stop a step short. `ndimage.zoom` takes a scale and nothing else, so it could not know. `_to_full_resolution` uses an affine transform, which carries the offset too. Recovering a ramp through the round trip, mean error over the sampled region falls from 10.7-21.1 pixels to 0.01-0.14, and it holds when the step does not divide the plane — which resampling half a cell in, the other candidate fix, does not.

End to end on a 512x512 plane with a blob of louder noise, cross-correlated against a centred reference:

| | before | after |
|---|---|---|
| x | +85.0 px | -3.7 px |
| y | +93.5 px | +7.6 px |

The residual is the probe's own precision — the sign differs between axes.

### 3. `306a40c` — linear interpolation instead of a cubic spline

A blank leaves a step in the map, where `nan_to_num` has put zero against a measured value, and the cubic overshoots it. On a 2000x2000 plane blanked to an eighth, the background **that was written out** reached -9.67 against an image whose noise is 1e-3, with the worst pixel one row past the blank edge. The RMS undershot to a floor of exactly zero — the clip firing, not a measured value.

| | cubic | linear |
|---|---|---|
| delivered background range | [-9.67, +4.49] | [-1.1e-3, +8.9e-4] |
| RMS floor | 0.000 (clamped) | 6.2e-4 (real) |
| time, 2000x2000 | 1.86 s | 0.81 s |

Away from the blanks the two agree to well under a percent of the RMS, so what is given up is smoothness that was never resolved — the samples are a step apart. The clip on negative noise stays, now as a guard rather than a fix, so raising the order again cannot quietly deliver a negative error.

### Follow-ups on review

`4fa9943` cuts the commentary back and inlines `_seed_estimates` and `_where_masked` — ninety lines out, thirty in, maps bit-identical. `1794b59` fixes a `typos` hit CI caught (`codespell` passes the same string, which is how it got through) and a docstring the linear step had made stale. `fdf8368` covers the `step_size=0` branch that Codecov flagged.

## Tests

Five new ones, each of which fails before the change it covers, or exercises a path nothing else did:

- `test_fft_average_puts_the_smoothed_pixel_over_the_pixel_it_smooths` — a delta against a centred convolution
- `test_the_noise_map_lines_up_with_the_noise_it_measures` — a blob of louder noise found within ten pixels of where it was put, against sixty-odd before
- `test_the_working_memory_stays_a_small_multiple_of_the_plane` — peak under 7x the plane, against 9.5x before
- `test_a_wider_plane_is_measured_as_float32` — pins the dtype contract
- `test_a_plane_measured_without_downsampling` — the one path that never steps the maps back up, so the only end-to-end check of the kernel centring on its own

The seventeen existing tests pass unchanged. None of them covered where a map puts a feature, which is why this ran for as long as it did.

`flint/bane.py` reads as 86% covered because `coverage` cannot see inside a compiled `njit` function; every uncovered line is inside one.

## Worth a second opinion

- **The memory bound is a judgement call.** 7x against 4.3-5.4x measured locally; numpy and scipy allocate differently between versions and CI spans 3.11 to 3.13. It has since passed on 3.13, so that is one version of evidence rather than three. If it flakes, loosen it rather than drop it.
- **The kernel centring is probably upstream too.** This was ported from `AegeanTools.BANE_fft` and the uncentred `rfft2(kernel, s=shape)` looks like it came across with it. Someone who knows that codebase should check.
- `robust_bane` now casts the plane to float32 up front, which it had been getting incidentally from the zero-filled copy that has gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Skuoh52Dn8WdnNmvijZvR