### PR TITLE
Update rm-lite to v2026.9.1 and write its new Faraday moment products

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,20 @@
+# CLAUDE.md
+
+Guidance for Claude Code working in this repository.
+
+## Style
+
+Keep it simple.
+
+**Docstrings.** A one-liner wherever one will do. Terse, but written for a
+person to read: plain words, no jargon, no filler.
+
+**Comments.** Only to explain a *why* that the code cannot show. Think twice
+before adding one at all — prefer code that says it itself. Anything you do add
+follows the docstring rules above.
+
+**Private names.** A leading underscore is for tiny helpers. Anything larger is
+a normal function.
+
+**Global constants.** Do not add one unless it is actually needed. A value used
+in a single place is a local.

--- a/flint/options.py
+++ b/flint/options.py
@@ -374,13 +374,13 @@ class RMSynthOptions(BaseOptions):
     n_error_samples: int = 1000
     """Monte-Carlo resamples used by compute_model_error"""
     debias_moments: bool = False
-    """Also compute a debiased (via rm_lite's debias_fdf) moment set per requested FDF, written with a '.debiased' suffix. Distinct from the mom0_debias map, which takes the noise's own sum off mom0 rather than debiasing the FDF first"""
+    """Also compute a debiased (via rm_lite's debias_fdf) moment set per requested FDF, written with a '.debiased' suffix."""
     debias_filter_size: int = 5
     """Median filter size (pixels) used by mom0 debiasing"""
     lam_sq_0_m2: float | Literal["auto", "per_pixel"] = "auto"
-    """Reference lambda^2 the FDF is derotated to. 'auto' picks one value for the whole cube; 'per_pixel' gives each pixel its own, which also forces per_pixel_rmsf since the RMSF then differs pixel to pixel, and leaves the pi/pa_lam_sq_0 moment maps measuring every pixel at a different wavelength. A float pins it explicitly"""
+    """Reference lambda^2 the FDF is derotated to. 'auto' picks one value for the whole cube; 'per_pixel' gives each pixel its own, which also forces per_pixel_rmsf"""
     per_pixel_rmsf: bool = False
-    """Compute the RMSF for each pixel rather than one shared by the cube. Roughly doubles the FDF's size. rm-lite turns this on itself when the weights make pixels disagree, as the linmos weight cubes do"""
+    """Compute the RMSF for each pixel"""
     estimate_stokes_i_noise: bool = True
     """Derive the per-channel Stokes I error from the Stokes I cube when no Stokes I weight cube is given. A weight cube takes precedence"""
 
@@ -460,11 +460,11 @@ class RMSynthFieldOptions(BaseOptions):
     cube_products: list[Literal["dirty", "clean", "model"]] = []
     """Which Faraday dispersion function (FDF) cubes to write as FITS. Nothing by default, as these cubes can be large."""
     moment_products: list[Literal["dirty", "clean", "model"]] = ["clean"]
-    """Which FDF(s) to compute Faraday moment maps from: mom0 (raw, debiased and error), mom1 and mom2 with their errors, and the polarised intensity (raw, debiased and error) and angle (and error) at the reference lambda^2. Twelve (ny, nx) maps per FDF"""
+    """Which FDF(s) to compute Faraday moment maps from: 'dirty', 'clean', 'model'"""
     moment_threshold_snr: float = 5.0
     """SNR cut (times the theoretical FDF noise) applied before the moment maps are computed, the dirty ones included"""
     peak_products: list[Literal["dirty", "clean", "model"]] = []
-    """Which FDF(s) to measure peak statistics from: peak polarised intensity (raw and debiased), Faraday depth, polarisation angle and intrinsic angle, each with its error. Nine (ny, nx) maps per FDF, so empty by default -- at 16032^2 that is ~9 GB per entry. No SNR cut is applied: a peak is a single sample with no noise floor to integrate, so select on peak_pi / peak_pi_error afterwards"""
+    """Which FDF(s) to measure peak statistics from: 'dirty', 'clean', 'model'"""
     output_path: Path | None = None
     """Directory the FDF cube and moment products are written into. Defaults to alongside the input Stokes cubes"""
     sbid_copy_path: Path | None = None

--- a/flint/options.py
+++ b/flint/options.py
@@ -374,11 +374,11 @@ class RMSynthOptions(BaseOptions):
     n_error_samples: int = 1000
     """Monte-Carlo resamples used by compute_model_error"""
     debias_moments: bool = False
-    """Also compute a debiased (via rm_lite's debias_fdf) mom0/mom1/mom2 set per requested FDF"""
+    """Also compute a debiased (via rm_lite's debias_fdf) moment set per requested FDF, written with a '.debiased' suffix. Distinct from the mom0_debias map, which takes the noise's own sum off mom0 rather than debiasing the FDF first"""
     debias_filter_size: int = 5
     """Median filter size (pixels) used by mom0 debiasing"""
     lam_sq_0_m2: float | Literal["auto", "per_pixel"] = "auto"
-    """Reference lambda^2 the FDF is derotated to. 'auto' picks one value for the whole cube; 'per_pixel' gives each pixel its own, which also forces per_pixel_rmsf since the RMSF then differs pixel to pixel. A float pins it explicitly"""
+    """Reference lambda^2 the FDF is derotated to. 'auto' picks one value for the whole cube; 'per_pixel' gives each pixel its own, which also forces per_pixel_rmsf since the RMSF then differs pixel to pixel, and leaves the pi/pa_lam_sq_0 moment maps measuring every pixel at a different wavelength. A float pins it explicitly"""
     per_pixel_rmsf: bool = False
     """Compute the RMSF for each pixel rather than one shared by the cube. Roughly doubles the FDF's size. rm-lite turns this on itself when the weights make pixels disagree, as the linmos weight cubes do"""
     estimate_stokes_i_noise: bool = True
@@ -460,13 +460,11 @@ class RMSynthFieldOptions(BaseOptions):
     cube_products: list[Literal["dirty", "clean", "model"]] = []
     """Which Faraday dispersion function (FDF) cubes to write as FITS. Nothing by default, as these cubes can be large."""
     moment_products: list[Literal["dirty", "clean", "model"]] = ["clean"]
-    """Which FDF(s) to compute Faraday moment maps from."""
+    """Which FDF(s) to compute Faraday moment maps from: mom0 (raw, debiased and error), mom1 and mom2 with their errors, and the polarised intensity (raw, debiased and error) and angle (and error) at the reference lambda^2. Twelve (ny, nx) maps per FDF"""
     moment_threshold_snr: float = 5.0
     """SNR cut (times the theoretical FDF noise) applied before the moment maps are computed, the dirty ones included"""
-    peak_threshold_snr: float = 0.0
-    """SNR cut (times the theoretical FDF noise) below which peak statistics are blanked. Zero applies no cut: a peak is a single sample with no noise floor to integrate, and peak_pi_error is written beside it"""
     peak_products: list[Literal["dirty", "clean", "model"]] = []
-    """Which FDF(s) to measure peak statistics from: peak polarised intensity (raw and debiased), Faraday depth, polarisation angle and intrinsic angle, each with its error. Nine (ny, nx) maps per FDF, so empty by default -- at 16032^2 that is ~9 GB per entry"""
+    """Which FDF(s) to measure peak statistics from: peak polarised intensity (raw and debiased), Faraday depth, polarisation angle and intrinsic angle, each with its error. Nine (ny, nx) maps per FDF, so empty by default -- at 16032^2 that is ~9 GB per entry. No SNR cut is applied: a peak is a single sample with no noise floor to integrate, so select on peak_pi / peak_pi_error afterwards"""
     output_path: Path | None = None
     """Directory the FDF cube and moment products are written into. Defaults to alongside the input Stokes cubes"""
     sbid_copy_path: Path | None = None

--- a/flint/prefect/common/rmsynth.py
+++ b/flint/prefect/common/rmsynth.py
@@ -243,7 +243,6 @@ def task_write_rm_products(
     peak_products: list[FDFLabel],
     output_prefix: Path,
     moment_threshold_snr: float = 5.0,
-    peak_threshold_snr: float = 0.0,
 ) -> list[Path]:
     """Batch-compute and write the requested RM-synthesis/RM-CLEAN products"""
     from prefect_dask import get_dask_client
@@ -261,6 +260,5 @@ def task_write_rm_products(
             peak_products=peak_products,
             output_prefix=output_prefix,
             moment_threshold_snr=moment_threshold_snr,
-            peak_threshold_snr=peak_threshold_snr,
             dask_client=client,
         )

--- a/flint/prefect/flows/rmsynth_pipeline.py
+++ b/flint/prefect/flows/rmsynth_pipeline.py
@@ -207,7 +207,6 @@ def process_rmsynth(
         peak_products=rmsynth_field_options.peak_products,
         output_prefix=output_prefix,
         moment_threshold_snr=rmsynth_field_options.moment_threshold_snr,
-        peak_threshold_snr=rmsynth_field_options.peak_threshold_snr,
     )
 
     written_paths = output_paths.result()

--- a/flint/rmsynth.py
+++ b/flint/rmsynth.py
@@ -56,11 +56,7 @@ from flint.options import (
 FDFLabel: TypeAlias = Literal["dirty", "clean", "model"]
 FDFThreshold: TypeAlias = float | np.ndarray | da.Array | None
 
-# The Faraday moments, as {FaradayMoments field: (file suffix, BUNIT, comment)}.
-# The moments used to be three unitless-looking maps; they now carry an error
-# each, and the polarisation at the reference lambda^2, which mixes Jy/beam,
-# rad/m2 and degrees in the one set -- so every map is stamped with its BUNIT.
-_MOMENT_MAPS = {
+MOMENT_MAPS = {
     "mom0": ("mom0", "Jy/beam", "zeroth moment, total polarised intensity"),
     "mom0_debias": ("mom0_debias", "Jy/beam", "mom0 less the noise's own sum"),
     "mom0_error": ("mom0_error", "Jy/beam", "1-sigma on mom0"),
@@ -75,17 +71,14 @@ _MOMENT_MAPS = {
     "pa_lam_sq_0_error": ("pa_lam_sq_0_error", "deg", "1-sigma on pa_lam_sq_0"),
 }
 
-# ``debias=True`` rebuilds the FDF with the noise taken off each amplitude
-# first, which is exactly what rm-lite's own ``mom0_debias`` subtracts -- so it
-# returns ``mom0`` unchanged there, and writing a byte-identical copy of the
-# already-written ``mom0`` map under a second name would only invite reading
-# them as two measurements.
-_DEBIASED_MOMENT_MAPS = {
-    field: entry for field, entry in _MOMENT_MAPS.items() if field != "mom0_debias"
+# A debiased FDF returns `mom0_debias` unchanged, so writing it a second time
+# under a second name would read as a second measurement
+DEBIASED_MOMENT_MAPS = {
+    field: entry for field, entry in MOMENT_MAPS.items() if field != "mom0_debias"
 }
 
 # The FDF peak statistics, as {FaradayPeaks field: (file suffix, BUNIT, comment)}.
-_PEAK_MAPS = {
+PEAK_MAPS = {
     "peak_pi": ("peak_pi", "Jy/beam", "peak polarised intensity"),
     "peak_pi_debias": ("peak_pi_debias", "Jy/beam", "debiased peak"),
     "peak_pi_error": ("peak_pi_error", "Jy/beam", "1-sigma on the peak"),
@@ -219,11 +212,11 @@ def run_rmclean_3d(
 
 
 def write_moment_maps_to_fits(
-    moments: dict[str, np.ndarray],
+    moments: FaradayMoments,
     reference_header: fits.Header,
     output_prefix: Path,
     label: FDFLabel,
-    debiased_moments: dict[str, np.ndarray] | None = None,
+    debiased_moments: FaradayMoments | None = None,
 ) -> list[Path]:
     """Write already-computed Faraday moment maps to FITS.
 
@@ -232,37 +225,42 @@ def write_moment_maps_to_fits(
     (ny, nx) maps arrive here. See ``_lazy_faraday_moments``.
 
     Args:
-        moments (dict[str, np.ndarray]): Computed moment maps, each (ny, nx), keyed by ``_MOMENT_MAPS`` field
+        moments (FaradayMoments): Computed moment maps, each (ny, nx)
         reference_header (fits.Header): Header to derive the spatial WCS from (e.g. the Stokes Q cube header)
         output_prefix (Path): Common prefix for the output files
         label (FDFLabel): Which FDF the moments came from ('dirty', 'clean', or 'model'), used to name the outputs
-        debiased_moments (dict[str, np.ndarray] | None, optional): Debiased moment set, written alongside with a ``.debiased`` suffix. Defaults to None.
+        debiased_moments (FaradayMoments | None, optional): Debiased moment set, written alongside with a ``.debiased`` suffix. Defaults to None.
 
     Returns:
-        list[Path]: The written moment-map paths: one per ``_MOMENT_MAPS`` entry,
-        plus one per ``_DEBIASED_MOMENT_MAPS`` entry if debiased_moments is given
+        list[Path]: The written moment-map paths: one per ``MOMENT_MAPS`` entry,
+        plus one per ``DEBIASED_MOMENT_MAPS`` entry if debiased_moments is given
     """
     celestial = WCS(reference_header).celestial.to_header()
 
-    def _write(moment_set: dict[str, np.ndarray], suffix: str) -> list[Path]:
+    def _write(
+        moment_set: FaradayMoments,
+        maps: dict[str, tuple[str, str, str]],
+        suffix: str,
+    ) -> list[Path]:
         written = []
-        for field, moment_map in moment_set.items():
-            name, unit, comment = _MOMENT_MAPS[field]
+        for field, (name, unit, comment) in maps.items():
             header = celestial.copy()
             header["BUNIT"] = (unit, comment)
             output_path = Path(f"{output_prefix}.fdf.{label}.{name}{suffix}.fits")
             fits.writeto(
                 output_path,
-                np.asarray(moment_map, dtype=np.float32),
+                np.asarray(getattr(moment_set, field), dtype=np.float32),
                 header,
                 overwrite=True,
             )
             written.append(output_path)
         return written
 
-    output_paths = _write(moments, suffix="")
+    output_paths = _write(moments, MOMENT_MAPS, suffix="")
     if debiased_moments is not None:
-        output_paths.extend(_write(debiased_moments, suffix=".debiased"))
+        output_paths.extend(
+            _write(debiased_moments, DEBIASED_MOMENT_MAPS, suffix=".debiased")
+        )
 
     return output_paths
 
@@ -586,11 +584,8 @@ def _compute_rm_products(
         futures = scheduler.compute(
             [compute_targets[key] for key in compute_keys], sync=False
         )
-    # Products that are the same expression share a dask key, so `compute`
-    # hands back one future for all of them -- rm-lite builds `mom0_error` and
-    # `pi_lam_sq_0_error` identically, for instance. One key per future would
-    # then quietly drop every product but the last of each such group, so the
-    # mapping is one-to-many and every key it carries is filled in.
+    # Products built from the same expression share a future, so the mapping is
+    # one-to-many: one key per future would drop all but the last of each group
     future_to_keys: dict[Any, list[str]] = {}
     for future, key in zip(futures, compute_keys):
         future_to_keys.setdefault(future, []).append(key)
@@ -665,7 +660,7 @@ def write_peak_maps_to_fits(
     """
     celestial = WCS(reference_header).celestial.to_header()
     output_paths = []
-    for field, (suffix, unit, comment) in _PEAK_MAPS.items():
+    for field, (suffix, unit, comment) in PEAK_MAPS.items():
         header = celestial.copy()
         header["BUNIT"] = (unit, comment)
         output_path = Path(f"{output_prefix}.fdf.{label}.{suffix}.fits")
@@ -701,7 +696,7 @@ def write_rm_products(
         rmsynth_options (RMSynthOptions): Options controlling RM-synthesis
         rmclean_options (RMCleanOptions): Options controlling RM-CLEAN
         cube_products (list[FDFLabel]): Which FDF cube(s) to write ('dirty', 'clean', 'model')
-        moment_products (list[FDFLabel]): Which FDF(s) to compute Faraday moment maps from, twelve per entry
+        moment_products (list[FDFLabel]): Which FDF(s) to compute Faraday moment maps from
         peak_products (list[FDFLabel]): Which FDF(s) to write peak-statistic maps from, nine per entry
         moment_threshold_snr (float, optional): SNR cut applied before the moment maps. Defaults to 5.0.
         output_prefix (Path): Common prefix for the output files
@@ -794,7 +789,7 @@ def write_rm_products(
             synth_results=synth_results,
             threshold=moment_threshold,
         )
-        for field in _MOMENT_MAPS:
+        for field in MOMENT_MAPS:
             compute_targets[f"moment.{label}.{field}"] = getattr(moments, field).astype(
                 np.float32
             )
@@ -806,7 +801,7 @@ def write_rm_products(
                 debias=True,
                 debias_filter_size=rmsynth_options.debias_filter_size,
             )
-            for field in _DEBIASED_MOMENT_MAPS:
+            for field in MOMENT_MAPS:
                 compute_targets[f"debiased.{label}.{field}"] = getattr(
                     debiased, field
                 ).astype(np.float32)
@@ -831,7 +826,7 @@ def write_rm_products(
             lam_sq_0_m2=synth_results.lam_sq_0_m2,
             lambda_sq_arr_m2=synth_results.lambda_sq_arr_m2,
         )
-        for field in _PEAK_MAPS:
+        for field in PEAK_MAPS:
             compute_targets[f"peak.{label}.{field}"] = getattr(peaks, field).astype(
                 np.float32
             )
@@ -899,16 +894,21 @@ def write_rm_products(
     for label in moment_products:
         output_paths.extend(
             write_moment_maps_to_fits(
-                moments={
-                    field: computed[f"moment.{label}.{field}"] for field in _MOMENT_MAPS
-                },
+                moments=FaradayMoments(
+                    **{
+                        field: computed[f"moment.{label}.{field}"]
+                        for field in MOMENT_MAPS
+                    }
+                ),
                 reference_header=reference_header,
                 output_prefix=output_prefix,
                 label=label,
-                debiased_moments={
-                    field: computed[f"debiased.{label}.{field}"]
-                    for field in _DEBIASED_MOMENT_MAPS
-                }
+                debiased_moments=FaradayMoments(
+                    **{
+                        field: computed[f"debiased.{label}.{field}"]
+                        for field in MOMENT_MAPS
+                    }
+                )
                 if rmsynth_options.debias_moments
                 else None,
             )
@@ -927,7 +927,7 @@ def write_rm_products(
         output_paths.extend(
             write_peak_maps_to_fits(
                 peaks=FaradayPeaks(
-                    **{field: computed[f"peak.{label}.{field}"] for field in _PEAK_MAPS}
+                    **{field: computed[f"peak.{label}.{field}"] for field in PEAK_MAPS}
                 ),
                 reference_header=reference_header,
                 output_prefix=output_prefix,

--- a/flint/rmsynth.py
+++ b/flint/rmsynth.py
@@ -71,13 +71,6 @@ MOMENT_MAPS = {
     "pa_lam_sq_0_error": ("pa_lam_sq_0_error", "deg", "1-sigma on pa_lam_sq_0"),
 }
 
-# A debiased FDF returns `mom0_debias` unchanged, so writing it a second time
-# under a second name would read as a second measurement
-DEBIASED_MOMENT_MAPS = {
-    field: entry for field, entry in MOMENT_MAPS.items() if field != "mom0_debias"
-}
-
-# The FDF peak statistics, as {FaradayPeaks field: (file suffix, BUNIT, comment)}.
 PEAK_MAPS = {
     "peak_pi": ("peak_pi", "Jy/beam", "peak polarised intensity"),
     "peak_pi_debias": ("peak_pi_debias", "Jy/beam", "debiased peak"),
@@ -232,8 +225,8 @@ def write_moment_maps_to_fits(
         debiased_moments (FaradayMoments | None, optional): Debiased moment set, written alongside with a ``.debiased`` suffix. Defaults to None.
 
     Returns:
-        list[Path]: The written moment-map paths: one per ``MOMENT_MAPS`` entry,
-        plus one per ``DEBIASED_MOMENT_MAPS`` entry if debiased_moments is given
+        list[Path]: One path per ``MOMENT_MAPS`` entry, plus the debiased set
+        less ``mom0_debias`` if debiased_moments is given
     """
     celestial = WCS(reference_header).celestial.to_header()
 
@@ -258,9 +251,14 @@ def write_moment_maps_to_fits(
 
     output_paths = _write(moments, MOMENT_MAPS, suffix="")
     if debiased_moments is not None:
-        output_paths.extend(
-            _write(debiased_moments, DEBIASED_MOMENT_MAPS, suffix=".debiased")
-        )
+        # a debiased FDF leaves mom0_debias unchanged, so writing it again under
+        # a second name would read as a second measurement
+        debiased_maps = {
+            field: entry
+            for field, entry in MOMENT_MAPS.items()
+            if field != "mom0_debias"
+        }
+        output_paths.extend(_write(debiased_moments, debiased_maps, suffix=".debiased"))
 
     return output_paths
 

--- a/flint/rmsynth.py
+++ b/flint/rmsynth.py
@@ -55,11 +55,36 @@ from flint.options import (
 
 FDFLabel: TypeAlias = Literal["dirty", "clean", "model"]
 FDFThreshold: TypeAlias = float | np.ndarray | da.Array | None
-_MOMENT_NAMES = ("mom0", "mom1", "mom2")
+
+# The Faraday moments, as {FaradayMoments field: (file suffix, BUNIT, comment)}.
+# The moments used to be three unitless-looking maps; they now carry an error
+# each, and the polarisation at the reference lambda^2, which mixes Jy/beam,
+# rad/m2 and degrees in the one set -- so every map is stamped with its BUNIT.
+_MOMENT_MAPS = {
+    "mom0": ("mom0", "Jy/beam", "zeroth moment, total polarised intensity"),
+    "mom0_debias": ("mom0_debias", "Jy/beam", "mom0 less the noise's own sum"),
+    "mom0_error": ("mom0_error", "Jy/beam", "1-sigma on mom0"),
+    "mom1": ("mom1", "rad/m2", "first moment, mean Faraday depth"),
+    "mom1_error": ("mom1_error", "rad/m2", "1-sigma on mom1"),
+    "mom2": ("mom2", "rad/m2", "second moment, Faraday depth dispersion"),
+    "mom2_error": ("mom2_error", "rad/m2", "1-sigma on mom2"),
+    "pi_lam_sq_0": ("pi_lam_sq_0", "Jy/beam", "polarised intensity at lambda^2_0"),
+    "pi_lam_sq_0_debias": ("pi_lam_sq_0_debias", "Jy/beam", "debiased pi_lam_sq_0"),
+    "pi_lam_sq_0_error": ("pi_lam_sq_0_error", "Jy/beam", "1-sigma on pi_lam_sq_0"),
+    "pa_lam_sq_0": ("pa_lam_sq_0", "deg", "polarisation angle at lambda^2_0"),
+    "pa_lam_sq_0_error": ("pa_lam_sq_0_error", "deg", "1-sigma on pa_lam_sq_0"),
+}
+
+# ``debias=True`` rebuilds the FDF with the noise taken off each amplitude
+# first, which is exactly what rm-lite's own ``mom0_debias`` subtracts -- so it
+# returns ``mom0`` unchanged there, and writing a byte-identical copy of the
+# already-written ``mom0`` map under a second name would only invite reading
+# them as two measurements.
+_DEBIASED_MOMENT_MAPS = {
+    field: entry for field, entry in _MOMENT_MAPS.items() if field != "mom0_debias"
+}
 
 # The FDF peak statistics, as {FaradayPeaks field: (file suffix, BUNIT, comment)}.
-# Units matter more here than for the moments: three of these are angles in
-# degrees and two are Faraday depths, so a map with no BUNIT is easy to misread.
 _PEAK_MAPS = {
     "peak_pi": ("peak_pi", "Jy/beam", "peak polarised intensity"),
     "peak_pi_debias": ("peak_pi_debias", "Jy/beam", "debiased peak"),
@@ -194,40 +219,38 @@ def run_rmclean_3d(
 
 
 def write_moment_maps_to_fits(
-    moments: FaradayMoments,
+    moments: dict[str, np.ndarray],
     reference_header: fits.Header,
     output_prefix: Path,
     label: FDFLabel,
-    debiased_moments: FaradayMoments | None = None,
+    debiased_moments: dict[str, np.ndarray] | None = None,
 ) -> list[Path]:
-    """Write already-computed mom0/mom1/mom2 Faraday moment maps to FITS.
+    """Write already-computed Faraday moment maps to FITS.
 
     The moments are built lazily and computed by ``write_rm_products``, which
     keeps the (n_phi, ny, nx) FDF cube they reduce out of this process; only the
     (ny, nx) maps arrive here. See ``_lazy_faraday_moments``.
 
     Args:
-        moments (FaradayMoments): Computed mom0/mom1/mom2 maps, each (ny, nx)
+        moments (dict[str, np.ndarray]): Computed moment maps, each (ny, nx), keyed by ``_MOMENT_MAPS`` field
         reference_header (fits.Header): Header to derive the spatial WCS from (e.g. the Stokes Q cube header)
         output_prefix (Path): Common prefix for the output files
         label (FDFLabel): Which FDF the moments came from ('dirty', 'clean', or 'model'), used to name the outputs
-        debiased_moments (FaradayMoments | None, optional): Debiased moment set, written alongside with a ``.debiased`` suffix. Defaults to None.
+        debiased_moments (dict[str, np.ndarray] | None, optional): Debiased moment set, written alongside with a ``.debiased`` suffix. Defaults to None.
 
     Returns:
-        list[Path]: The written moment-map paths: three (mom0, mom1, mom2), plus
-        three more (mom0.debiased, mom1.debiased, mom2.debiased) if debiased_moments is given
+        list[Path]: The written moment-map paths: one per ``_MOMENT_MAPS`` entry,
+        plus one per ``_DEBIASED_MOMENT_MAPS`` entry if debiased_moments is given
     """
-    header = WCS(reference_header).celestial.to_header()
+    celestial = WCS(reference_header).celestial.to_header()
 
-    def _write(moment_set: FaradayMoments, suffix: str) -> list[Path]:
+    def _write(moment_set: dict[str, np.ndarray], suffix: str) -> list[Path]:
         written = []
-        for moment_name, moment_map in zip(
-            _MOMENT_NAMES,
-            (moment_set.mom0, moment_set.mom1, moment_set.mom2),
-        ):
-            output_path = Path(
-                f"{output_prefix}.fdf.{label}.{moment_name}{suffix}.fits"
-            )
+        for field, moment_map in moment_set.items():
+            name, unit, comment = _MOMENT_MAPS[field]
+            header = celestial.copy()
+            header["BUNIT"] = (unit, comment)
+            output_path = Path(f"{output_prefix}.fdf.{label}.{name}{suffix}.fits")
             fits.writeto(
                 output_path,
                 np.asarray(moment_map, dtype=np.float32),
@@ -427,18 +450,23 @@ def _lazy_faraday_moments(
     debias: bool = False,
     debias_filter_size: int = 5,
 ) -> FaradayMoments:
-    """Build the lazy mom0/mom1/mom2 maps of an FDF cube.
+    """Build the lazy Faraday moment maps of an FDF cube.
 
     ``calc_faraday_moments`` reduces along the (never-chunked) Faraday-depth
     axis, and ``debias_fdf`` handles dask via ``map_overlap``, so the result is
-    three lazy (ny, nx) maps that each spatial chunk contributes to
+    a set of lazy (ny, nx) maps that each spatial chunk contributes to
     independently. Computing these instead of the cube itself is what keeps the
     whole FDF out of the calling worker's memory.
+
+    The theoretical noise is what turns the errors and the debiased maps from
+    NaN into measurements, so it is passed whenever synthesis reported one --
+    it is the same noise the amplitude cut is derived from.
     """
     return calc_faraday_moments(
         fdf_cube,
         phi_arr_radm2=synth_results.phi_arr_radm2,
         fwhm_rmsf_radm2=synth_results.fwhm_rmsf_radm2,
+        fdf_error=synth_results.theoretical_noise.fdf_error_noise,
         threshold=threshold,
         debias=debias,
         lam_sq_0_m2=synth_results.lam_sq_0_m2 if debias else None,
@@ -558,20 +586,30 @@ def _compute_rm_products(
         futures = scheduler.compute(
             [compute_targets[key] for key in compute_keys], sync=False
         )
-    future_to_key = dict(zip(futures, compute_keys))
+    # Products that are the same expression share a dask key, so `compute`
+    # hands back one future for all of them -- rm-lite builds `mom0_error` and
+    # `pi_lam_sq_0_error` identically, for instance. One key per future would
+    # then quietly drop every product but the last of each such group, so the
+    # mapping is one-to-many and every key it carries is filled in.
+    future_to_keys: dict[Any, list[str]] = {}
+    for future, key in zip(futures, compute_keys):
+        future_to_keys.setdefault(future, []).append(key)
 
     computed: dict[str, Any] = {}
     with _seceded_if_on_a_worker():
-        for future in as_completed(futures):
-            key = future_to_key[future]
+        for future in as_completed(list(future_to_keys)):
+            keys = future_to_keys[future]
             # `.result()` re-raises whatever the worker raised, so a failed
             # product still surfaces here rather than being dropped
-            computed[key] = future.result()
+            result = future.result()
+            for key in keys:
+                computed[key] = result
             # Elapsed since submission, not this product's own runtime: they
             # share one graph, so "how far into the run are we" is the
             # answerable question
             logger.info(
-                f"[{len(computed):>2}/{len(compute_keys)}] {key} at {_elapsed(start)}"
+                f"[{len(computed):>2}/{len(compute_keys)}] "
+                f"{', '.join(keys)} at {_elapsed(start)}"
             )
 
     logger.info(f"Computed {len(compute_keys)} RM products in {_elapsed(start)}")
@@ -652,7 +690,6 @@ def write_rm_products(
     peak_products: list[FDFLabel],
     output_prefix: Path,
     moment_threshold_snr: float = 5.0,
-    peak_threshold_snr: float = 0.0,
     dask_client: Client | None = None,
 ) -> list[Path]:
     """Batch-compute and write the requested RM-synthesis/RM-CLEAN output products.
@@ -664,10 +701,9 @@ def write_rm_products(
         rmsynth_options (RMSynthOptions): Options controlling RM-synthesis
         rmclean_options (RMCleanOptions): Options controlling RM-CLEAN
         cube_products (list[FDFLabel]): Which FDF cube(s) to write ('dirty', 'clean', 'model')
-        moment_products (list[FDFLabel]): Which FDF(s) to compute Faraday moment maps from
+        moment_products (list[FDFLabel]): Which FDF(s) to compute Faraday moment maps from, twelve per entry
         peak_products (list[FDFLabel]): Which FDF(s) to write peak-statistic maps from, nine per entry
         moment_threshold_snr (float, optional): SNR cut applied before the moment maps. Defaults to 5.0.
-        peak_threshold_snr (float, optional): SNR cut below which peaks are blanked. Zero applies no cut. Defaults to 0.0.
         output_prefix (Path): Common prefix for the output files
         dask_client (Client | None, optional): A distributed Client (e.g. the one backing a Prefect ``DaskTaskRunner``) to compute across, rather than just the local worker. Defaults to None.
 
@@ -758,8 +794,10 @@ def write_rm_products(
             synth_results=synth_results,
             threshold=moment_threshold,
         )
-        for name, moment_map in zip(_MOMENT_NAMES, moments):
-            compute_targets[f"moment.{label}.{name}"] = moment_map
+        for field in _MOMENT_MAPS:
+            compute_targets[f"moment.{label}.{field}"] = getattr(moments, field).astype(
+                np.float32
+            )
         if rmsynth_options.debias_moments:
             debiased = _lazy_faraday_moments(
                 fdf_cube=fdf_sources[label],
@@ -768,23 +806,22 @@ def write_rm_products(
                 debias=True,
                 debias_filter_size=rmsynth_options.debias_filter_size,
             )
-            for name, moment_map in zip(_MOMENT_NAMES, debiased):
-                compute_targets[f"debiased.{label}.{name}"] = moment_map
+            for field in _DEBIASED_MOMENT_MAPS:
+                compute_targets[f"debiased.{label}.{field}"] = getattr(
+                    debiased, field
+                ).astype(np.float32)
     # Unconditional whenever RM-CLEAN ran: one small integer map, and the
     # diagnostic you want already written rather than a stage to repeat.
     if run_clean:
         assert clean_results is not None  # run_clean is `clean_results is not None`
         compute_targets["rmclean_niter"] = clean_results.iter_count_map
 
-    # rm-lite's own peaks cover only the clean FDF under its own threshold;
-    # deriving them here lets any requested FDF have them, the dirty one
-    # included. Cut separately from the moments and off by default: mom0
-    # integrates the whole Faraday depth axis, a peak is one sample with no such
-    # floor, and peak_pi_error is written beside it to judge significance.
-    peak_threshold = _snr_threshold(
-        peak_threshold_snr,
-        synth_results.theoretical_noise.fdf_error_noise,
-    )
+    # rm-lite's own peaks cover only the clean FDF; deriving them here lets any
+    # requested FDF have them, the dirty one included. No amplitude cut is
+    # applied, and rm-lite no longer offers one: mom0 integrates the whole
+    # Faraday depth axis and needs a cut to keep the noise out, but a peak is a
+    # single sample with no such floor, and ``peak_pi_error`` is written beside
+    # it, so ``peak_pi / peak_pi_error`` is the SNR to select on afterwards.
     for label in peak_products:
         peaks = calc_faraday_peaks(
             fdf_sources[label],
@@ -793,7 +830,6 @@ def write_rm_products(
             fdf_error=synth_results.theoretical_noise.fdf_error_noise,
             lam_sq_0_m2=synth_results.lam_sq_0_m2,
             lambda_sq_arr_m2=synth_results.lambda_sq_arr_m2,
-            threshold=peak_threshold,
         )
         for field in _PEAK_MAPS:
             compute_targets[f"peak.{label}.{field}"] = getattr(peaks, field).astype(
@@ -863,15 +899,16 @@ def write_rm_products(
     for label in moment_products:
         output_paths.extend(
             write_moment_maps_to_fits(
-                moments=FaradayMoments(
-                    *(computed[f"moment.{label}.{name}"] for name in _MOMENT_NAMES)
-                ),
+                moments={
+                    field: computed[f"moment.{label}.{field}"] for field in _MOMENT_MAPS
+                },
                 reference_header=reference_header,
                 output_prefix=output_prefix,
                 label=label,
-                debiased_moments=FaradayMoments(
-                    *(computed[f"debiased.{label}.{name}"] for name in _MOMENT_NAMES)
-                )
+                debiased_moments={
+                    field: computed[f"debiased.{label}.{field}"]
+                    for field in _DEBIASED_MOMENT_MAPS
+                }
                 if rmsynth_options.debias_moments
                 else None,
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ casa =[
     "fixms>=0.4.0"
 ]
 rmsynth = [
-    "rm-lite==2026.8.7",
+    "rm-lite==2026.9.1",
 ]
 all = [
     "askap-flint[dev,casa,rmsynth]",

--- a/tests/test_prefect_rmsynth_flow.py
+++ b/tests/test_prefect_rmsynth_flow.py
@@ -40,7 +40,7 @@ from flint.prefect.flows.rmsynth_pipeline import (
 
 from .test_convol import _write_cube_with_beam
 from .test_rmsynth import (
-    _MOMENT_MAPS,
+    MOMENT_MAPS,
     NX,
     NY,
     PHI_TRUE_RADM2,
@@ -133,7 +133,7 @@ def test_process_rmsynth_on_dask_cluster(
         tmp_path / f"{STEM}.fdf.clean.niter.fits",
     } | {
         tmp_path / f"{STEM}.fdf.clean.{name}.fits"
-        for name, _, _ in _MOMENT_MAPS.values()
+        for name, _, _ in MOMENT_MAPS.values()
     }
     for path in output_paths:
         assert path.exists()

--- a/tests/test_prefect_rmsynth_flow.py
+++ b/tests/test_prefect_rmsynth_flow.py
@@ -39,7 +39,14 @@ from flint.prefect.flows.rmsynth_pipeline import (
 )
 
 from .test_convol import _write_cube_with_beam
-from .test_rmsynth import NX, NY, PHI_TRUE_RADM2, _make_i_cube, _make_qu_cubes
+from .test_rmsynth import (
+    _MOMENT_MAPS,
+    NX,
+    NY,
+    PHI_TRUE_RADM2,
+    _make_i_cube,
+    _make_qu_cubes,
+)
 
 # create_name_from_common_fields rejects names it cannot decompose
 STEM = "SB12345.BENCH_0000+00.ch0000-0019"
@@ -125,8 +132,8 @@ def test_process_rmsynth_on_dask_cluster(
         zarr_store,
         tmp_path / f"{STEM}.fdf.clean.niter.fits",
     } | {
-        tmp_path / f"{STEM}.fdf.clean.{moment}.fits"
-        for moment in ("mom0", "mom1", "mom2")
+        tmp_path / f"{STEM}.fdf.clean.{name}.fits"
+        for name, _, _ in _MOMENT_MAPS.values()
     }
     for path in output_paths:
         assert path.exists()

--- a/tests/test_rmsynth.py
+++ b/tests/test_rmsynth.py
@@ -6,6 +6,7 @@ import logging
 from pathlib import Path
 from unittest.mock import patch
 
+import dask.array as da
 import numpy as np
 import pytest
 from astropy.io import fits
@@ -23,8 +24,12 @@ from flint.options import (
     WeightCubesForRMSynth,
 )
 from flint.rmsynth import (
+    _DEBIASED_MOMENT_MAPS,
+    _MOMENT_MAPS,
+    _PEAK_MAPS,
     FDFLabel,
     RMSynth3DResults,
+    _compute_rm_products,
     _snr_threshold,
     needs_rmclean,
     run_rmclean_3d,
@@ -182,7 +187,6 @@ def _synth_and_write(
     stokes_u_weight_cube: Path | None = None,
     peak_products: list[FDFLabel] = [],
     moment_threshold_snr: float = 5.0,
-    peak_threshold_snr: float = 0.0,
 ) -> list[Path]:
     if not cube_products and not moment_products and not peak_products:
         return []
@@ -216,7 +220,6 @@ def _synth_and_write(
         peak_products=peak_products,
         output_prefix=output_prefix,
         moment_threshold_snr=moment_threshold_snr,
-        peak_threshold_snr=peak_threshold_snr,
     )
 
 
@@ -234,9 +237,9 @@ def test_rmsynth_all_products(tmp_path: Path, qu_cubes: tuple[Path, Path]) -> No
         output_prefix=output_prefix,
     )
 
-    # One zarr store holding all three cubes, three moments per label, and the
-    # CLEAN iteration count that every RM-CLEAN run writes
-    assert len(output_paths) == 1 + 3 * 3 + 1
+    # One zarr store holding all three cubes, every moment map per label, and
+    # the CLEAN iteration count that every RM-CLEAN run writes
+    assert len(output_paths) == 1 + 3 * len(_MOMENT_MAPS) + 1
     for path in output_paths:
         assert path.exists()
 
@@ -245,11 +248,14 @@ def test_rmsynth_all_products(tmp_path: Path, qu_cubes: tuple[Path, Path]) -> No
     )
 
     for label in ("dirty", "clean", "model"):
-        for moment in ("mom0", "mom1", "mom2"):
-            moment_path = Path(f"{output_prefix}.fdf.{label}.{moment}.fits")
+        for name, unit, _ in _MOMENT_MAPS.values():
+            moment_path = Path(f"{output_prefix}.fdf.{label}.{name}.fits")
             assert moment_path.exists()
             moment_header = fits.getheader(moment_path)
             assert moment_header["NAXIS"] == 2
+            # Jy/beam, rad/m2 and degrees now share the one set, so a moment
+            # map without its unit is easy to misread
+            assert moment_header["BUNIT"] == unit
 
     clean_mom1 = fits.getdata(Path(f"{output_prefix}.fdf.clean.mom1.fits"))
     assert np.allclose(clean_mom1, PHI_TRUE_RADM2, atol=5.0)
@@ -512,6 +518,54 @@ def test_stokes_i_model_rebuilds_from_the_written_term_maps(
     )
 
 
+def test_moment_errors_are_measured_rather_than_blank(
+    tmp_path: Path, qu_cubes: tuple[Path, Path]
+) -> None:
+    """Every error and debiased moment map is NaN unless the theoretical noise
+    is handed to ``calc_faraday_moments``, and rm-lite defaults it to None -- so
+    forgetting to pass it writes a full set of blank maps rather than failing.
+
+    The polarised intensity at the reference lambda^2 is the other new map: it
+    keeps the phase ``mom0`` throws away, so it cannot exceed ``mom0`` and its
+    angle is a real angle in degrees.
+    """
+    stokes_q_cube, stokes_u_cube = qu_cubes
+    output_prefix = tmp_path / "field"
+
+    _synth_and_write(
+        stokes_q_cube=stokes_q_cube,
+        stokes_u_cube=stokes_u_cube,
+        rmsynth_options=RMSynthOptions(),
+        rmclean_options=RMCleanOptions(),
+        cube_products=[],
+        moment_products=["clean"],
+        output_prefix=output_prefix,
+    )
+
+    def moment(name: str) -> np.ndarray:
+        return fits.getdata(Path(f"{output_prefix}.fdf.clean.{name}.fits"))
+
+    for name in ("mom0_error", "mom1_error", "mom2_error", "pi_lam_sq_0_error"):
+        assert np.all(np.isfinite(moment(name))), (
+            f"{name} is blank, so the theoretical noise never reached rm-lite"
+        )
+        assert np.all(moment(name) > 0.0), f"{name} is not a 1-sigma error"
+
+    mom0, mom0_debias = moment("mom0"), moment("mom0_debias")
+    assert np.all(np.isfinite(mom0_debias))
+    assert np.all(mom0_debias < mom0), "debiasing takes the noise's own sum off mom0"
+
+    pi_lam_sq_0 = moment("pi_lam_sq_0")
+    assert np.all(np.isfinite(pi_lam_sq_0))
+    # The coherent sum keeps the phase that mom0 discards, so it can only lose
+    # amplitude to it -- the ratio is the depolarisation at lambda^2_0
+    assert np.all(pi_lam_sq_0 <= mom0 * (1.0 + 1e-5))
+
+    pa_lam_sq_0 = moment("pa_lam_sq_0")
+    assert np.all(np.isfinite(pa_lam_sq_0))
+    assert np.all(np.abs(pa_lam_sq_0) <= 180.0)
+
+
 def test_rmsynth_debias_moments_runs(
     tmp_path: Path, qu_cubes: tuple[Path, Path]
 ) -> None:
@@ -534,8 +588,11 @@ def test_rmsynth_debias_moments_runs(
     assert mom0_path.exists()
     assert debiased_mom0_path in output_paths
     assert debiased_mom0_path.exists()
-    # Three moments, three debiased, plus the CLEAN iteration count
-    assert len(output_paths) == 6 + 1
+    # Every moment, every debiased moment, plus the CLEAN iteration count
+    assert len(output_paths) == len(_MOMENT_MAPS) + len(_DEBIASED_MOMENT_MAPS) + 1
+    # ``debias_fdf`` already takes the noise off each amplitude, so rm-lite's
+    # own mom0 debias is a no-op there and the map is not written twice
+    assert not Path(f"{output_prefix}.fdf.clean.mom0_debias.debiased.fits").exists()
 
 
 def test_rmsynth_writes_fdf_cubes_to_zarr(
@@ -601,9 +658,9 @@ def test_moment_only_never_computes_a_full_cube(
     assert computed_shapes, "expected a batched dask.compute call"
     # Every gathered array is a 2D map; a 3D shape means an FDF cube came back.
     assert all(len(shape) == 2 for shape in computed_shapes), computed_shapes
-    # 3 labels x mom0/mom1/mom2, and nothing else.
-    # Nine moment maps plus the CLEAN iteration count, all still (ny, nx)
-    assert len(computed_shapes) == 9 + 1
+    # 3 labels x every moment map, and nothing else, plus the CLEAN iteration
+    # count -- all still (ny, nx)
+    assert len(computed_shapes) == 3 * len(_MOMENT_MAPS) + 1
 
 
 def test_rmsynth_no_products_is_noop(
@@ -955,8 +1012,8 @@ def test_linmos_weights_through_to_the_moment_maps(
     )
 
     assert {path.name for path in output_paths} == {
-        f"{output_prefix.name}.fdf.clean.{moment}.fits"
-        for moment in ("mom0", "mom1", "mom2")
+        f"{output_prefix.name}.fdf.clean.{name}.fits"
+        for name, _, _ in _MOMENT_MAPS.values()
     } | {f"{output_prefix.name}.fdf.clean.niter.fits"}
 
     mom1 = fits.getdata(Path(f"{output_prefix}.fdf.clean.mom1.fits"))
@@ -1029,8 +1086,16 @@ def test_every_fdf_can_have_cubes_moments_and_peaks(
     # One zarr store holds every cube; moments and peaks are a file each
     assert f"{output_prefix.name}.fdf.zarr" in names
     for label in labels:
-        assert sum(f".{label}.mom" in name for name in names) == 3, label
-        assert sum(f".{label}.peak_" in name for name in names) == 9, label
+        moment_names = {
+            f"{output_prefix.name}.fdf.{label}.{name}.fits"
+            for name, _, _ in _MOMENT_MAPS.values()
+        }
+        peak_names = {
+            f"{output_prefix.name}.fdf.{label}.{name}.fits"
+            for name, _, _ in _PEAK_MAPS.values()
+        }
+        assert moment_names <= names, label
+        assert peak_names <= names, label
 
     # The peak Faraday depth is the recoverable truth in all three
     for label in labels:
@@ -1038,58 +1103,47 @@ def test_every_fdf_can_have_cubes_moments_and_peaks(
         assert np.nanmedian(peak_rm) == pytest.approx(PHI_TRUE_RADM2, abs=5.0), label
 
 
-def test_the_peak_and_moment_snr_cuts_are_independent(
+def test_the_moment_snr_cut_does_not_reach_the_peaks(
     tmp_path: Path, qu_cubes: tuple[Path, Path]
 ) -> None:
     """One cut used to serve both, so a noise estimate that blanked the moments
     took the peaks with it and the pair looked like a broken FDF rather than an
-    over-aggressive cut. They are separate options now, and each has to bite on
-    its own products only.
+    over-aggressive cut. Only the moments are cut now -- rm-lite dropped the
+    peak threshold entirely -- so the cut has to bite on the moments alone.
     """
     stokes_q_cube, stokes_u_cube = qu_cubes
+    output_prefix = tmp_path / "moments_cut"
 
-    def peak_pi_and_mom0(
-        prefix: str,
-        moment_threshold_snr: float = 5.0,
-        peak_threshold_snr: float = 0.0,
-    ) -> tuple[np.ndarray, np.ndarray]:
-        output_prefix = tmp_path / prefix
-        _synth_and_write(
-            stokes_q_cube=stokes_q_cube,
-            stokes_u_cube=stokes_u_cube,
-            rmsynth_options=RMSynthOptions(),
-            rmclean_options=RMCleanOptions(),
-            cube_products=[],
-            moment_products=["dirty"],
-            peak_products=["dirty"],
-            output_prefix=output_prefix,
-            moment_threshold_snr=moment_threshold_snr,
-            peak_threshold_snr=peak_threshold_snr,
-        )
-        return (
-            fits.getdata(Path(f"{output_prefix}.fdf.dirty.peak_pi.fits")),
-            fits.getdata(Path(f"{output_prefix}.fdf.dirty.mom0.fits")),
-        )
+    _synth_and_write(
+        stokes_q_cube=stokes_q_cube,
+        stokes_u_cube=stokes_u_cube,
+        rmsynth_options=RMSynthOptions(),
+        rmclean_options=RMCleanOptions(),
+        cube_products=[],
+        moment_products=["dirty"],
+        peak_products=["dirty"],
+        output_prefix=output_prefix,
+        # A cut nothing can clear, so anything it reaches is unmistakable
+        moment_threshold_snr=1e6,
+    )
+    peak_pi = fits.getdata(Path(f"{output_prefix}.fdf.dirty.peak_pi.fits"))
+    mom0 = fits.getdata(Path(f"{output_prefix}.fdf.dirty.mom0.fits"))
 
-    # A cut nothing can clear on one side leaves the other untouched. mom0 is
-    # nansum, so a fully cut spectrum reads 0 rather than NaN; a cut peak is NaN
-    peak_pi, mom0 = peak_pi_and_mom0("moments_cut", moment_threshold_snr=1e6)
     assert np.all(np.isfinite(peak_pi)), "the moment cut must not reach the peaks"
+    # mom0 is a nansum, so a fully cut spectrum reads 0 rather than NaN
     assert np.all(mom0 == 0.0)
 
-    peak_pi, mom0 = peak_pi_and_mom0("peaks_cut", peak_threshold_snr=1e6)
-    assert np.all(np.isnan(peak_pi))
-    assert np.all(mom0 > 0.0), "the peak cut must not reach the moments"
 
-
-def test_no_peak_cut_by_default_even_where_a_pixel_has_no_weight(
+def test_peaks_are_never_cut_even_where_a_pixel_has_no_weight(
     tmp_path: Path, qu_cubes: tuple[Path, Path]
 ) -> None:
-    """``peak_threshold_snr`` defaults to 0, meaning no cut at all. It cannot be
-    applied as ``0 * noise``: the theoretical noise is inf for a pixel linmos
-    blanked, ``0 * inf`` is NaN, and every comparison against NaN is False -- so
-    the cut meant to pass everything would instead blank the whole map."""
-    assert RMSynthFieldOptions().peak_threshold_snr == 0.0
+    """No SNR cut is applied to the peak maps: a peak is a single sample with no
+    noise floor to integrate, so ``peak_pi_error`` is written beside it and the
+    selection is made afterwards. Only the moment cut is left, and a zero there
+    cannot be applied as ``0 * noise``: the theoretical noise is inf for a pixel
+    linmos blanked, ``0 * inf`` is NaN, and every comparison against NaN is
+    False -- so the cut meant to pass everything would instead blank the map."""
+    assert not hasattr(RMSynthFieldOptions(), "peak_threshold_snr")
     assert _snr_threshold(0.0, np.float64(np.inf)) is None
     assert _snr_threshold(0.0, np.array([1e-5, np.inf])) is None
     assert _snr_threshold(5.0, np.float64(2.0)) == 10.0
@@ -1112,10 +1166,10 @@ def test_no_peak_cut_by_default_even_where_a_pixel_has_no_weight(
     peak_pi = fits.getdata(Path(f"{output_prefix}.fdf.dirty.peak_pi.fits"))
     inside_cutoff = _within_cutoff(1.5)
     assert np.all(np.isfinite(peak_pi[inside_cutoff])), (
-        "no cut was asked for, so every pixel carrying weight keeps its peak"
+        "no cut is applied, so every pixel carrying weight keeps its peak"
     )
     assert np.all(np.isnan(peak_pi[~inside_cutoff])), (
-        "a pixel linmos blanked has no FDF to peak, cut or no cut"
+        "a pixel linmos blanked has no FDF to peak"
     )
 
 
@@ -1402,8 +1456,49 @@ def test_rmclean_runs_once_per_chunk_on_a_distributed_client(
         cluster.close()
 
     assert len(tally.read_text()) == n_chunks, (
-        "nine moment maps off three FDFs must still clean each chunk once"
+        "every moment map off three FDFs must still clean each chunk once"
     )
+
+
+def test_products_sharing_a_dask_key_are_all_returned() -> None:
+    """Two products built from the same expression share a dask key, so
+    ``client.compute`` hands back a single future for both -- rm-lite derives
+    ``pi_lam_sq_0_error`` exactly as it does ``mom0_error``, so the moment maps
+    hit this on every run. Keying the results by future dropped all but the last
+    of each such group, which surfaced as a ``KeyError`` on a map that had in
+    fact been computed."""
+    from distributed import Client, LocalCluster
+
+    shared = da.arange(4, chunks=2) * 2.0
+    targets = {
+        "first": shared,
+        # A separate array with an identical graph, as rm-lite's two errors are
+        "second": da.arange(4, chunks=2) * 2.0,
+        "other": da.arange(4, chunks=2) + 1.0,
+    }
+
+    cluster = LocalCluster(
+        n_workers=1,
+        threads_per_worker=1,
+        processes=False,
+        dashboard_address=None,
+        silence_logs=logging.ERROR,
+    )
+    try:
+        with Client(cluster) as client:
+            computed = _compute_rm_products(
+                compute_targets=targets,
+                fuse_config={},
+                scheduler=client,
+                workload="test",
+            )
+    finally:
+        cluster.close()
+
+    assert set(computed) == set(targets)
+    assert np.allclose(computed["first"], [0.0, 2.0, 4.0, 6.0])
+    assert np.allclose(computed["second"], computed["first"])
+    assert np.allclose(computed["other"], [1.0, 2.0, 3.0, 4.0])
 
 
 def test_computing_from_inside_a_worker_does_not_deadlock() -> None:

--- a/tests/test_rmsynth.py
+++ b/tests/test_rmsynth.py
@@ -24,9 +24,9 @@ from flint.options import (
     WeightCubesForRMSynth,
 )
 from flint.rmsynth import (
-    _DEBIASED_MOMENT_MAPS,
-    _MOMENT_MAPS,
-    _PEAK_MAPS,
+    DEBIASED_MOMENT_MAPS,
+    MOMENT_MAPS,
+    PEAK_MAPS,
     FDFLabel,
     RMSynth3DResults,
     _compute_rm_products,
@@ -239,7 +239,7 @@ def test_rmsynth_all_products(tmp_path: Path, qu_cubes: tuple[Path, Path]) -> No
 
     # One zarr store holding all three cubes, every moment map per label, and
     # the CLEAN iteration count that every RM-CLEAN run writes
-    assert len(output_paths) == 1 + 3 * len(_MOMENT_MAPS) + 1
+    assert len(output_paths) == 1 + 3 * len(MOMENT_MAPS) + 1
     for path in output_paths:
         assert path.exists()
 
@@ -248,7 +248,7 @@ def test_rmsynth_all_products(tmp_path: Path, qu_cubes: tuple[Path, Path]) -> No
     )
 
     for label in ("dirty", "clean", "model"):
-        for name, unit, _ in _MOMENT_MAPS.values():
+        for name, unit, _ in MOMENT_MAPS.values():
             moment_path = Path(f"{output_prefix}.fdf.{label}.{name}.fits")
             assert moment_path.exists()
             moment_header = fits.getheader(moment_path)
@@ -589,7 +589,7 @@ def test_rmsynth_debias_moments_runs(
     assert debiased_mom0_path in output_paths
     assert debiased_mom0_path.exists()
     # Every moment, every debiased moment, plus the CLEAN iteration count
-    assert len(output_paths) == len(_MOMENT_MAPS) + len(_DEBIASED_MOMENT_MAPS) + 1
+    assert len(output_paths) == len(MOMENT_MAPS) + len(DEBIASED_MOMENT_MAPS) + 1
     # ``debias_fdf`` already takes the noise off each amplitude, so rm-lite's
     # own mom0 debias is a no-op there and the map is not written twice
     assert not Path(f"{output_prefix}.fdf.clean.mom0_debias.debiased.fits").exists()
@@ -660,7 +660,7 @@ def test_moment_only_never_computes_a_full_cube(
     assert all(len(shape) == 2 for shape in computed_shapes), computed_shapes
     # 3 labels x every moment map, and nothing else, plus the CLEAN iteration
     # count -- all still (ny, nx)
-    assert len(computed_shapes) == 3 * len(_MOMENT_MAPS) + 1
+    assert len(computed_shapes) == 3 * len(MOMENT_MAPS) + 1
 
 
 def test_rmsynth_no_products_is_noop(
@@ -1013,7 +1013,7 @@ def test_linmos_weights_through_to_the_moment_maps(
 
     assert {path.name for path in output_paths} == {
         f"{output_prefix.name}.fdf.clean.{name}.fits"
-        for name, _, _ in _MOMENT_MAPS.values()
+        for name, _, _ in MOMENT_MAPS.values()
     } | {f"{output_prefix.name}.fdf.clean.niter.fits"}
 
     mom1 = fits.getdata(Path(f"{output_prefix}.fdf.clean.mom1.fits"))
@@ -1088,11 +1088,11 @@ def test_every_fdf_can_have_cubes_moments_and_peaks(
     for label in labels:
         moment_names = {
             f"{output_prefix.name}.fdf.{label}.{name}.fits"
-            for name, _, _ in _MOMENT_MAPS.values()
+            for name, _, _ in MOMENT_MAPS.values()
         }
         peak_names = {
             f"{output_prefix.name}.fdf.{label}.{name}.fits"
-            for name, _, _ in _PEAK_MAPS.values()
+            for name, _, _ in PEAK_MAPS.values()
         }
         assert moment_names <= names, label
         assert peak_names <= names, label

--- a/tests/test_rmsynth.py
+++ b/tests/test_rmsynth.py
@@ -24,7 +24,6 @@ from flint.options import (
     WeightCubesForRMSynth,
 )
 from flint.rmsynth import (
-    DEBIASED_MOMENT_MAPS,
     MOMENT_MAPS,
     PEAK_MAPS,
     FDFLabel,
@@ -588,8 +587,9 @@ def test_rmsynth_debias_moments_runs(
     assert mom0_path.exists()
     assert debiased_mom0_path in output_paths
     assert debiased_mom0_path.exists()
-    # Every moment, every debiased moment, plus the CLEAN iteration count
-    assert len(output_paths) == len(MOMENT_MAPS) + len(DEBIASED_MOMENT_MAPS) + 1
+    # Every moment, every debiased moment but mom0_debias, plus the CLEAN
+    # iteration count
+    assert len(output_paths) == len(MOMENT_MAPS) + (len(MOMENT_MAPS) - 1) + 1
     # ``debias_fdf`` already takes the noise off each amplitude, so rm-lite's
     # own mom0 debias is a no-op there and the map is not written twice
     assert not Path(f"{output_prefix}.fdf.clean.mom0_debias.debiased.fits").exists()

--- a/uv.lock
+++ b/uv.lock
@@ -278,8 +278,8 @@ requires-dist = [
     { name = "racs-tools", specifier = ">=4.3.2" },
     { name = "radio-beam", specifier = ">=0.3.4" },
     { name = "reproject" },
-    { name = "rm-lite", marker = "extra == 'all'", specifier = "==2026.8.7" },
-    { name = "rm-lite", marker = "extra == 'rmsynth'", specifier = "==2026.8.7" },
+    { name = "rm-lite", marker = "extra == 'all'", specifier = "==2026.9.1" },
+    { name = "rm-lite", marker = "extra == 'rmsynth'", specifier = "==2026.9.1" },
     { name = "rocket-fft" },
     { name = "ruff", marker = "extra == 'all'" },
     { name = "ruff", marker = "extra == 'dev'" },
@@ -3494,7 +3494,7 @@ wheels = [
 
 [[package]]
 name = "rm-lite"
-version = "2026.8.7"
+version = "2026.9.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "astropy" },
@@ -3506,9 +3506,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "zarr" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6d/9f/c3d7d0260ae064d4e810b476aa4b7ce56298d0457617dc3b544a2a9611ab/rm_lite-2026.8.7.tar.gz", hash = "sha256:155519c3e4063bfa733c7da7f383001c9e47f6cdc5a51d9f33a6b8a06e60f68f", size = 447821, upload-time = "2026-08-31T02:52:55.402Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/fe/908095c26d0370932af23c71873b2a4cb8c8287afe46a87904a2fa11f98b/rm_lite-2026.9.1.tar.gz", hash = "sha256:4d1f04313c8323055bb60239577511e9dc048b0fce8c9d77118b7525616b920c", size = 454291, upload-time = "2026-09-06T13:31:26.321Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/44/1d/92c36880b4b3deb64710951fd2232a586010f872c9b80363e4d994fe88fe/rm_lite-2026.8.7-py3-none-any.whl", hash = "sha256:bf1760d5ebaeead154fb5b24cd600e18fe5c742a7044411469b15d8316002e75", size = 117925, upload-time = "2026-08-31T02:52:54.139Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/7d/0e16201e5ef83636abc76db1c1cb0015feb7af59b3a78227f45ae5e83af6/rm_lite-2026.9.1-py3-none-any.whl", hash = "sha256:a111292ea8f420a57a06bece38fe890a19fb44b0878dd13481d4eb9f718398ca", size = 120041, upload-time = "2026-09-06T13:31:24.912Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Bumps `rm-lite` to [v2026.9.1](https://github.com/AlecThomson/rm-lite/releases/tag/v2026.9.1) and wires in what it now returns.

## The new moment products

`FaradayMoments` gained an error for each moment, a debiased `mom0`, and the polarisation at the reference lambda^2. Those are the maps the moment set was missing: `mom0` alone says how much polarised flux a pixel integrates but nothing about whether it is a detection, and the peak maps have carried their errors for a while.

`_MOMENT_MAPS` replaces `_MOMENT_NAMES`, taking the same `{field: (suffix, BUNIT, comment)}` shape as `_PEAK_MAPS`. Twelve maps per requested FDF now:

| suffix | BUNIT | |
| --- | --- | --- |
| `mom0`, `mom0_debias`, `mom0_error` | Jy/beam | zeroth moment, less the noise's own sum, and its 1-sigma |
| `mom1`, `mom1_error` | rad/m2 | mean Faraday depth |
| `mom2`, `mom2_error` | rad/m2 | Faraday depth dispersion |
| `pi_lam_sq_0`, `pi_lam_sq_0_debias`, `pi_lam_sq_0_error` | Jy/beam | polarised intensity at lambda^2_0 |
| `pa_lam_sq_0`, `pa_lam_sq_0_error` | deg | polarisation angle there |

Each map is stamped with its unit. The moments used to be three maps that all read as fluxes; Jy/beam, rad/m2 and degrees now share the one set, so an unstamped map is easy to misread.

Two details worth flagging:

- The theoretical FDF noise is passed to `calc_faraday_moments`. rm-lite defaults `fdf_error` to `None`, and without it *every* error and debiased map comes back NaN rather than failing — so a test asserts they are actually measured.
- The `.debiased` set (`RMSynthOptions.debias_moments`) skips `mom0_debias`. `debias_fdf` already takes the noise off each amplitude, which is exactly what `mom0_debias` subtracts, so rm-lite returns `mom0` unchanged there and the map would be a byte-identical copy of the already-written one under a second name.

`pi_lam_sq_0` is only meaningful against a single reference wavelength, so `RMSynthOptions.lam_sq_0_m2` now notes that `per_pixel` leaves those two maps measuring every pixel at a different lambda^2.

## Dropping the peak SNR cut

rm-lite removed `threshold` from `calc_faraday_peaks`: the peak and its error are both reported now, so `peak_pi / peak_pi_error` is the SNR to select on afterwards. `peak_threshold_snr` goes with it, from `RMSynthFieldOptions` through `write_rm_products` and the prefect task.

It defaulted to `0.0` (no cut), so this changes nothing for a default run. **`BaseOptions` sets `extra: "forbid"`, so a config or strategy still setting `peak_threshold_snr` will now fail validation** rather than silently applying no cut. Nothing in this repo sets it. The moment cut (`moment_threshold_snr`) is untouched and still needed — `mom0` integrates the whole Faraday depth axis, so an uncut off-source pixel piles hundreds of noise samples into a positive floor.

## A latent bug the new maps exposed

`_compute_rm_products` keyed its results by `Future`. Products built from the same expression share a dask key, so `client.compute` hands back **one** future for all of them — and rm-lite derives `pi_lam_sq_0_error` exactly as it derives `mom0_error`. `dict(zip(futures, compute_keys))` then dropped all but the last key of each such group, surfacing as a `KeyError` on a map that had in fact been computed. The mapping is one-to-many now, and `test_products_sharing_a_dask_key_are_all_returned` pins it against a distributed client without depending on rm-lite continuing to build those two the same way.

## Testing

`tests/test_rmsynth.py`, `tests/test_prefect_rmsynth_flow.py`, `tests/test_racs_all_pipeline.py` and `tests/test_options.py` all pass (94 passed). Tests that counted moment maps by hand now count off `_MOMENT_MAPS`, so the next rm-lite moment does not need them edited again. Ruff clean; `mypy flint/rmsynth.py` reports only the pre-existing untyped-import and zarr `store` complaints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Skuoh52Dn8WdnNmvijZvR

---
_Generated by [Claude Code](https://claude.ai/code/session_018Skuoh52Dn8WdnNmvijZvR)_