### PR TITLE
Pin rm-lite to v2026.9.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ casa =[
     "fixms>=0.4.0"
 ]
 rmsynth = [
-    "rm-lite==2026.9.1",
+    "rm-lite==2026.9.2",
 ]
 all = [
     "askap-flint[dev,casa,rmsynth]",

--- a/uv.lock
+++ b/uv.lock
@@ -278,8 +278,8 @@ requires-dist = [
     { name = "racs-tools", specifier = ">=4.3.2" },
     { name = "radio-beam", specifier = ">=0.3.4" },
     { name = "reproject" },
-    { name = "rm-lite", marker = "extra == 'all'", specifier = "==2026.9.1" },
-    { name = "rm-lite", marker = "extra == 'rmsynth'", specifier = "==2026.9.1" },
+    { name = "rm-lite", marker = "extra == 'all'", specifier = "==2026.9.2" },
+    { name = "rm-lite", marker = "extra == 'rmsynth'", specifier = "==2026.9.2" },
     { name = "rocket-fft" },
     { name = "ruff", marker = "extra == 'all'" },
     { name = "ruff", marker = "extra == 'dev'" },
@@ -3494,7 +3494,7 @@ wheels = [
 
 [[package]]
 name = "rm-lite"
-version = "2026.9.1"
+version = "2026.9.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "astropy" },
@@ -3506,9 +3506,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "zarr" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/57/fe/908095c26d0370932af23c71873b2a4cb8c8287afe46a87904a2fa11f98b/rm_lite-2026.9.1.tar.gz", hash = "sha256:4d1f04313c8323055bb60239577511e9dc048b0fce8c9d77118b7525616b920c", size = 454291, upload-time = "2026-09-06T13:31:26.321Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5d/2d/5dd32b9962b36fa3cf0cfc743fd7e27f04cc55bf202361bbc44e7462e651/rm_lite-2026.9.2.tar.gz", hash = "sha256:6654ddf6a99f3e6a20ec9542c7f52a701c5895c9e1ae51dfb7844011934641fb", size = 461583, upload-time = "2026-09-09T01:40:37.255Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/7d/0e16201e5ef83636abc76db1c1cb0015feb7af59b3a78227f45ae5e83af6/rm_lite-2026.9.1-py3-none-any.whl", hash = "sha256:a111292ea8f420a57a06bece38fe890a19fb44b0878dd13481d4eb9f718398ca", size = 120041, upload-time = "2026-09-06T13:31:24.912Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/d0/4d16952fb4dcf83a40bf7a3416f01002ad6b87cd95f49ede6fe4e08c9708/rm_lite-2026.9.2-py3-none-any.whl", hash = "sha256:00a7386043723911583511c45ae988152f2f8651efd28518903c63ed761515ea", size = 121790, upload-time = "2026-09-09T01:40:35.235Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Bumps the `rmsynth` extra to [rm-lite v2026.9.2](https://github.com/AlecThomson/rm-lite/releases/tag/v2026.9.2), which makes the Stokes I fit robust to bad channels (AlecThomson/rm-lite#79) and stops Q/U being divided by an unusable Stokes I model (AlecThomson/rm-lite#80). `pyproject.toml` and `uv.lock` only.

## No flint code changes needed

Checked against the sdist diff, not just the release notes:

- Nothing flint calls changed shape. `rmsynth_3d_from_fits`, `run_rmclean_from_synth`, `calc_faraday_moments`, `calc_faraday_peaks`, `FaradayMoments` and `FaradayPeaks` all keep their signatures; `RMSynth3DResults` keeps its fields.
- The two new keywords, `stokes_i_robust_loss` (default `"cauchy"`) and `stokes_i_f_scale` (default 3.0), are additive. Flint passes neither, so it takes the robust fit by default. They could be surfaced on `RMSynthOptions` later, but the defaults are what we want and there is nothing to plumb for this bump.

`tests/test_rmsynth.py` (42 tests) and `tests/test_prefect_rmsynth_flow.py` + `tests/test_options.py` (27 tests) all pass against v2026.9.2.

## What does change in the products

Not "no functional changes" in the written maps, but every difference is a fix on pixels that were previously wrong. Running flint's `run_rmsynth_3d` over the same synthetic cube under both versions, with one channel boosted 5x and another given an error 1000x too small:

- `stokesi.alpha` came back at ≈-2.0 across the source under v2026.9.1 against a true -0.8, and at ≈-0.80 under v2026.9.2. The old failure was silent: the pixels still reported as fitted, with a finite model and a finite alpha.
- `stokesi.ref_flux` is now NaN on pixels that were never fitted (below `stokes_i_snr_cut`, or a negative pixel), where it used to export a mean of noise as a flux. It is NaN on exactly the pixels `stokesi.alpha` and `stokesi.model_order` already were, so fractional polarisation against it no longer has a meaningless denominator. Anything reading those maps should expect NaN there.
- A noise pixel whose flat model was 6e-16 no longer divides the FDF up to 236 Jy/beam — the flat fallback is 1.0 when the mean cannot safely divide.
- The SNR cut is now `median(I) * sqrt(n) / median(error)` rather than mean and rms, so one bad channel no longer decides whether a pixel is fitted. Which pixels get a flat model can therefore shift slightly near the cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Skuoh52Dn8WdnNmvijZvR


---
_Generated by [Claude Code](https://claude.ai/code/session_018Skuoh52Dn8WdnNmvijZvR)_