### PR TITLE
Take up rm-lite 2026.9.3, and expose the zarr conversion

### DIFF
--- a/flint/options.py
+++ b/flint/options.py
@@ -363,8 +363,8 @@ class RMSynthOptions(BaseOptions):
     """finufft OpenMP threads per dask chunk"""
     target_chunk_mb: float = 256
     """Target per-chunk memory footprint, in MB, when reading the Q/U cubes"""
-    convert_to_zarr: Path | None = None
-    """Directory to copy the cubes into as zarr stores before reading them, chunked as the FDF needs. Worth it for a cube wide enough that the chunking has to split the image width, since a FITS block narrower than the image still costs a full-width read. None reads the cubes where they are"""
+    convert_to_zarr: bool = False
+    """Convert the cubes to zarr beside the Stokes Q cube before reading them. Worth it for a wide image, where a FITS read is full-width whatever the chunk"""
     fit_order: int = 2
     """Stokes I fractional-polarisation fit order; negative iterates orders and picks the best by AIC"""
     fit_function: Literal["log", "linear"] = "log"

--- a/flint/options.py
+++ b/flint/options.py
@@ -364,7 +364,7 @@ class RMSynthOptions(BaseOptions):
     target_chunk_mb: float = 256
     """Target per-chunk memory footprint, in MB, when reading the Q/U cubes"""
     convert_to_zarr: bool = False
-    """Convert the cubes to zarr beside the Stokes Q cube before reading them. Worth it for a wide image, where a FITS read is full-width whatever the chunk"""
+    """Convert each cube to a zarr store beside it before reading, so cube.fits gives cube.zarr. Worth it for a wide image, where a FITS read is full-width whatever the chunk"""
     fit_order: int = 2
     """Stokes I fractional-polarisation fit order; negative iterates orders and picks the best by AIC"""
     fit_function: Literal["log", "linear"] = "log"

--- a/flint/options.py
+++ b/flint/options.py
@@ -363,6 +363,8 @@ class RMSynthOptions(BaseOptions):
     """finufft OpenMP threads per dask chunk"""
     target_chunk_mb: float = 256
     """Target per-chunk memory footprint, in MB, when reading the Q/U cubes"""
+    convert_to_zarr: Path | None = None
+    """Directory to copy the cubes into as zarr stores before reading them, chunked as the FDF needs. Worth it for a cube wide enough that the chunking has to split the image width, since a FITS block narrower than the image still costs a full-width read. None reads the cubes where they are"""
     fit_order: int = 2
     """Stokes I fractional-polarisation fit order; negative iterates orders and picks the best by AIC"""
     fit_function: Literal["log", "linear"] = "log"

--- a/flint/options.py
+++ b/flint/options.py
@@ -364,7 +364,7 @@ class RMSynthOptions(BaseOptions):
     target_chunk_mb: float = 256
     """Target per-chunk memory footprint, in MB, when reading the Q/U cubes"""
     convert_to_zarr: bool = False
-    """Convert each cube to a zarr store beside it before reading, so cube.fits gives cube.zarr. Worth it for a wide image, where a FITS read is full-width whatever the chunk"""
+    """Convert each FITS cube to a zarr store beside it before reading"""
     fit_order: int = 2
     """Stokes I fractional-polarisation fit order; negative iterates orders and picks the best by AIC"""
     fit_function: Literal["log", "linear"] = "log"

--- a/flint/rmsynth.py
+++ b/flint/rmsynth.py
@@ -120,7 +120,7 @@ def _check_cubes_memmappable(*cubes: Path | None) -> None:
         raise NotSupportedError(msg)
 
 
-def _check_cubes_are_single_precision(*cubes: Path | None) -> None:
+def check_cubes_are_single_precision(*cubes: Path | None) -> None:
     """rm-lite takes the FDF's precision from the cubes it is given, so a
     double-precision cube doubles every Faraday-depth array it builds. Warned
     about rather than refused: it is a memory cost, not an error."""
@@ -135,6 +135,20 @@ def _check_cubes_are_single_precision(*cubes: Path | None) -> None:
             "will be complex128 and take twice the memory. Write the cubes as "
             "float32 unless the extra precision is actually wanted."
         )
+
+
+def zarr_store_directory(
+    stokes_cubes: CubesForRMSynth, rmsynth_options: RMSynthOptions
+) -> Path | None:
+    """Where the converted cubes go, or None when the conversion is off.
+
+    Named after the Stokes Q cube rather than taken from the options: one
+    strategy file runs over many fields, so a directory set there would have
+    every field write ``q.zarr`` over the last one's.
+    """
+    if not rmsynth_options.convert_to_zarr:
+        return None
+    return stokes_cubes.q_path.parent / f"{stokes_cubes.q_path.stem}.zarr"
 
 
 def run_rmsynth_3d(
@@ -158,7 +172,7 @@ def run_rmsynth_3d(
     _check_cubes_memmappable(
         *stokes_cubes.paths, *(error_cubes.paths if error_cubes else ())
     )
-    _check_cubes_are_single_precision(*stokes_cubes.paths)
+    check_cubes_are_single_precision(*stokes_cubes.paths)
     stokes_i_kwargs = (
         {
             "stokes_i_file": stokes_cubes.i_path,
@@ -193,7 +207,7 @@ def run_rmsynth_3d(
         per_pixel_rmsf=rmsynth_options.per_pixel_rmsf,
         nufft_nthreads=rmsynth_options.nufft_nthreads,
         target_chunk_mb=rmsynth_options.target_chunk_mb,
-        convert_to_zarr=rmsynth_options.convert_to_zarr,
+        convert_to_zarr=zarr_store_directory(stokes_cubes, rmsynth_options),
         log_level=logging.INFO,
         **stokes_i_kwargs,
     )
@@ -446,7 +460,7 @@ def write_stokes_i_coeff_maps_to_fits(
     return output_paths
 
 
-def _snr_threshold(snr: float, fdf_error_noise: FDFThreshold) -> FDFThreshold:
+def fdf_threshold_from_snr(snr: float, fdf_error_noise: FDFThreshold) -> FDFThreshold:
     """An FDF amplitude cut ``snr`` times the theoretical noise, or None for no cut.
 
     Zero short-circuits rather than multiplying through: the noise is ``inf``
@@ -553,7 +567,7 @@ def _seceded_if_on_a_worker() -> Iterator[None]:
         rejoin()
 
 
-def _compute_rm_products(
+def compute_rm_products(
     compute_targets: dict[str, Any],
     fuse_config: dict[str, Any],
     scheduler: Client | str,
@@ -797,7 +811,7 @@ def write_rm_products(
     # (mom1/mom2 are then weighted by that noise and mean nothing). rm-lite
     # applies this same cut inside RM-CLEAN to its own moment maps, which flint
     # does not use, so it is rederived here from the shared theoretical noise.
-    moment_threshold = _snr_threshold(
+    moment_threshold = fdf_threshold_from_snr(
         moment_threshold_snr,
         synth_results.theoretical_noise.fdf_error_noise,
     )
@@ -895,7 +909,7 @@ def write_rm_products(
         if dask_client is not None
         else ("processes" if run_clean else "threads")
     )
-    computed = _compute_rm_products(
+    computed = compute_rm_products(
         compute_targets=compute_targets,
         fuse_config=fuse_config,
         scheduler=scheduler,

--- a/flint/rmsynth.py
+++ b/flint/rmsynth.py
@@ -193,6 +193,7 @@ def run_rmsynth_3d(
         per_pixel_rmsf=rmsynth_options.per_pixel_rmsf,
         nufft_nthreads=rmsynth_options.nufft_nthreads,
         target_chunk_mb=rmsynth_options.target_chunk_mb,
+        convert_to_zarr=rmsynth_options.convert_to_zarr,
         log_level=logging.INFO,
         **stokes_i_kwargs,
     )

--- a/flint/rmsynth.py
+++ b/flint/rmsynth.py
@@ -137,20 +137,6 @@ def check_cubes_are_single_precision(*cubes: Path | None) -> None:
         )
 
 
-def zarr_store_directory(
-    stokes_cubes: CubesForRMSynth, rmsynth_options: RMSynthOptions
-) -> Path | None:
-    """Where the converted cubes go, or None when the conversion is off.
-
-    Named after the Stokes Q cube rather than taken from the options: one
-    strategy file runs over many fields, so a directory set there would have
-    every field write ``q.zarr`` over the last one's.
-    """
-    if not rmsynth_options.convert_to_zarr:
-        return None
-    return stokes_cubes.q_path.parent / f"{stokes_cubes.q_path.stem}.zarr"
-
-
 def run_rmsynth_3d(
     stokes_cubes: CubesForRMSynth,
     rmsynth_options: RMSynthOptions,
@@ -207,7 +193,7 @@ def run_rmsynth_3d(
         per_pixel_rmsf=rmsynth_options.per_pixel_rmsf,
         nufft_nthreads=rmsynth_options.nufft_nthreads,
         target_chunk_mb=rmsynth_options.target_chunk_mb,
-        convert_to_zarr=zarr_store_directory(stokes_cubes, rmsynth_options),
+        convert_to_zarr=rmsynth_options.convert_to_zarr,
         log_level=logging.INFO,
         **stokes_i_kwargs,
     )

--- a/flint/rmsynth.py
+++ b/flint/rmsynth.py
@@ -120,6 +120,23 @@ def _check_cubes_memmappable(*cubes: Path | None) -> None:
         raise NotSupportedError(msg)
 
 
+def _check_cubes_are_single_precision(*cubes: Path | None) -> None:
+    """rm-lite takes the FDF's precision from the cubes it is given, so a
+    double-precision cube doubles every Faraday-depth array it builds. Warned
+    about rather than refused: it is a memory cost, not an error."""
+    double = [
+        cube
+        for cube in cubes
+        if cube is not None and fits.getheader(cube).get("BITPIX") == -64
+    ]
+    if double:
+        logger.warning(
+            f"{double} are double precision, so the FDF, RMSF and CLEAN cubes "
+            "will be complex128 and take twice the memory. Write the cubes as "
+            "float32 unless the extra precision is actually wanted."
+        )
+
+
 def run_rmsynth_3d(
     stokes_cubes: CubesForRMSynth,
     rmsynth_options: RMSynthOptions,
@@ -141,6 +158,7 @@ def run_rmsynth_3d(
     _check_cubes_memmappable(
         *stokes_cubes.paths, *(error_cubes.paths if error_cubes else ())
     )
+    _check_cubes_are_single_precision(*stokes_cubes.paths)
     stokes_i_kwargs = (
         {
             "stokes_i_file": stokes_cubes.i_path,
@@ -497,7 +515,8 @@ def _describe_rm_workload(
     per_pixel_rmsf = synth_results.rmsf_cube is not None
     return (
         f"{len(compute_keys)} products over {n_y}x{n_x} pixels and {n_phi} "
-        f"Faraday depths, in {n_chunks} chunks; "
+        f"Faraday depths in {fdf_cube.dtype}, in {n_chunks} chunks of "
+        f"{fdf_cube.chunksize[1]}x{fdf_cube.chunksize[2]} pixels; "
         f"per-pixel RMSF {'on' if per_pixel_rmsf else 'off'}"
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ casa =[
     "fixms>=0.4.0"
 ]
 rmsynth = [
-    "rm-lite==2026.9.3",
+    "rm-lite==2026.9.4",
 ]
 all = [
     "askap-flint[dev,casa,rmsynth]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ casa =[
     "fixms>=0.4.0"
 ]
 rmsynth = [
-    "rm-lite==2026.9.2",
+    "rm-lite==2026.9.3",
 ]
 all = [
     "askap-flint[dev,casa,rmsynth]",

--- a/tests/test_rmsynth.py
+++ b/tests/test_rmsynth.py
@@ -28,6 +28,7 @@ from flint.rmsynth import (
     PEAK_MAPS,
     FDFLabel,
     RMSynth3DResults,
+    _check_cubes_are_single_precision,
     _compute_rm_products,
     _snr_threshold,
     needs_rmclean,
@@ -682,6 +683,26 @@ def test_rmsynth_no_products_is_noop(
     assert not list(tmp_path.glob("*.fits")) or all(
         p in (stokes_q_cube, stokes_u_cube) for p in tmp_path.glob("*.fits")
     )
+
+
+def test_rmsynth_warns_about_double_precision_cubes(tmp_path, caplog) -> None:
+    """rm-lite takes the FDF's precision from the cubes, so a float64 cube
+    silently doubles every Faraday-depth array it builds."""
+    stokes_q_cube, stokes_u_cube = _make_qu_cubes(tmp_path)
+
+    with caplog.at_level("WARNING"):
+        _check_cubes_are_single_precision(stokes_q_cube, stokes_u_cube)
+    assert "double precision" not in caplog.text
+
+    doubled = tmp_path / "q_f8.fits"
+    with fits.open(stokes_q_cube) as hdul:
+        fits.PrimaryHDU(hdul[0].data.astype(np.float64), header=hdul[0].header).writeto(
+            doubled
+        )
+
+    with caplog.at_level("WARNING"):
+        _check_cubes_are_single_precision(doubled, stokes_u_cube)
+    assert "double precision" in caplog.text
 
 
 def test_rmsynth_rejects_compressed_cubes(tmp_path: Path) -> None:

--- a/tests/test_rmsynth.py
+++ b/tests/test_rmsynth.py
@@ -28,9 +28,9 @@ from flint.rmsynth import (
     PEAK_MAPS,
     FDFLabel,
     RMSynth3DResults,
-    _check_cubes_are_single_precision,
-    _compute_rm_products,
-    _snr_threshold,
+    check_cubes_are_single_precision,
+    compute_rm_products,
+    fdf_threshold_from_snr,
     needs_rmclean,
     run_rmclean_3d,
     run_rmsynth_3d,
@@ -691,7 +691,7 @@ def test_rmsynth_warns_about_double_precision_cubes(tmp_path, caplog) -> None:
     stokes_q_cube, stokes_u_cube = _make_qu_cubes(tmp_path)
 
     with caplog.at_level("WARNING"):
-        _check_cubes_are_single_precision(stokes_q_cube, stokes_u_cube)
+        check_cubes_are_single_precision(stokes_q_cube, stokes_u_cube)
     assert "double precision" not in caplog.text
 
     doubled = tmp_path / "q_f8.fits"
@@ -701,7 +701,7 @@ def test_rmsynth_warns_about_double_precision_cubes(tmp_path, caplog) -> None:
         )
 
     with caplog.at_level("WARNING"):
-        _check_cubes_are_single_precision(doubled, stokes_u_cube)
+        check_cubes_are_single_precision(doubled, stokes_u_cube)
     assert "double precision" in caplog.text
 
 
@@ -804,7 +804,7 @@ def test_rmsynth_options_reach_rm_lite(
     rmsynth_options = RMSynthOptions(
         per_pixel_rmsf=True,
         estimate_stokes_i_noise=False,
-        convert_to_zarr=tmp_path / "stores",
+        convert_to_zarr=True,
     )
     with pytest.raises(NotSupportedError, match="stop before synthesising"):
         _run_rmsynth_3d(
@@ -816,9 +816,16 @@ def test_rmsynth_options_reach_rm_lite(
 
     # Applied by flint after rm-lite returns, so they have nothing to forward.
     flint_side = {"debias_moments", "debias_filter_size"}
-    for field in set(type(rmsynth_options).model_fields) - flint_side:
+    # A bool here, but rm-lite wants the directory flint picks for it.
+    transformed = {"convert_to_zarr"}
+    for field in set(type(rmsynth_options).model_fields) - flint_side - transformed:
         assert field in captured, f"{field} never reaches rm-lite"
         assert captured[field] == getattr(rmsynth_options, field)
+
+    assert (
+        captured["convert_to_zarr"]
+        == stokes_q_cube.parent / f"{stokes_q_cube.stem}.zarr"
+    )
 
 
 def _within_cutoff(blank_outside: float) -> np.ndarray:
@@ -1172,9 +1179,9 @@ def test_peaks_are_never_cut_even_where_a_pixel_has_no_weight(
     linmos blanked, ``0 * inf`` is NaN, and every comparison against NaN is
     False -- so the cut meant to pass everything would instead blank the map."""
     assert not hasattr(RMSynthFieldOptions(), "peak_threshold_snr")
-    assert _snr_threshold(0.0, np.float64(np.inf)) is None
-    assert _snr_threshold(0.0, np.array([1e-5, np.inf])) is None
-    assert _snr_threshold(5.0, np.float64(2.0)) == 10.0
+    assert fdf_threshold_from_snr(0.0, np.float64(np.inf)) is None
+    assert fdf_threshold_from_snr(0.0, np.array([1e-5, np.inf])) is None
+    assert fdf_threshold_from_snr(5.0, np.float64(2.0)) == 10.0
 
     stokes_q_cube, stokes_u_cube = qu_cubes
     output_prefix = tmp_path / "default_cut"
@@ -1431,7 +1438,7 @@ def test_rmclean_runs_once_per_chunk_on_a_distributed_client(
     """The same once-per-chunk guarantee as the threaded test, on the path a real
     pipeline run takes.
 
-    ``_compute_rm_products`` submits to a distributed Client as futures so it can
+    ``compute_rm_products`` submits to a distributed Client as futures so it can
     report each product as it lands. Submitting them one at a time instead would
     rebuild the shared synthesis/RM-CLEAN graph per product -- invisible in the
     output, just N times the runtime of the slowest stage. The threaded test
@@ -1514,7 +1521,7 @@ def test_products_sharing_a_dask_key_are_all_returned() -> None:
     )
     try:
         with Client(cluster) as client:
-            computed = _compute_rm_products(
+            computed = compute_rm_products(
                 compute_targets=targets,
                 fuse_config={},
                 scheduler=client,
@@ -1546,10 +1553,10 @@ def test_computing_from_inside_a_worker_does_not_deadlock() -> None:
     import dask
     from distributed import Client, LocalCluster, get_client
 
-    from flint.rmsynth import _compute_rm_products
+    from flint.rmsynth import compute_rm_products
 
     def compute_on_the_worker() -> dict[str, object]:
-        return _compute_rm_products(
+        return compute_rm_products(
             compute_targets={"only": dask.delayed(int)(7)},
             fuse_config={},
             scheduler=get_client(),
@@ -1582,7 +1589,7 @@ def test_a_failed_product_is_raised_not_dropped(tmp_path: Path) -> None:
     import dask
     from distributed import Client, LocalCluster
 
-    from flint.rmsynth import _compute_rm_products
+    from flint.rmsynth import compute_rm_products
 
     def explode() -> None:
         msg = "this product could not be computed"
@@ -1598,7 +1605,7 @@ def test_a_failed_product_is_raised_not_dropped(tmp_path: Path) -> None:
     try:
         with Client(cluster) as client:
             with pytest.raises(ValueError, match="could not be computed"):
-                _compute_rm_products(
+                compute_rm_products(
                     compute_targets={
                         "fine": dask.delayed(int)(1),
                         "broken": dask.delayed(explode)(),

--- a/tests/test_rmsynth.py
+++ b/tests/test_rmsynth.py
@@ -816,16 +816,9 @@ def test_rmsynth_options_reach_rm_lite(
 
     # Applied by flint after rm-lite returns, so they have nothing to forward.
     flint_side = {"debias_moments", "debias_filter_size"}
-    # A bool here, but rm-lite wants the directory flint picks for it.
-    transformed = {"convert_to_zarr"}
-    for field in set(type(rmsynth_options).model_fields) - flint_side - transformed:
+    for field in set(type(rmsynth_options).model_fields) - flint_side:
         assert field in captured, f"{field} never reaches rm-lite"
         assert captured[field] == getattr(rmsynth_options, field)
-
-    assert (
-        captured["convert_to_zarr"]
-        == stokes_q_cube.parent / f"{stokes_q_cube.stem}.zarr"
-    )
 
 
 def _within_cutoff(blank_outside: float) -> np.ndarray:

--- a/tests/test_rmsynth.py
+++ b/tests/test_rmsynth.py
@@ -801,7 +801,11 @@ def test_rmsynth_options_reach_rm_lite(
     monkeypatch.setattr(rmsynth_mod, "rmsynth_3d_from_fits", _capture)
 
     stokes_q_cube, stokes_u_cube = qu_cubes
-    rmsynth_options = RMSynthOptions(per_pixel_rmsf=True, estimate_stokes_i_noise=False)
+    rmsynth_options = RMSynthOptions(
+        per_pixel_rmsf=True,
+        estimate_stokes_i_noise=False,
+        convert_to_zarr=tmp_path / "stores",
+    )
     with pytest.raises(NotSupportedError, match="stop before synthesising"):
         _run_rmsynth_3d(
             stokes_q_cube=stokes_q_cube,
@@ -810,8 +814,11 @@ def test_rmsynth_options_reach_rm_lite(
             rmsynth_options=rmsynth_options,
         )
 
-    assert captured["per_pixel_rmsf"] is True
-    assert captured["estimate_stokes_i_noise"] is False
+    # Applied by flint after rm-lite returns, so they have nothing to forward.
+    flint_side = {"debias_moments", "debias_filter_size"}
+    for field in set(type(rmsynth_options).model_fields) - flint_side:
+        assert field in captured, f"{field} never reaches rm-lite"
+        assert captured[field] == getattr(rmsynth_options, field)
 
 
 def _within_cutoff(blank_outside: float) -> np.ndarray:

--- a/uv.lock
+++ b/uv.lock
@@ -278,8 +278,8 @@ requires-dist = [
     { name = "racs-tools", specifier = ">=4.3.2" },
     { name = "radio-beam", specifier = ">=0.3.4" },
     { name = "reproject" },
-    { name = "rm-lite", marker = "extra == 'all'", specifier = "==2026.9.2" },
-    { name = "rm-lite", marker = "extra == 'rmsynth'", specifier = "==2026.9.2" },
+    { name = "rm-lite", marker = "extra == 'all'", specifier = "==2026.9.3" },
+    { name = "rm-lite", marker = "extra == 'rmsynth'", specifier = "==2026.9.3" },
     { name = "rocket-fft" },
     { name = "ruff", marker = "extra == 'all'" },
     { name = "ruff", marker = "extra == 'dev'" },
@@ -3494,7 +3494,7 @@ wheels = [
 
 [[package]]
 name = "rm-lite"
-version = "2026.9.2"
+version = "2026.9.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "astropy" },
@@ -3506,9 +3506,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "zarr" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5d/2d/5dd32b9962b36fa3cf0cfc743fd7e27f04cc55bf202361bbc44e7462e651/rm_lite-2026.9.2.tar.gz", hash = "sha256:6654ddf6a99f3e6a20ec9542c7f52a701c5895c9e1ae51dfb7844011934641fb", size = 461583, upload-time = "2026-09-09T01:40:37.255Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/86/02/2bf8c44381b10bcf9f20f84b1757e82016ade096097fe5f566cf374a08c4/rm_lite-2026.9.3.tar.gz", hash = "sha256:7294b39268094c92f6271b1dd49df4938a9d8df4e0273749a37aec2a3f77eb9c", size = 416754, upload-time = "2026-09-10T07:03:03.991Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a5/d0/4d16952fb4dcf83a40bf7a3416f01002ad6b87cd95f49ede6fe4e08c9708/rm_lite-2026.9.2-py3-none-any.whl", hash = "sha256:00a7386043723911583511c45ae988152f2f8651efd28518903c63ed761515ea", size = 121790, upload-time = "2026-09-09T01:40:35.235Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/a1/1e95ad86491ff6d18dbd0be6b24cf340c2d1c53bc2f37611946adfa72472/rm_lite-2026.9.3-py3-none-any.whl", hash = "sha256:c3e409f5f7d7a2d8090d62397068c7be73eca64054f173716ae9c2ce78025f0c", size = 127887, upload-time = "2026-09-10T07:03:02.579Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -278,8 +278,8 @@ requires-dist = [
     { name = "racs-tools", specifier = ">=4.3.2" },
     { name = "radio-beam", specifier = ">=0.3.4" },
     { name = "reproject" },
-    { name = "rm-lite", marker = "extra == 'all'", specifier = "==2026.9.3" },
-    { name = "rm-lite", marker = "extra == 'rmsynth'", specifier = "==2026.9.3" },
+    { name = "rm-lite", marker = "extra == 'all'", specifier = "==2026.9.4" },
+    { name = "rm-lite", marker = "extra == 'rmsynth'", specifier = "==2026.9.4" },
     { name = "rocket-fft" },
     { name = "ruff", marker = "extra == 'all'" },
     { name = "ruff", marker = "extra == 'dev'" },
@@ -3494,7 +3494,7 @@ wheels = [
 
 [[package]]
 name = "rm-lite"
-version = "2026.9.3"
+version = "2026.9.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "astropy" },
@@ -3506,9 +3506,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "zarr" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/86/02/2bf8c44381b10bcf9f20f84b1757e82016ade096097fe5f566cf374a08c4/rm_lite-2026.9.3.tar.gz", hash = "sha256:7294b39268094c92f6271b1dd49df4938a9d8df4e0273749a37aec2a3f77eb9c", size = 416754, upload-time = "2026-09-10T07:03:03.991Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/5c/18e0d1967d4995348d68c67f80979312d0f94a1421f2cad15d79d6abff1f/rm_lite-2026.9.4.tar.gz", hash = "sha256:1719eb00d1f517eb284b50241533d9921eabe61f5aa2199094fe2f18c40fbdea", size = 416804, upload-time = "2026-09-10T07:36:32.697Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/a1/1e95ad86491ff6d18dbd0be6b24cf340c2d1c53bc2f37611946adfa72472/rm_lite-2026.9.3-py3-none-any.whl", hash = "sha256:c3e409f5f7d7a2d8090d62397068c7be73eca64054f173716ae9c2ce78025f0c", size = 127887, upload-time = "2026-09-10T07:03:02.579Z" },
+    { url = "https://files.pythonhosted.org/packages/71/ee/f9eb11aa67e06d43ee21ab755b204caf3c3a875937cd8cd21a8ef896ab09/rm_lite-2026.9.4-py3-none-any.whl", hash = "sha256:bf4b39d3abd18f6863fca1114b3b940fb9642c1d10917c636a4a0aae637f8033", size = 128004, upload-time = "2026-09-10T07:36:31.182Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Companion to AlecThomson/rm-lite#81, #82, #83 and #84, which came out of a RACS field whose RM-synthesis stage died with `KilledWorker`.

rm-lite now takes the FDF's precision from the cubes it is handed rather than always using complex128. flint feeds it float32 cubes, so it gets complex64 and halves the memory of every Faraday-depth array for free.

## Pin

`rm-lite==2026.9.4`, which carries the precision and task-graph work (#81), the zarr IO (#82), the `convert_to_zarr` bool (#83) and `py.typed` (#84). `uv.lock` regenerated with `uv lock`.

That line raises rm-lite's floor to Python 3.11, because sharded zarr writes need zarr 3. flint already requires `>=3.11,<3.14`, so nothing changes here.

`py.typed` means mypy now type-checks flint's calls into rm-lite instead of skipping them as untyped. flint's mypy hook runs isolated without rm-lite installed, so CI is unaffected; the benefit shows up running mypy in a real environment.

## Expose the zarr conversion

`RMSynthOptions.convert_to_zarr` is a bool, passed straight to `rmsynth_3d_from_fits`. rm-lite converts each cube to a store beside it, named after it:

```
SB9999.beam00.q.cube.fits  ->  SB9999.beam00.q.cube.zarr
SB9999.beam00.u.cube.fits  ->  SB9999.beam00.u.cube.zarr
SB9999.beam00.i.cube.fits  ->  SB9999.beam00.i.cube.zarr
```

Worth setting for a cube wide enough that the chunking has to split the image width. A FITS cube is one contiguous array, so a block narrower than the image still costs a full-width read; a zarr chunk costs itself. On the cube rm-lite measured, one 0.2 MiB block cost 512 MiB resident from FITS against 11 MiB from a store. Off by default, since it copies the data.

Checked end to end through the real path rather than the mocked one: with the flag off no stores are written, with it on exactly those three appear, and `max |plain - converted| = 0.0`.

## Warn on a double-precision cube

If a float64 cube ever reaches the RM-synthesis stage, the FDF, RMSF and CLEAN cubes all become complex128 and every Faraday-depth array doubles. That would now be silent, so `check_cubes_are_single_precision` reads the BITPIX of each Stokes cube and warns. Warned rather than refused: it costs memory, it is not wrong, and rewriting a 16 GB cube is not something the pipeline should do on its own.

## Report the precision and the chunk shape

`_describe_rm_workload` now includes the FDF's dtype and the spatial chunk shape:

```
69 products over 17000x19533 pixels and 587 Faraday depths in complex64,
in 3400 chunks of 5x19533 pixels; per-pixel RMSF on
```

Both were invisible before. On the failing run the log said "in 17000 chunks" and nothing about how big one was, which is the number that actually explains a killed worker. `target_chunk_mb` was also being silently ignored from the FITS entry point (fixed in rm-lite), and this line is where that would have shown.

## Review follow-ups

- `convert_to_zarr` is a bool rather than a path. A strategy file is reused across fields, so a directory set there would have every field write over the last one's stores. Fixed properly in rm-lite #83 by naming stores after their cubes, which removes the failure mode for every caller rather than just this one.
- `check_cubes_are_single_precision`, `compute_rm_products` and `fdf_threshold_from_snr` dropped their underscores, since the tests import them. The last also says what it returns.
- `test_rmsynth_options_reach_rm_lite` now checks that every `RMSynthOptions` field reaches rm-lite, rather than the two it happened to assert. Its docstring already claimed the general property. `debias_moments` and `debias_filter_size` are named as the exceptions, since flint applies those itself after rm-lite returns.

`uv run pytest tests/test_rmsynth.py` passes (43 tests) against a clean `uv sync` of the new pin. `pre-commit run --all-files` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AN9y36hf41ZmfkLQPnd4AN

---
_Generated by [Claude Code](https://claude.ai/code/session_01AN9y36hf41ZmfkLQPnd4AN)_