### PR TITLE
Split cubes into planes in one pass

### DIFF
--- a/flint/imager/wsclean.py
+++ b/flint/imager/wsclean.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import re
 import socket
+import time
 from argparse import ArgumentParser
 from collections.abc import Collection
 from glob import glob
@@ -34,8 +35,13 @@ from capn_crunch import (
 )
 from fitscube.bounding_box import BoundingBox
 from fitscube.combine_fits import combine_fits, compress_cube
-from fitscube.exceptions import TargetAxisMissingException
-from fitscube.extract import ExtractOptions, extract_plane_from_cube, find_target_axis
+from fitscube.exceptions import ShapeMismatchException, TargetAxisMissingException
+from fitscube.extract import (
+    ExtractPlanesOptions,
+    count_cube_planes,
+    extract_planes_from_cube,
+    find_target_axis,
+)
 
 from flint.exceptions import (
     AttemptRerunException,
@@ -243,27 +249,6 @@ def image_set_from_result(wsclean_result: WSCleanResult) -> ImageSet | None:
     return wsclean_result.image_set
 
 
-def assert_common_pixel_grid(images: Collection[Path]) -> None:
-    """Ensure a set of images all share the same spatial pixel grid.
-
-    ``fitscube`` writes each plane into the cube at a fixed byte offset, so
-    planes of differing shape are silently interleaved rather than rejected.
-
-    Args:
-        images (Collection[Path]): The images that will be stacked into a cube
-
-    Raises:
-        ShapeMismatchError: If the images do not share a common NAXIS1/NAXIS2
-    """
-    shapes = {
-        (header["NAXIS1"], header["NAXIS2"])
-        for header in (fits.getheader(image) for image in images)
-    }
-    if len(shapes) > 1:
-        msg = f"Images to be cubed have differing pixel grids: {shapes=}"
-        raise ShapeMismatchError(msg)
-
-
 def combine_images_to_cube(
     images: list[Path],
     prefix: str,
@@ -291,25 +276,33 @@ def combine_images_to_cube(
     logger.info("Combining subband images into fits cubes")
     logger.info(f"Running on {socket.gethostname()=}")
 
-    assert_common_pixel_grid(images=images)
-
     output_cube_name = create_image_cube_name(image_prefix=Path(prefix), mode=mode)
 
-    logger.info(f"Combining {len(images)} images. {images=}")
-    freqs = combine_fits(
-        file_list=images,
-        out_cube=output_cube_name,
-        max_workers=fitscube_options.max_workers,
-        invalidate_zeros=fitscube_options.invalidate_zeros,
-        bounding_box=fitscube_options.bounding_box
-        if bounding_box is None
-        else bounding_box,
-        create_blanks=fitscube_options.create_blanks,
+    logger.info(f"Combining {len(images)} images into {output_cube_name}")
+    logger.debug(f"{images=}")
+    start = time.perf_counter()
+    # fitscube checks the pixel grids itself, in parallel, before it writes
+    # anything, so there is no need to walk every header again first
+    try:
+        freqs = combine_fits(
+            file_list=images,
+            out_cube=output_cube_name,
+            max_workers=fitscube_options.max_workers,
+            invalidate_zeros=fitscube_options.invalidate_zeros,
+            bounding_box=fitscube_options.bounding_box
+            if bounding_box is None
+            else bounding_box,
+            create_blanks=fitscube_options.create_blanks,
+        )
+    except ShapeMismatchException as e:
+        msg = f"Images to be cubed have differing pixel grids: {e}"
+        raise ShapeMismatchError(msg) from e
+    logger.info(
+        f"Combined {len(images)} images into {output_cube_name.name} in "
+        f"{time.perf_counter() - start:.0f}s"
     )
-    rotate_cube(output_cube_name, inplace=fitscube_options.inplace)
 
-    # Write out the hdu to preserve the beam table constructed in fitscube
-    logger.info(f"Writing {output_cube_name=}")
+    rotate_cube(output_cube_name, inplace=fitscube_options.inplace)
 
     output_freqs_name = output_cube_name.with_suffix(".freqs_Hz.txt")
     np.savetxt(output_freqs_name, freqs.to("Hz").value)
@@ -318,8 +311,12 @@ def combine_images_to_cube(
         remove_files_folders(*images)
 
     if fitscube_options.compress:
+        start = time.perf_counter()
         output_cube_name = compress_cube(
             output_cube_name, method=fitscube_options.compress_method
+        )
+        logger.info(
+            f"Compressed to {output_cube_name.name} in {time.perf_counter() - start:.0f}s"
         )
 
     return output_cube_name
@@ -484,7 +481,9 @@ def transpose_and_sort_channel_images(
     return [list(channel_group) for channel_group in zip(*sorted_beams)]
 
 
-def split_cube_into_planes(cube: Path, output_path: Path | None = None) -> list[Path]:
+def split_cube_into_planes(
+    cube: Path, output_path: Path | None = None, num_workers: int = 4
+) -> list[Path]:
     """Extract each channel of a FITS cube into its own image, named following the
     flint processed name format so that the planes may be regrouped across beams
     by ``transpose_and_sort_channel_images``.
@@ -492,21 +491,22 @@ def split_cube_into_planes(cube: Path, output_path: Path | None = None) -> list[
     Args:
         cube (Path): The FITS cube to split apart
         output_path (Path | None, optional): Directory the planes are written into. Only the flint name fields are retained, so cubes that share them (e.g. an image cube and its weights) need separate directories. Defaults to alongside ``cube``.
+        num_workers (int, optional): Planes written at once. Defaults to 4.
 
     Returns:
         list[Path]: The per-channel images extracted from ``cube``
 
     Raises:
-        NotSupportedError: If ``cube`` is gzip-compressed. Splitting reopens
-            the cube once per channel, and astropy cannot memmap a gzip file,
-            so each reopen decompresses the entire cube into memory. Set
-            ``FitsCubeOptions.compress=False`` for cubes that get split.
+        NotSupportedError: If ``cube`` is gzip-compressed, as astropy cannot
+            memmap a compressed FITS file and would decompress the whole cube
+            into memory. Set ``FitsCubeOptions.compress=False`` for cubes that
+            get split.
     """
     if cube.suffix == ".gz":
         msg = (
             f"{cube=} is gzip-compressed and cannot be split into planes: "
-            "astropy cannot memmap a compressed FITS file, so each of the "
-            "per-channel reads would decompress the whole cube into memory. "
+            "astropy cannot memmap a compressed FITS file, so the per-channel "
+            "reads would decompress the whole cube into memory. "
             "Disable FitsCubeOptions.compress for cubes that will be split."
         )
         raise NotSupportedError(msg)
@@ -519,11 +519,6 @@ def split_cube_into_planes(cube: Path, output_path: Path | None = None) -> list[
     if output_path is not None:
         output_path.mkdir(parents=True, exist_ok=True)
 
-    with fits.open(cube, memmap=True, lazy_load_hdus=True) as open_fits:
-        header = open_fits[0].header
-    channels = int(header[f"NAXIS{find_target_axis(header=header).axis}"])
-    logger.info(f"Splitting {cube} into {channels} planes")
-
     def _plane_path(channel: int) -> Path:
         # Only the flint name fields are retained, so a single cube per beam
         # should be split at a time to avoid clobbering planes
@@ -535,15 +530,17 @@ def split_cube_into_planes(cube: Path, output_path: Path | None = None) -> list[
         )
         return Path(f"{plane_base}.fits")
 
-    return [
-        extract_plane_from_cube(
-            fits_cube=cube,
-            extract_options=ExtractOptions(
-                channel_index=channel, output_path=_plane_path(channel), overwrite=True
-            ),
-        )
-        for channel in range(channels)
-    ]
+    channels = count_cube_planes(header=fits.getheader(cube))
+    logger.info(f"Splitting {cube} into {channels} planes")
+
+    return extract_planes_from_cube(
+        cube,
+        ExtractPlanesOptions(
+            output_paths=[_plane_path(channel) for channel in range(channels)],
+            overwrite=True,
+            max_workers=num_workers,
+        ),
+    )
 
 
 def get_wsclean_output_source_list_path(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ dependencies = [
     "scikit-image",
     "pandas",
     "ConfigArgParse>=1.7",
-    "fitscube[pgzip]>=2.6",
+    "fitscube[pgzip]>=2.7",
     "astroquery>=0.4.8.dev0",
     "crystalball>=0.4.3",
     "jolly-roger>=0.10.1",

--- a/tests/test_convol.py
+++ b/tests/test_convol.py
@@ -318,7 +318,7 @@ def test_cubes_share_common_beam_with_cutoff(tmp_path) -> None:
 
 
 def _write_plane_with_beam(path: Path, bmaj_arcsec: float | None) -> Path:
-    """A single channel image, cut out of a cube exactly as
+    """A single channel image, cut out of a cube the way
     ``split_cube_into_planes`` does, so the plane carries its channel's beam"""
     cube = _write_cube_with_beam(
         path.with_name(f"cube.{path.name}"), [bmaj_arcsec or 0.0] * 2

--- a/tests/test_wsclean.py
+++ b/tests/test_wsclean.py
@@ -7,11 +7,13 @@ import shutil
 from pathlib import Path
 from typing import Any
 
+import astropy.units as u
 import numpy as np
 import pytest
 from astropy.io import fits
 from fitscube.bounding_box import get_common_bounding_box
 from fitscube.extract import find_target_axis
+from radio_beam import Beams
 
 from flint.exceptions import (
     AttemptRerunException,
@@ -49,11 +51,16 @@ from flint.utils import get_packaged_resource_path
 
 
 def _write_channel_image(
-    path: Path, channel: int, shape: tuple[int, int], nan_border: int = 0
+    path: Path,
+    channel: int,
+    shape: tuple[int, int],
+    nan_border: int = 0,
+    bmaj: float = 0.01,
 ) -> Path:
     """A wsclean-like single channel image, with each pixel uniquely valued so
     that any scrambling of the data is detectable. A ``nan_border`` pixels wide
-    border of NaNs may be added to exercise bounding-box trimming."""
+    border of NaNs may be added to exercise bounding-box trimming. Vary ``bmaj``
+    across channels to have the cube carry a beam table."""
     ny, nx = shape
     data = (
         channel * 1000.0
@@ -68,7 +75,7 @@ def _write_channel_image(
     header = fits.Header(
         {
             "BUNIT": "JY/BEAM",
-            "BMAJ": 0.01,
+            "BMAJ": bmaj,
             "BMIN": 0.01,
             "BPA": 0.0,
             "CTYPE1": "RA---SIN",
@@ -354,6 +361,65 @@ def test_split_cube_into_planes(tmpdir) -> None:
 
     with pytest.raises(NamingException):
         split_cube_into_planes(cube=Path(shutil.copy(cube, Path(tmpdir) / "bad.fits")))
+
+
+def _write_varying_beam_cube(tmp_path: Path, channels: int) -> Path:
+    """A cube whose channels each have their own beam, so it carries a beam table"""
+    images = [
+        _write_channel_image(
+            tmp_path / f"SB1234.RACS_0000-00.beam00.round1-{channel:04d}-image.fits",
+            channel=channel,
+            shape=(6, 6),
+            bmaj=0.01 + channel * 1e-4,
+        )
+        for channel in range(channels)
+    ]
+    return combine_images_to_cube(
+        images=images,
+        prefix=f"{tmp_path}/SB1234.RACS_0000-00.beam00.round1",
+        mode="image",
+        fitscube_options=FitsCubeOptions(
+            invalidate_zeros=False, remove_original_images=False
+        ),
+    )
+
+
+def test_split_cube_into_planes_carries_channel_beams(tmp_path) -> None:
+    """A plane takes its own channel's beam out of the cube's beam table, and
+    stops claiming to carry a table of its own"""
+    channels = 5
+    cube = _write_varying_beam_cube(tmp_path=tmp_path, channels=channels)
+
+    with fits.open(cube) as open_fits:
+        assert open_fits[0].header["CASAMBM"], "Cube should carry a beam table"
+        beams = Beams.from_fits_bintable(open_fits["BEAMS"])
+
+    planes = split_cube_into_planes(cube=cube, output_path=tmp_path / "planes")
+
+    assert len(planes) == channels
+    for channel, plane in enumerate(planes):
+        header = fits.getheader(plane)
+        assert "CASAMBM" not in header
+        assert header["BMAJ"] == pytest.approx(beams[channel].major.to(u.deg).value)
+        assert header["BMIN"] == pytest.approx(beams[channel].minor.to(u.deg).value)
+        assert header["BPA"] == pytest.approx(beams[channel].pa.to(u.deg).value)
+
+
+def test_split_cube_into_planes_threaded_matches_serial(tmp_path) -> None:
+    """Spreading the plane writes over threads must not change what is written"""
+    cube = _write_varying_beam_cube(tmp_path=tmp_path, channels=5)
+
+    serial = split_cube_into_planes(
+        cube=cube, output_path=tmp_path / "serial", num_workers=1
+    )
+    threaded = split_cube_into_planes(
+        cube=cube, output_path=tmp_path / "threaded", num_workers=4
+    )
+
+    assert [plane.name for plane in serial] == [plane.name for plane in threaded]
+    for one, many in zip(serial, threaded):
+        assert np.array_equal(fits.getdata(one), fits.getdata(many))
+        assert fits.getheader(one).tostring() == fits.getheader(many).tostring()
 
 
 def test_transpose_and_sort_channel_images() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -244,7 +244,7 @@ requires-dist = [
     { name = "configargparse", specifier = ">=1.7" },
     { name = "crystalball", specifier = ">=0.4.3" },
     { name = "dask-jobqueue" },
-    { name = "fitscube", extras = ["pgzip"], specifier = ">=2.6" },
+    { name = "fitscube", extras = ["pgzip"], specifier = ">=2.7" },
     { name = "fixms", marker = "extra == 'all'", specifier = ">=0.4.0" },
     { name = "fixms", marker = "extra == 'casa'", specifier = ">=0.4.0" },
     { name = "furo", marker = "extra == 'all'" },
@@ -1257,7 +1257,7 @@ wheels = [
 
 [[package]]
 name = "fitscube"
-version = "2.6.0"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "astropy" },
@@ -1265,9 +1265,9 @@ dependencies = [
     { name = "radio-beam" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e6/82/097d1f2c9441b07f91a75d57ddbe62a32dde8dba11f93968395c349523af/fitscube-2.6.0.tar.gz", hash = "sha256:d073194681e93a0b3069d7e430cf75f0c21882fefc5d54ef631c7c4654109c77", size = 794576, upload-time = "2026-08-31T08:06:08.977Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/bf/57d9b6b603af3d5ea0f56b920fef44e3315d2ba085cd8bea6a7b117c0cce/fitscube-2.7.0.tar.gz", hash = "sha256:a8c7071c18da9e079274a06d31d9ce7115ccf7248c88fc18b7719faaaf916adb", size = 796080, upload-time = "2026-09-10T12:48:56.239Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/50/a3/010b81e2cca21ea4f362903eb181082aca6cb788597ef0441eea1f9cea5a/fitscube-2.6.0-py3-none-any.whl", hash = "sha256:6094a8af7dc52a0250549e67030398d5ce52e8d38a2a0cc0db0306b05fc33aac", size = 31194, upload-time = "2026-08-31T08:06:07.446Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/c9/0e905a4f885652911d48d4a9408f9ba72123d36dbf8ff999fdbd7697d3e8/fitscube-2.7.0-py3-none-any.whl", hash = "sha256:45ca2895b53aaff23b86b0465af90c28c93ff3e9c78fc438d34409919e590e1b", size = 32346, upload-time = "2026-09-10T12:48:54.683Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Splitting

`split_cube_into_planes` called fitscube's `extract_plane_from_cube` once per channel. Each of those calls reopened the cube, re-read its header, and re-parsed the whole `BEAMS` table for a single row, so the beam work grew with the square of the channel count. A 288 channel cube meant over a thousand file opens.

It now hands the plane paths to `extract_planes_from_cube` (fitscube 2.7), which opens the cube once and reads the beam table once. Cold cache, before vs after:

| cube | before | after |
|---|---|---|
| 288ch × 512² | 5.5-6.2s | 1.35-1.48s |
| 288ch × 1024² | 14.1-15.0s | 3.4-4.7s |
| 36ch × 2048² | 2.7-4.2s | 1.5-1.8s |

Worth knowing before expecting this to fix everything: the win is per-channel *overhead*, so it is largest on channel-deep cubes and smallest on pixel-large ones. On pixel-large cubes the operation is bandwidth bound — a plain `cp` of the same bytes into one file takes about as long as this takes to write them as 288 planes — so there is little left in this loop. If the remaining time is there, the next lever is the pipeline shape (split, convolve per plane, re-cube writes and re-reads the cube several times), not this function.

## Cubing

`combine_images_to_cube` walked every input header to check the pixel grids before handing the same files to `combine_fits`, which runs that exact check itself, in parallel, before it writes anything. Dropped the duplicate pass and mapped fitscube's `ShapeMismatchException` onto ours, so callers see the same error as before. `assert_common_pixel_grid` goes with it, having had no other caller.

## Progress

Neither stage said anything while it worked, which is what made a slow one impossible to read. fitscube already reports its progress on its own logger, tqdm bars included, so surfacing it is `PREFECT_LOGGING_EXTRA_LOGGERS=fitscube` rather than anything in this diff.

## Verification

- 73 tests pass in `tests/test_wsclean.py` and `tests/test_convol.py` against the released fitscube 2.7.0, so the new tests exercise the upstream loop rather than a local copy.
- The one-pass split was checked plane for plane against the old path — identical data and identical headers — on cubes with a beam table, with a single beam, with `CASAMBM` but no table, and with three axes. The same guarantee is tested upstream in AlecThomson/fitscube#65.
- New tests cover the per-channel beams reaching the planes, and output being the same however many planes are written at once.
- The full suite passed at 557 before the rebase, with two failures — `test_get_vizier_catalogue` (network) and `test_copy_directory` — that fail identically on a clean checkout of the base.

Pin moves to `fitscube[pgzip]>=2.7`; the lock change is fitscube only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AN9y36hf41ZmfkLQPnd4AN